### PR TITLE
Static file routing

### DIFF
--- a/framework/src/play/mvc/Router.java
+++ b/framework/src/play/mvc/Router.java
@@ -341,36 +341,11 @@ public class Router {
 
     public static String reverseWithCheck(String name, VirtualFile file, boolean absolute) {
         if (file == null || !file.exists()) {
-            //throw new NoRouteFoundException(name + " (file not found)");
-            return reverseStaticFile(name, absolute);
+            throw new NoRouteFoundException(name + " (file not found)");
         }
         return reverse(file, absolute);
     }
     
-    // see if this is a staticFile: route
-    private static String reverseStaticFile(String name, boolean absolute) {
-        for (Route route : routes) {
-            String staticDir = route.staticDir;
-            if (staticDir != null) {
-                if (name.equals(route.path)) {
-                    String to = route.staticDir;
-                    if (!to.startsWith("/")) {
-                        to = "/" + to;
-                    }
-                    if (absolute) {
-                        if (!StringUtils.isEmpty(route.host)) {
-                            to = (Http.Request.current().secure ? "https://" : "http://") + route.host + to;
-                        } else {
-                            to = Http.Request.current().getBase() + to;
-                        }
-                    }
-                    return to;
-                }
-            }
-        }
-        throw new NoRouteFoundException(name);
-    }
-
     public static ActionDefinition reverse(String action, Map<String, Object> args) {
         if (action.startsWith("controllers.")) {
             action = action.substring(12);


### PR DESCRIPTION
Small change to add a way to declare a staticFile route, which maps a single GET request to a specific file.  Reuses much of the staticDir logic except, of course, it's specific to one file.

Example route:

GET     /foobar                                 staticFile:public/stylesheets/main.css
GET     /favicon.ico                          staticFile:public/images/favicon.png
GET     /public/                                 staticDir:public

This allows me to make /favicon.ico work even though I use the standard Play! convention of having static files under 'public'.
