### PR TITLE
Fixed faulty assumption: not all systems default to python2 as "python".

### DIFF
--- a/play
+++ b/play
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Play command line script www.playframework.org/
 
@@ -23,7 +23,7 @@ def get_opt(args, arg, env):
             args.remove(a)
             # print "~ get_opt: '%s' -> '%s'" % (arg, env[arg])
             break
-    
+
 
 # ~~~~~~~~~
 # Main


### PR DESCRIPTION
I updated the play script to work on Arch Linux, a system for which the default python is python3; only a single character modification was required. 
