### PR TITLE
Stackoverflow with property enhancer

### DIFF
--- a/framework/src/play/classloading/enhancers/PropertiesEnhancer.java
+++ b/framework/src/play/classloading/enhancers/PropertiesEnhancer.java
@@ -115,7 +115,8 @@ public class PropertiesEnhancer extends Enhancer {
 
                             // Si c'est un getter ou un setter
                             String propertyName = null;
-                            if(fieldAccess.getField().getDeclaringClass().equals(ctMethod.getDeclaringClass())) {
+                            if(fieldAccess.getField().getDeclaringClass().equals(ctMethod.getDeclaringClass())
+                               || ctMethod.getDeclaringClass().subclassOf(fieldAccess.getField().getDeclaringClass())) {
                                 if ((ctMethod.getName().startsWith("get") || ctMethod.getName().startsWith("set")) && ctMethod.getName().length() > 3) {
                                     propertyName = ctMethod.getName().substring(3);
                                     propertyName = propertyName.substring(0, 1).toLowerCase() + propertyName.substring(1);


### PR DESCRIPTION
Hi,

I'm having problem with application https://github.com/jfp/play-test-cases. There's a two class model: a base class Animal with height property, and a subclass Dog. The Dog class defines a getter (getHeight). In the implementation, the data property is accessed, but the property enhancer tries to invoke the getter again causing a stack overflow. 

Maybe we're not supposed to do so with beans, but stack overflowing is not very nice. The path makes the enhancer consider the property should be directly accessed from within class hierarchy.
