### PR TITLE
Idea: allow mocking web services for testing purposes

### DIFF
--- a/framework/src/play/libs/WS.java
+++ b/framework/src/play/libs/WS.java
@@ -53,6 +53,7 @@ import com.google.gson.JsonParser;
 public class WS extends PlayPlugin {
 
     private static WSImpl wsImpl = null;
+    private static String mockUrl = null;
 
     @Override
     public void onApplicationStop() {
@@ -102,7 +103,11 @@ public class WS extends PlayPlugin {
      */
     public static WSRequest url(String url) {
         init();
-        return wsImpl.newRequest(url);
+        if (mockUrl != null) {
+            return wsImpl.newRequest(mockUrl);
+        } else {
+            return wsImpl.newRequest(url);
+        }
     }
 
     /**
@@ -119,6 +124,14 @@ public class WS extends PlayPlugin {
             encodedParams[i] = encode(params[i]);
         }
         return url(String.format(url, encodedParams));
+    }
+
+    /**
+     * Set URL to use instead of original for future requests.
+     * @param url to mock to
+     */
+    public static void mock(String url) {
+        mockUrl = url;
     }
 
     public interface WSImpl {


### PR DESCRIPTION
Idea is to redirect WS requests to a different url. For example, you want to test method User.getIdByUsername(String username) which looks like this:

```
public static Long getIdByUsername(String username) {
    WS.HttpResponse response = WS.url("http://some.remote.url/api/getidbyusername").setParameter("username", username).post();
    return Long.valueOf(response.getString());
}
```

You can create some mock controller with logic required for test:

```
public class Mock extends Controller {
    public static void getIdByUsername(String username) {
        if (username.equals("adam")) {
            renderText("12");
        } else {
             renderText("0");
        }
    }
}
```

And use it in test with:

```
@Test
public void testGetIdByUsername() {
    WS.mock(Router.getFullUrl("Mock.getIdByUsername"));
    assertEquals(12, User.getIdByUsername("adam"));
    assertEquals(0, User.getIdByUsername("unknown"));
    WS.mock(null);
}
```

The only problem - you will have to set "play.pull" to 2+ in this case.

Is this an acceptable change? If it is I can finish it.
