### PR TITLE
Added note about reserved names in template documentation

### DIFF
--- a/documentation/manual/templates.textile
+++ b/documentation/manual/templates.textile
@@ -363,6 +363,6 @@ When you render a template from an action, the framework also adds implicit obje
 | **request** | The current HTTP request | "play.mvc.Http.Request":/@api/play/mvc/Http.Request.html  |  |
 | **session** | Session scope | "play.mvc.Scope.Session":/@api/play/mvc/Scope.Session.html  | "Controllers - Session & Flash Scope":controllers#session |
 
-In addition to the list above the names **owner** and **delegate** are reserved and can't be used as variable names in templates.
+In addition to the list above the names **owner**, **delegate** and **it** are reserved and can't be used as variable names in templates.
 
 p(note). Next: %(next)"Form data validation":validation%


### PR DESCRIPTION
As discussed [here](http://groups.google.com/group/play-framework/browse_thread/thread/7c22f25ff8239e90/e2c0f9b139a36eaa?lnk=gst#e2c0f9b139a36eaa) the words _owner_ and _delegate_ can't be used for variable names in templates.

I think this is worth a short note in the documentation as I'm not the only one who stumbled upon this.
