### PR TITLE
Fix for 353

### DIFF
--- a/framework/src/play/templates/GroovyTemplateCompiler.java
+++ b/framework/src/play/templates/GroovyTemplateCompiler.java
@@ -65,7 +65,7 @@ public class GroovyTemplateCompiler extends TemplateCompiler {
             source = source.replaceAll("new " + Pattern.quote(cName) + "(\\([^)]*\\))", "_('" + originalNames.get(cName) + "').newInstance$1");
             source = source.replaceAll("([a-zA-Z0-9.-_$]+)\\s+instanceof\\s+" + Pattern.quote(cName), "_('" + originalNames.get(cName).replace("$", "\\$") + "').isAssignableFrom($1.class)");
             source = source.replaceAll("([^.])" + Pattern.quote(cName) + ".class", "$1_('" + originalNames.get(cName) + "')");
-            source = source.replaceAll("([^'\".])" + Pattern.quote(cName) + "([^'\"])", "$1_('" + originalNames.get(cName).replace("$", "\\$") + "')$2");
+            source = source.replaceAll("([^'\".](?<!@\\{))" + Pattern.quote(cName) + "([^'\"])", "$1_('" + originalNames.get(cName).replace("$", "\\$") + "')$2");
         }
 
         return source;


### PR DESCRIPTION
I picked this bug out from lighthouse:

http://play.lighthouseapp.com/projects/57987/tickets/353-template-compilation-error-with-similarly-named-classes

I was able to reproduce the bug, and I have a potential fix. I just modified the regular expression in GroovyTemplateCompiler.java to ignore the classname if it starts with "@{" (because that would indicate that it is actually a reverse route to a controller class).

Thanks!
