### PR TITLE
Fix for issue 437, XML.getDocument(String) encoding.

### DIFF
--- a/framework/src/play/libs/XML.java
+++ b/framework/src/play/libs/XML.java
@@ -37,6 +37,7 @@ import org.xml.sax.SAXException;
 import play.Logger;
 
 import com.sun.org.apache.xml.internal.serialize.XMLSerializer;
+import java.io.StringReader;
 
 /**
  * XML utils
@@ -82,7 +83,7 @@ public class XML {
      * @return null if an error occurs during parsing.
      */
     public static Document getDocument(String xml) {
-        InputSource source = new InputSource(new ByteArrayInputStream(xml.getBytes()));
+        InputSource source = new InputSource(new StringReader(xml));
         DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
         try {
             return dbf.newDocumentBuilder().parse(source);


### PR DESCRIPTION
This fixes http://play.lighthouseapp.com/projects/57987/tickets/437-xmlgetdocumentstring-does-not-deal-with-encoding-correctly
