### PR TITLE
Lighthouse 625 patch

### DIFF
--- a/framework/pym/play/application.py
+++ b/framework/pym/play/application.py
@@ -26,7 +26,7 @@ class PlayApplication:
         else:
             self.conf = None
         self.play_env = env
-        self.jpda_port = self.readConf('jpda_port')
+        self.jpda_port = self.readConf('jpda.port')
         self.ignoreMissingModules = ignoreMissingModules
 
     # ~~~~~~~~~~~~~~~~~~~~~~ Configuration File


### PR DESCRIPTION
See http://play.lighthouseapp.com/projects/57987-play-framework/tickets/625 . I have tried to alter the least amount of what was already there.

Some of the existing code is very strange.  For instance, self.jpda_port gets assigned in three different functions: once in the constructor, then in self.check_jpda and in self.java_cmd. The assignment in the constructor used to access the wrong configuration key, so it certainly is at least useless.
