### PR TITLE
594 errors tag filter by fieldname

### DIFF
--- a/documentation/manual/tags.textile
+++ b/documentation/manual/tags.textile
@@ -142,6 +142,16 @@ bc. <table>
 #{/errors}
 </table>
 
+You can also use the optional field parameter, or just the default parameter, to filter only the errors belonging to a certain field.
+
+bc. <ul>
+#{errors 'myField'}
+    There where errors with the field myField<br />
+    <li>${error}</li>
+#{/errors}
+</ul>
+
+
 h2. <a name="extends">extends</a>
 
 Makes the template inherit another template.
@@ -367,6 +377,8 @@ bc. #{option user.id} ${user.name} #{/option}
 Will output:
 
 bc. <option value="42">jto</option>h2. <a name="script">script</a>
+
+h2. <a name="script">script</a>
 
 Inserts a **script** tag in the template. By convention, the tag refers to a script in **/public/javascripts**
 

--- a/framework/templates/tags/errors.tag
+++ b/framework/templates/tags/errors.tag
@@ -1,11 +1,27 @@
-%{ play.data.validation.Validation.errors().eachWithIndex() { item, i -> }%
-	%{
-		attrs = [:]
-		attrs.put('error', item)
-		attrs.put('error_index', i+1)
-		attrs.put('error_isLast', (i+1) == size)
-		attrs.put('error_isFirst', i==0)
-		attrs.put('error_parity', (i+1)%2==0?'even':'odd')
-	}%
-        #{doBody vars:attrs /}
-%{ } }%
+*{ 
+	_arg:	(optional) fieldname to filter errors, if not specified all 
+errors are returned 
+	_field:	(optional) fieldname to filter errors, if not specified all 
+errors are returned 
+}* 
+
+%{ 
+        _field = _arg ?: _field 
+        if (! _field) { 
+                validations = play.data.validation.Validation.errors() 
+        } else { 
+                validations = play.data.validation.Validation.errors(_field) 
+        } 
+        size = validations.size()
+        validations.eachWithIndex() { item, i -> 
+                attrs = [:] 
+                attrs.put('error', item) 
+                attrs.put('error_index', i+1) 
+                attrs.put('error_isLast', (i+1) == size) 
+                attrs.put('error_isFirst', i==0) 
+                attrs.put('error_parity', (i+1)%2==0?'even':'odd') 
+}% 
+        #{doBody vars:attrs /} 
+%{ 
+        } 
+}% 

--- a/samples-and-tests/just-test-cases/app/controllers/ErrorsTag.java
+++ b/samples-and-tests/just-test-cases/app/controllers/ErrorsTag.java
@@ -1,0 +1,40 @@
+package controllers;
+
+import play.mvc.Controller;
+
+public class ErrorsTag extends Controller {
+
+	public static void noError() {
+		render("@error");
+	}
+
+	public static void errorGeneral() {
+		validation.addError("", "general error 1");
+		validation.addError("", "general error 2");
+		
+		render("@error");
+	}
+
+	public static void errorField1() {
+		validation.addError("", "general error 1");
+		validation.addError("", "general error 2");
+		validation.addError("field1", "field 1 error 1");
+		validation.addError("field1", "field 1 error 2");
+		
+		render("@error");
+	}
+
+	public static void errorField1andField2() {
+		validation.addError("", "general error 1");
+		validation.addError("", "general error 2");
+		validation.addError("field1", "field 1 error 1");
+		validation.addError("field1", "field 1 error 2");
+		validation.addError("field2", "field 2 error 1");
+		validation.addError("field2", "field 2 error 2");
+		validation.addError("field2", "field 2 error 3");
+		
+		render("@error");
+	}
+
+	
+}

