### PR TITLE
Fix incorrect documentation about parameterized localization messages.

### DIFF
--- a/documentation/manual/guide12.textile
+++ b/documentation/manual/guide12.textile
@@ -150,7 +150,7 @@ bc. &{'views.Application.listTagged.title', tag}
 
 When a message contains multiple parameters, add an index to the format string to allow for different word order in another language: 
 
-bc. views.Admin.index.welcome = Welcome %1s, <span>you have written %2s posts so far</span> 
+bc. views.Admin.index.welcome = Welcome %1$s, <span>you have written %2$s posts so far</span> 
 
 … with a list in the template: 
 
@@ -158,7 +158,7 @@ bc. &{'views.Admin.index.welcome', user, posts.size()}
 
 In this example, we would also like to use the correct plural form for the word 'post', so make that word a parameter too: 
 
-bc. views.Admin.index.welcome = Welcome %1s, <span>you have written %2s %3s so far</span> 
+bc. views.Admin.index.welcome = Welcome %1$s, <span>you have written %2$s %3$s so far</span> 
 
 … and use the **pluralize** extension in the template 
 


### PR DESCRIPTION
Fixed incorrect documentation about parameterized localization messages. Format strings used in the docs were wrong when using multiple parameters.
