### PR TITLE
Added standard validators @Phone @IPAddress @NoSpecialChars @OnlyLetters

### DIFF
--- a/framework/src/play/data/validation/IPAddress.java
+++ b/framework/src/play/data/validation/IPAddress.java
@@ -1,0 +1,20 @@
+package play.data.validation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import net.sf.oval.configuration.annotation.Constraint;
+
+/**
+ * This field must be a valid IP address.
+ * Message key: validation.ip
+ * $1: field name
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.FIELD, ElementType.PARAMETER })
+@Constraint(checkWith = IPAddressCheck.class)
+public @interface IPAddress {
+	String message() default IPAddressCheck.mes;
+}

--- a/framework/src/play/data/validation/IPAddressCheck.java
+++ b/framework/src/play/data/validation/IPAddressCheck.java
@@ -1,0 +1,31 @@
+package play.data.validation;
+
+import java.util.regex.Pattern;
+
+import net.sf.oval.Validator;
+import net.sf.oval.configuration.annotation.AbstractAnnotationCheck;
+import net.sf.oval.context.OValContext;
+import net.sf.oval.exception.OValException;
+
+public class IPAddressCheck extends AbstractAnnotationCheck<IPAddress> {
+
+	final static String mes = "validation.ip";
+
+	static private Pattern ipPattern = Pattern
+			.compile("^([1-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])(\\.([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])){3}$");
+
+	@Override
+	public void configure(IPAddress phone) {
+		setMessage(phone.message());
+	}
+
+	@Override
+	public boolean isSatisfied(Object validatedObject, Object value, OValContext context, Validator validator)
+			throws OValException {
+		if (value == null || value.toString().length() == 0) {
+			return true;
+		}
+		return ipPattern.matcher(value.toString()).matches();
+	}
+
+}

--- a/framework/src/play/data/validation/NoSpecialChars.java
+++ b/framework/src/play/data/validation/NoSpecialChars.java
@@ -1,0 +1,20 @@
+package play.data.validation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import net.sf.oval.configuration.annotation.Constraint;
+
+/**
+ * This field must only contain letters and space.
+ * Message key: validation.nospecialchars
+ * $1: field name
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.FIELD, ElementType.PARAMETER })
+@Constraint(checkWith = NoSpecialCharsCheck.class)
+public @interface NoSpecialChars {
+	String message() default NoSpecialCharsCheck.mes;
+}

--- a/framework/src/play/data/validation/NoSpecialCharsCheck.java
+++ b/framework/src/play/data/validation/NoSpecialCharsCheck.java
@@ -1,0 +1,30 @@
+package play.data.validation;
+
+import java.util.regex.Pattern;
+
+import net.sf.oval.Validator;
+import net.sf.oval.configuration.annotation.AbstractAnnotationCheck;
+import net.sf.oval.context.OValContext;
+import net.sf.oval.exception.OValException;
+
+public class NoSpecialCharsCheck extends AbstractAnnotationCheck<NoSpecialChars> {
+
+	final static String mes = "validation.nospecialchars";
+
+	static private Pattern pattern = Pattern.compile("^[0-9a-zA-Z]+$");
+
+	@Override
+	public void configure(NoSpecialChars phone) {
+		setMessage(phone.message());
+	}
+
+	@Override
+	public boolean isSatisfied(Object validatedObject, Object value, OValContext context, Validator validator)
+			throws OValException {
+		if (value == null || value.toString().length() == 0) {
+			return true;
+		}
+		return pattern.matcher(value.toString()).matches();
+	}
+
+}

--- a/framework/src/play/data/validation/OnlyLetters.java
+++ b/framework/src/play/data/validation/OnlyLetters.java
@@ -1,0 +1,20 @@
+package play.data.validation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import net.sf.oval.configuration.annotation.Constraint;
+
+/**
+ * This field must only contain letters, no space or special chars.
+ * Message key: validation.onlyletters
+ * $1: field name
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.FIELD, ElementType.PARAMETER })
+@Constraint(checkWith = OnlyLettersCheck.class)
+public @interface OnlyLetters {
+	String message() default OnlyLettersCheck.mes;
+}

--- a/framework/src/play/data/validation/OnlyLettersCheck.java
+++ b/framework/src/play/data/validation/OnlyLettersCheck.java
@@ -1,0 +1,30 @@
+package play.data.validation;
+
+import java.util.regex.Pattern;
+
+import net.sf.oval.Validator;
+import net.sf.oval.configuration.annotation.AbstractAnnotationCheck;
+import net.sf.oval.context.OValContext;
+import net.sf.oval.exception.OValException;
+
+public class OnlyLettersCheck extends AbstractAnnotationCheck<OnlyLetters> {
+
+	final static String mes = "validation.onlyletters";
+
+	static private Pattern pattern = Pattern.compile("^[a-zA-Z \\']+$");
+
+	@Override
+	public void configure(OnlyLetters phone) {
+		setMessage(phone.message());
+	}
+
+	@Override
+	public boolean isSatisfied(Object validatedObject, Object value, OValContext context, Validator validator)
+			throws OValException {
+		if (value == null || value.toString().length() == 0) {
+			return true;
+		}
+		return pattern.matcher(value.toString()).matches();
+	}
+
+}

--- a/framework/src/play/data/validation/Phone.java
+++ b/framework/src/play/data/validation/Phone.java
@@ -1,0 +1,20 @@
+package play.data.validation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import net.sf.oval.configuration.annotation.Constraint;
+
+/**
+ * This field contain a phone
+ * Message key: validation.phone
+ * $1: field name
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.FIELD, ElementType.PARAMETER })
+@Constraint(checkWith = PhoneCheck.class)
+public @interface Phone {
+	String message() default PhoneCheck.mes;
+}

--- a/framework/src/play/data/validation/PhoneCheck.java
+++ b/framework/src/play/data/validation/PhoneCheck.java
@@ -1,0 +1,31 @@
+package play.data.validation;
+
+import java.util.regex.Pattern;
+
+import net.sf.oval.Validator;
+import net.sf.oval.configuration.annotation.AbstractAnnotationCheck;
+import net.sf.oval.context.OValContext;
+import net.sf.oval.exception.OValException;
+
+public class PhoneCheck extends AbstractAnnotationCheck<Phone> {
+
+	final static String mes = "validation.phone";
+
+	static private Pattern phonePattern = Pattern
+			.compile("^([\\+][0-9]{1,3}([ \\.\\-])?)?([\\(]{1}[0-9]{3}[\\)])?([0-9A-Z \\.\\-]{1,32})((x|ext|extension)[ ]?[0-9]{1,4})?$");
+
+	@Override
+	public void configure(Phone phone) {
+		setMessage(phone.message());
+	}
+
+	@Override
+	public boolean isSatisfied(Object validatedObject, Object value, OValContext context, Validator validator)
+			throws OValException {
+		if (value == null || value.toString().length() == 0) {
+			return true;
+		}
+		return phonePattern.matcher(value.toString()).matches();
+	}
+
+}

--- a/resources/messages
+++ b/resources/messages
@@ -26,3 +26,7 @@ validation.before=Must be before %2$s
 validation.object=Validation failed
 validation.notFound=Object not found for id %2$s
 validation.url=Not a valid URL
+validation.phone=Not a valid phone
+validation.ip=Not a valid IP address
+validation.nospecialchars=Special characters are not allowed
+validation.onlyletters=Only letters allowed


### PR DESCRIPTION
Hi,
Added more validation checks for phone numbers and IP.
the phone number regex is permissive and works great for US and FR numbers. It should work fine with other countries as well. The ip regex will fail on "0.234.22.3" or "192.930.23.2"

As far as @NoSpecialChars @OnlyLetters, those are convenient validation to avoid XSS attacks

Cheers,
Olivier
