### PR TITLE
[#405] add jnlp (webstart) mime type

### DIFF
--- a/framework/src/play/libs/mime-types.properties
+++ b/framework/src/play/libs/mime-types.properties
@@ -161,6 +161,7 @@ java=text/x-java-source
 jcm=application/x-java-commerce
 jfif-tbnl=image/jpeg
 jfif=image/jpeg
+jnlp=application/x-java-jnlp-file
 jpe=image/jpeg
 jpeg=image/jpeg
 jpg=image/jpeg


### PR DESCRIPTION
To successfully prompt a browser to open jnlp files with java webstart I needed to add this line to mime-types and use renderbinary to send the file.