--- a/samples-and-tests/just-test-cases/app/views/ErrorsTag/error.html
+++ b/samples-and-tests/just-test-cases/app/views/ErrorsTag/error.html
@@ -1,0 +1,133 @@
+#{extends 'main.html' /}
+
+<h1>Errors tag</h1>
+
+%{ error_count = 0 }%
+
+<h3>#errors tag</h3>
+#{errors}
+	#errors.errors present<br />
+	
+	#errors(${error_index}).error: ${error}<br />
+	#errors(${error}).error_index: ${error_index}<br />
+	
+	#errors(${error}).error_isFirst: ${error_isFirst}<br />
+	#errors(${error}).error_isLast: ${error_isLast}<br />
+	#errors(${error}).error_parity: ${error_parity}<br />
+	<br />
+	%{ error_count += 1 }%
+	
+#{/errors}
+
+#errors.count: ${error_count}<br />
+<hr />
+
+%{ error_count = 0 }%
+
+<h3>#errors field1 tag</h3>
+#{errors 'field1'}
+	#errors(field1).errors present<br />
+	
+	#errors(field1,${error_index}).error: ${error}<br />
+	#errors(field1,${error}).error_index: ${error_index}<br />
+	
+	#errors(field1,${error}).error_isFirst: ${error_isFirst}<br />
+	#errors(field1,${error}).error_isLast: ${error_isLast}<br />
+	#errors(field1,${error}).error_parity: ${error_parity}<br />
+	<br />
+	%{ error_count += 1 }%
+	
+#{/errors}
+
+#errors(field1).count: ${error_count}<br />
+<hr />
+
+%{ error_count = 0 }%
+
+<h3>#errors field:field1 tag (with named parameter)</h3>
+#{errors field:'field1'}
+	#errors(field:field1).errors present<br />
+	
+	#errors(field:field1,${error_index}).error: ${error}<br />
+	#errors(field:field1,${error}).error_index: ${error_index}<br />
+	
+	#errors(field:field1,${error}).error_isFirst: ${error_isFirst}<br />
+	#errors(field:field1,${error}).error_isLast: ${error_isLast}<br />
+	#errors(field:field1,${error}).error_parity: ${error_parity}<br />
+	<br />
+	%{ error_count += 1 }%
+	
+#{/errors}
+
+#errors(field:field1).count: ${error_count}<br />
+<hr />
+
+%{ error_count = 0 }%
+
+<h3>#errors field2 tag</h3>
+#{errors 'field2'}
+	#errors(field2).errors present<br />
+	
+	#errors(field2,${error_index}).error: ${error}<br />
+	#errors(field2,${error}).error_index: ${error_index}<br />
+	
+	#errors(field2,${error}).error_isFirst: ${error_isFirst}<br />
+	#errors(field2,${error}).error_isLast: ${error_isLast}<br />
+	#errors(field2,${error}).error_parity: ${error_parity}<br />
+	<br />
+	%{ error_count += 1 }%
+	
+#{/errors}
+
+#errors(field2).count: ${error_count}<br />
+<hr />
+
+%{ error_count = 0 }%
+
+<h3>#errors field2 tag (with named parameter)</h3>
+#{errors field:'field2'}
+	#errors(field:field2).errors present<br />
+	
+	#errors(field:field2,${error_index}).error: ${error}<br />
+	#errors(field:field2,${error}).error_index: ${error_index}<br />
+	
+	#errors(field:field2,${error}).error_isFirst: ${error_isFirst}<br />
+	#errors(field:field2,${error}).error_isLast: ${error_isLast}<br />
+	#errors(field:field2,${error}).error_parity: ${error_parity}<br />
+	<br />
+	%{ error_count += 1 }%
+	
+#{/errors}
+
+#errors(field:field2).count: ${error_count}<br />
+<hr />
+
+<h3>errorClass tag</h3>
+
+#errorClass field1: #{errorClass 'field1' /};<br />
+#errorClass field2: #{errorClass 'field2' /};<br />
+
+<hr />
+
+<h3>error tag</h3>
+
+#error field1: #{error 'field1' /};<br />
+#error field2: #{error 'field2' /};<br />
+
+<hr />
+
+<h3>ifErrors tag</h3>
+
+#{ifErrors}
+  #iferrors present<br />
+#{/ifErrors}
+
+<h3>ifError tag</h3>
+
+#{ifError 'field1'}
+  #iferror field1 present<br />
+#{/ifError}
+
+#{ifError 'field2'}
+  #iferror field2 present<br />
+#{/ifError}

