### PR TITLE
Bug fix: 'play war' command without --exclude option fails

### DIFF
--- a/framework/pym/play/commands/war.py
+++ b/framework/pym/play/commands/war.py
@@ -21,7 +21,7 @@ def execute(**kargs):
 
     war_path = None
     war_zip_path = None
-    war_exclusion_list = None
+    war_exclusion_list = []
     try:
         optlist, args = getopt.getopt(args, 'o:', ['output=', 'zip','exclude='])
         for o, a in optlist:


### PR DESCRIPTION
I was playing with Play's latest master branch, and found a bug that 'play war' doesn't work.
I have not created a ticket on lighthouse for this, as I don't know the exact version number of it.
