### PR TITLE
[#628] Value-less parameters not exposed to Controller

### DIFF
--- a/framework/src/play/data/parsing/UrlEncodedParser.java
+++ b/framework/src/play/data/parsing/UrlEncodedParser.java
@@ -58,6 +58,8 @@ public class UrlEncodedParser extends DataParser {
                         if (key != null) {
                             Utils.Maps.mergeValueInMap(params, key, value);
                             key = null;
+                        } else {
+                            Utils.Maps.mergeValueInMap(params, value, (String) null);
                         }
                         ox = 0;
                         break;
@@ -80,9 +82,11 @@ public class UrlEncodedParser extends DataParser {
                 }
             }
             //The last value does not end in '&'.  So save it now.
+            value = new String(data, 0, ox, "utf-8");
             if (key != null) {
-                value = new String(data, 0, ox, "utf-8");
                 Utils.Maps.mergeValueInMap(params, key, value);
+            } else if (!value.isEmpty()) {
+                Utils.Maps.mergeValueInMap(params, value, (String) null);
             }
             return params;
         } catch (Exception e) {

--- a/samples-and-tests/just-test-cases/app/controllers/DataBinding.java
+++ b/samples-and-tests/just-test-cases/app/controllers/DataBinding.java
@@ -3,6 +3,7 @@ package controllers;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.text.SimpleDateFormat;
 
 import models.Person;
@@ -85,6 +86,15 @@ public class DataBinding extends Controller {
     
     public static void createFactory(@play.data.validation.Valid models.Factory factory) {
         renderText(validation.hasErrors() + " -> " + factory.name + "," + factory.color);
+    }
+
+    public static void printParams() {
+        Map<String, String> paramMap = params.allSimple();
+        String out = "";
+        for (String key : paramMap.keySet()) {
+            out += key + " " + paramMap.get(key) + "\n";
+        }
+        renderText(out);
     }
 }
 

--- a/samples-and-tests/just-test-cases/test/binding.test.html
+++ b/samples-and-tests/just-test-cases/test/binding.test.html
@@ -87,4 +87,10 @@
 		open('/databinding/createFactory?factory.number=457&factory.name=Nestle&factory.color=')
 		assertTextPresent('false -> Nestle,null')
 
-#{/selenium}	
+        <!-- Test that value-less params are noticed -->
+        open('@{DataBinding.printParams()}?noValue&noValue2&key=value&noValue3')
+        assertTextPresent('noValue null')
+        assertTextPresent('noValue2 null')
+        assertTextPresent('key value')
+        assertTextPresent('noValue3 null')
+#{/selenium}


### PR DESCRIPTION
http://play.lighthouseapp.com/projects/57987-play-framework/tickets/628-value-less-parameters-not-exposed-to-controller

Play! presently ignores value-less url parameters. For example, in the request /Application/test?foo&bar&baz , params.all() does not contain 'foo', 'bar', or 'baz'.

I have patched our local installation to allow this use case -- I'll open a pull request in case you would like this change as well (I'm not sure if the omission was intentional or not).