--- a/samples-and-tests/just-test-cases/test/errorsTag.test.html
+++ b/samples-and-tests/just-test-cases/test/errorsTag.test.html
@@ -1,0 +1,281 @@
+#{selenium 'Test error tags: errors, error, hasError, ifErrors, ifError'}
+
+	open('@{ErrorsTag.noError()}')
+
+	assertTextPresent('#errors.count: 0')
+	assertTextNotPresent('#errors.errors present')
+	
+	assertTextPresent('#errors(field1).count: 0')
+	assertTextPresent('#errors(field:field1).count: 0')
+
+	assertTextNotPresent('#errors(field1).errors present')
+	assertTextNotPresent('#errors(field:field1).errors present')
+
+	assertTextPresent('#errors(field2).count: 0')
+	assertTextPresent('#errors(field:field2).count: 0')
+	
+	assertTextNotPresent('#errors(field2).errors present')
+	assertTextNotPresent('#errors(field:field2).errors present')
+
+	assertTextPresent('#errorClass field1: ;')
+	assertTextPresent('#errorClass field2: ;')
+	
+	assertTextPresent('#error field1: ;')
+	assertTextPresent('#error field2: ;')
+	
+	assertTextNotPresent('#iferrors present')
+	assertTextNotPresent('#iferror field1 present')
+	assertTextNotPresent('#iferror field2 present')
+
+	open('@{ErrorsTag.errorGeneral()}')
+	
+	assertTextPresent('#errors.errors present')
+	assertTextPresent('#errors(1).error: general error 1')
+	assertTextPresent('#errors(general error 1).error_index: 1')
+	assertTextPresent('#errors(general error 1).error_isFirst: true')
+	assertTextPresent('#errors(general error 1).error_isLast: false')
+	assertTextPresent('#errors(general error 1).error_parity: odd')
+	
+	assertTextPresent('#errors.errors present')
+	assertTextPresent('#errors(2).error: general error 2')
+	assertTextPresent('#errors(general error 2).error_index: 2')
+	assertTextPresent('#errors(general error 2).error_isFirst: false')
+	assertTextPresent('#errors(general error 2).error_isLast: true')
+	assertTextPresent('#errors(general error 2).error_parity: even')
+	
+	assertTextPresent('#errors.count: 2')
+
+	assertTextPresent('#errors(field1).count: 0')
+	assertTextPresent('#errors(field:field1).count: 0')
+
+	assertTextNotPresent('#errors(field1).errors present')
+	assertTextNotPresent('#errors(field:field1).errors present')
+
+	assertTextPresent('#errors(field2).count: 0')
+	assertTextPresent('#errors(field:field2).count: 0')
+	
+	assertTextNotPresent('#errors(field2).errors present')
+	assertTextNotPresent('#errors(field:field2).errors present')
+
+	assertTextPresent('#errorClass field1: ;')
+	assertTextPresent('#errorClass field2: ;')
+	
+	assertTextPresent('#error field1: ;')
+	assertTextPresent('#error field2: ;')
+
+	assertTextPresent('#iferrors present')
+	assertTextNotPresent('#iferror field1 present')
+	assertTextNotPresent('#iferror field2 present')
+
+
+	open('@{ErrorsTag.errorField1()}')
+	
+	assertTextPresent('#errors.errors present
+	assertTextPresent('#errors(1).error: general error 1')
+	assertTextPresent('#errors(general error 1).error_index: 1')
+	assertTextPresent('#errors(general error 1).error_isFirst: true')
+	assertTextPresent('#errors(general error 1).error_isLast: false')
+	assertTextPresent('#errors(general error 1).error_parity: odd')
+	
+	assertTextPresent('#errors(2).error: general error 2')
+	assertTextPresent('#errors(general error 2).error_index: 2')
+	assertTextPresent('#errors(general error 2).error_isFirst: false')
+	assertTextPresent('#errors(general error 2).error_isLast: false')
+	assertTextPresent('#errors(general error 2).error_parity: even')
+	
+	assertTextPresent('#errors(3).error: field 1 error 1')
+	assertTextPresent('#errors(field 1 error 1).error_index: 3')
+	assertTextPresent('#errors(field 1 error 1).error_isFirst: false')
+	assertTextPresent('#errors(field 1 error 1).error_isLast: false')
+	assertTextPresent('#errors(field 1 error 1).error_parity: odd')
+	
+	assertTextPresent('#errors(4).error: field 1 error 2')
+	assertTextPresent('#errors(field 1 error 2).error_index: 4')
+	assertTextPresent('#errors(field 1 error 2).error_isFirst: false')
+	assertTextPresent('#errors(field 1 error 2).error_isLast: true')
+	assertTextPresent('#errors(field 1 error 2).error_parity: even')
+	
+	assertTextPresent('#errors.count: 4')
+	
+	assertTextPresent('#errors(field1).errors present')
+	assertTextPresent('#errors(field1,1).error: field 1 error 1')
+	assertTextPresent('#errors(field1,field 1 error 1).error_index: 1')
+	assertTextPresent('#errors(field1,field 1 error 1).error_isFirst: true')
+	assertTextPresent('#errors(field1,field 1 error 1).error_isLast: false')
+	assertTextPresent('#errors(field1,field 1 error 1).error_parity: odd')
+	
+	assertTextPresent('#errors(field1,2).error: field 1 error 2')
+	assertTextPresent('#errors(field1,field 1 error 2).error_index: 2')
+	assertTextPresent('#errors(field1,field 1 error 2).error_isFirst: false')
+	assertTextPresent('#errors(field1,field 1 error 2).error_isLast: true')
+	assertTextPresent('#errors(field1,field 1 error 2).error_parity: even')
+	
+	assertTextPresent('#errors(field1).count: 2')
+	
+	assertTextPresent('#errors(field:field1).errors present')
+	assertTextPresent('#errors(field:field1,1).error: field 1 error 1')
+	assertTextPresent('#errors(field:field1,field 1 error 1).error_index: 1')
+	assertTextPresent('#errors(field:field1,field 1 error 1).error_isFirst: true')
+	assertTextPresent('#errors(field:field1,field 1 error 1).error_isLast: false')
+	assertTextPresent('#errors(field:field1,field 1 error 1).error_parity: odd')
+	
+	assertTextPresent('#errors(field:field1).errors present')
+	assertTextPresent('#errors(field:field1,2).error: field 1 error 2')
+	assertTextPresent('#errors(field:field1,field 1 error 2).error_index: 2')
+	assertTextPresent('#errors(field:field1,field 1 error 2).error_isFirst: false')
+	assertTextPresent('#errors(field:field1,field 1 error 2).error_isLast: true')
+	assertTextPresent('#errors(field:field1,field 1 error 2).error_parity: even')
+	
+	assertTextPresent('#errors(field:field1).count: 2')
+
+	assertTextPresent('#errors(field2).count: 0')
+	assertTextPresent('#errors(field:field2).count: 0')
+	
+	assertTextNotPresent('#errors(field2).errors present')
+	assertTextNotPresent('#errors(field:field2).errors present')
+
+	assertTextPresent('#errorClass field1: hasError;')
+	assertTextPresent('#errorClass field2: ;')
+	
+	assertTextPresent('#error field1: field 1 error 1;')
+	assertTextPresent('#error field2: ;')
+	
+	assertTextPresent('#iferrors present')
+	
+	assertTextPresent('#iferror field1 present')
+	
+	assertTextNotPresent('#iferror field2 present')
+
+
+	open('@{ErrorsTag.errorField1andField2()}')
+
+	assertTextPresent('#errors.errors present')
+	assertTextPresent('#errors(1).error: general error 1')
+	assertTextPresent('#errors(general error 1).error_index: 1')
+	assertTextPresent('#errors(general error 1).error_isFirst: true')
+	assertTextPresent('#errors(general error 1).error_isLast: false')
+	assertTextPresent('#errors(general error 1).error_parity: odd')
+	
+	assertTextPresent('#errors(2).error: general error 2')
+	assertTextPresent('#errors(general error 2).error_index: 2')
+	assertTextPresent('#errors(general error 2).error_isFirst: false')
+	assertTextPresent('#errors(general error 2).error_isLast: false')
+	assertTextPresent('#errors(general error 2).error_parity: even')
+	
+	assertTextPresent('#errors(3).error: field 1 error 1')
+	assertTextPresent('#errors(field 1 error 1).error_index: 3')
+	assertTextPresent('#errors(field 1 error 1).error_isFirst: false')
+	assertTextPresent('#errors(field 1 error 1).error_isLast: false')
+	assertTextPresent('#errors(field 1 error 1).error_parity: odd')
+	
+	assertTextPresent('#errors(4).error: field 1 error 2')
+	assertTextPresent('#errors(field 1 error 2).error_index: 4')
+	assertTextPresent('#errors(field 1 error 2).error_isFirst: false')
+	assertTextPresent('#errors(field 1 error 2).error_isLast: false')
+	assertTextPresent('#errors(field 1 error 2).error_parity: even')
+	
+	assertTextPresent('#errors(5).error: field 2 error 1')
+	assertTextPresent('#errors(field 2 error 1).error_index: 5')
+	assertTextPresent('#errors(field 2 error 1).error_isFirst: false')
+	assertTextPresent('#errors(field 2 error 1).error_isLast: false')
+	assertTextPresent('#errors(field 2 error 1).error_parity: odd')
+	
+	assertTextPresent('#errors(6).error: field 2 error 2')
+	assertTextPresent('#errors(field 2 error 2).error_index: 6')
+	assertTextPresent('#errors(field 2 error 2).error_isFirst: false')
+	assertTextPresent('#errors(field 2 error 2).error_isLast: false')
+	assertTextPresent('#errors(field 2 error 2).error_parity: even')
+	
+	assertTextPresent('#errors(7).error: field 2 error 3')
+	assertTextPresent('#errors(field 2 error 3).error_index: 7')
+	assertTextPresent('#errors(field 2 error 3).error_isFirst: false')
+	assertTextPresent('#errors(field 2 error 3).error_isLast: true')
+	assertTextPresent('#errors(field 2 error 3).error_parity: odd')
+	
+	assertTextPresent('#errors.count: 7')
+	
+	assertTextPresent('#errors(field1).errors present')
+	assertTextPresent('#errors(field1,1).error: field 1 error 1')
+	assertTextPresent('#errors(field1,field 1 error 1).error_index: 1')
+	assertTextPresent('#errors(field1,field 1 error 1).error_isFirst: true')
+	assertTextPresent('#errors(field1,field 1 error 1).error_isLast: false')
+	assertTextPresent('#errors(field1,field 1 error 1).error_parity: odd')
+	
+	assertTextPresent('#errors(field1,2).error: field 1 error 2')
+	assertTextPresent('#errors(field1,field 1 error 2).error_index: 2')
+	assertTextPresent('#errors(field1,field 1 error 2).error_isFirst: false')
+	assertTextPresent('#errors(field1,field 1 error 2).error_isLast: true')
+	assertTextPresent('#errors(field1,field 1 error 2).error_parity: even')
+	
+	assertTextPresent('#errors(field1).count: 2')
+	
+	assertTextPresent('#errors(field:field1).errors present')
+	assertTextPresent('#errors(field:field1,1).error: field 1 error 1')
+	assertTextPresent('#errors(field:field1,field 1 error 1).error_index: 1')
+	assertTextPresent('#errors(field:field1,field 1 error 1).error_isFirst: true')
+	assertTextPresent('#errors(field:field1,field 1 error 1).error_isLast: false')
+	assertTextPresent('#errors(field:field1,field 1 error 1).error_parity: odd')
+	
+	assertTextPresent('#errors(field:field1,2).error: field 1 error 2')
+	assertTextPresent('#errors(field:field1,field 1 error 2).error_index: 2')
+	assertTextPresent('#errors(field:field1,field 1 error 2).error_isFirst: false')
+	assertTextPresent('#errors(field:field1,field 1 error 2).error_isLast: true')
+	assertTextPresent('#errors(field:field1,field 1 error 2).error_parity: even')
+	
+	assertTextPresent('#errors(field:field1).count: 2')
+	assertTextPresent('#errors field2 tag')
+	
+	assertTextPresent('#errors(field2).errors present')
+	assertTextPresent('#errors(field2,1).error: field 2 error 1')
+	assertTextPresent('#errors(field2,field 2 error 1).error_index: 1')
+	assertTextPresent('#errors(field2,field 2 error 1).error_isFirst: true')
+	assertTextPresent('#errors(field2,field 2 error 1).error_isLast: false')
+	assertTextPresent('#errors(field2,field 2 error 1).error_parity: odd')
+	
+	assertTextPresent('#errors(field2,2).error: field 2 error 2')
+	assertTextPresent('#errors(field2,field 2 error 2).error_index: 2')
+	assertTextPresent('#errors(field2,field 2 error 2).error_isFirst: false')
+	assertTextPresent('#errors(field2,field 2 error 2).error_isLast: false')
+	assertTextPresent('#errors(field2,field 2 error 2).error_parity: even')
+	
+	assertTextPresent('#errors(field2,3).error: field 2 error 3')
+	assertTextPresent('#errors(field2,field 2 error 3).error_index: 3')
+	assertTextPresent('#errors(field2,field 2 error 3).error_isFirst: false')
+	assertTextPresent('#errors(field2,field 2 error 3).error_isLast: true')
+	assertTextPresent('#errors(field2,field 2 error 3).error_parity: odd')
+	
+	assertTextPresent('#errors(field2).count: 3')
+	
+	assertTextPresent('#errors(field:field2).errors present')
+	assertTextPresent('#errors(field:field2,1).error: field 2 error 1')
+	assertTextPresent('#errors(field:field2,field 2 error 1).error_index: 1')
+	assertTextPresent('#errors(field:field2,field 2 error 1).error_isFirst: true')
+	assertTextPresent('#errors(field:field2,field 2 error 1).error_isLast: false')
+	assertTextPresent('#errors(field:field2,field 2 error 1).error_parity: odd')
+	
+	assertTextPresent('#errors(field:field2,2).error: field 2 error 2')
+	assertTextPresent('#errors(field:field2,field 2 error 2).error_index: 2')
+	assertTextPresent('#errors(field:field2,field 2 error 2).error_isFirst: false')
+	assertTextPresent('#errors(field:field2,field 2 error 2).error_isLast: false')
+	assertTextPresent('#errors(field:field2,field 2 error 2).error_parity: even')
+	
+	assertTextPresent('#errors(field:field2,3).error: field 2 error 3')
+	assertTextPresent('#errors(field:field2,field 2 error 3).error_index: 3')
+	assertTextPresent('#errors(field:field2,field 2 error 3).error_isFirst: false')
+	assertTextPresent('#errors(field:field2,field 2 error 3).error_isLast: true')
+	assertTextPresent('#errors(field:field2,field 2 error 3).error_parity: odd')
+	
+	assertTextPresent('#errors(field:field2).count: 3')
+	
+	assertTextPresent('#errorClass field1: hasError;')
+	assertTextPresent('#errorClass field2: hasError;')
+	
+	assertTextPresent('#error field1: field 1 error 1;')
+	assertTextPresent('#error field2: field 2 error 1;')
+	
+	assertTextPresent('#iferrors present')
+	
+	assertTextPresent('#iferror field1 present')
+	assertTextPresent('#iferror field2 present')
+
+#{/selenium}


### PR DESCRIPTION
added functionality to errors tag

added test cases for the following tags: errors, error, errorClass, ifErrors, ifError

fixed bug in errors.last (wasn't working, size variable in errors.tag wasn't initialized)

updated documentation - tags.textile

fixed small typo in tags documentation, script tag title was missing

see http://www.playframework.org/documentation/1.1.1/tags#option
