### PR TITLE
In eclipse, the lauch configuration define a wrong classpath order.

### DIFF
--- a/resources/eclipse/debug.launch
+++ b/resources/eclipse/debug.launch
@@ -9,8 +9,8 @@
     <booleanAttribute key="org.eclipse.debug.core.appendEnvironmentVariables" value="true"/>
     <listAttribute key="org.eclipse.jdt.launching.CLASSPATH">
         <listEntry value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;&#10;&lt;runtimeClasspathEntry containerPath=&quot;org.eclipse.jdt.launching.JRE_CONTAINER&quot; javaProject=&quot;%PROJECT_NAME%&quot; path=&quot;1&quot; type=&quot;4&quot;/&gt;&#10;"/>
-        <listEntry value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;&#10;&lt;runtimeClasspathEntry id=&quot;org.eclipse.jdt.launching.classpathentry.defaultClasspath&quot;&gt;&#10;&lt;memento exportedEntriesOnly=&quot;false&quot; project=&quot;%PROJECT_NAME%&quot;/&gt;&#10;&lt;/runtimeClasspathEntry&gt;&#10;"/>
         <listEntry value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;&#10;&lt;runtimeClasspathEntry internalArchive=&quot;/%PROJECT_NAME%/conf&quot; path=&quot;3&quot; type=&quot;2&quot;/&gt;&#10;"/>
+        <listEntry value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;&#10;&lt;runtimeClasspathEntry id=&quot;org.eclipse.jdt.launching.classpathentry.defaultClasspath&quot;&gt;&#10;&lt;memento exportedEntriesOnly=&quot;false&quot; project=&quot;%PROJECT_NAME%&quot;/&gt;&#10;&lt;/runtimeClasspathEntry&gt;&#10;"/>
     </listAttribute>
     <booleanAttribute key="org.eclipse.jdt.launching.DEFAULT_CLASSPATH" value="false"/>
     <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="play.server.Server"/>


### PR DESCRIPTION
When i use Eclipse, the launch configuration defines the play.jar before the /conf folder. 

This is why, even if i creates my own log4j.properties, the default play log4j.properties is used.

This can be corrected by modifying the "resources/eclipse/debug.launch"
