### PR TITLE
Lighthouse 511 patch

### DIFF
--- a/framework/src/play/mvc/results/RenderJson.java
+++ b/framework/src/play/mvc/results/RenderJson.java
@@ -45,11 +45,15 @@ public class RenderJson extends Result {
     //
     
     static Method getMethod(Class<?> clazz, String name) {
+        Method bestMatch = null;
         for(Method m : clazz.getDeclaredMethods()) {
             if(m.getName().equals(name)) {
-                return m;
+                if (bestMatch == null ||  
+                    !Object.class.equals(m.getParameterTypes()[0])) {
+                    bestMatch = m;
+                }
             }
         }
-        return null;
+        return bestMatch;
     }
 } 


### PR DESCRIPTION
RenderJson#getMethod previously returned the first serialize method it found in the supplied class.  This patch checks for a method with a more specific object-type than Object.class.

See http://groups.google.com/group/play-framework/browse_thread/thread/7203c7675d4ee6b9/668650fd5db118c3?lnk=gst&q=chaloner#668650fd5db118c3 for a further discussion of this bug.
