### PR TITLE
[#629] eclipsify: log4j.properties are not recognized in test mode because conf folder is too late on classpath 

### DIFF
--- a/resources/eclipse/test.launch
+++ b/resources/eclipse/test.launch
@@ -9,9 +9,9 @@
     <booleanAttribute key="org.eclipse.debug.core.appendEnvironmentVariables" value="true"/>
     <listAttribute key="org.eclipse.jdt.launching.CLASSPATH">
         <listEntry value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;&#10;&lt;runtimeClasspathEntry containerPath=&quot;org.eclipse.jdt.launching.JRE_CONTAINER&quot; javaProject=&quot;%PROJECT_NAME%&quot; path=&quot;1&quot; type=&quot;4&quot;/&gt;&#10;"/>
+        <listEntry value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;&#10;&lt;runtimeClasspathEntry internalArchive=&quot;/%PROJECT_NAME%/conf&quot; path=&quot;3&quot; type=&quot;2&quot;/&gt;&#10;"/>
         <listEntry value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&#13;&#10;&lt;runtimeClasspathEntry externalArchive=&quot;%PLAY_BASE%/modules/testrunner/lib/play-testrunner.jar&quot; path=&quot;3&quot; type=&quot;2&quot;/&gt;&#13;&#10;"/>
         <listEntry value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;&#10;&lt;runtimeClasspathEntry id=&quot;org.eclipse.jdt.launching.classpathentry.defaultClasspath&quot;&gt;&#10;&lt;memento exportedEntriesOnly=&quot;false&quot; project=&quot;%PROJECT_NAME%&quot;/&gt;&#10;&lt;/runtimeClasspathEntry&gt;&#10;"/>
-        <listEntry value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;&#10;&lt;runtimeClasspathEntry internalArchive=&quot;/%PROJECT_NAME%/conf&quot; path=&quot;3&quot; type=&quot;2&quot;/&gt;&#10;"/>
     </listAttribute>
     <booleanAttribute key="org.eclipse.jdt.launching.DEFAULT_CLASSPATH" value="false"/>
     <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="play.server.Server"/>


### PR DESCRIPTION
Fixes  [Lighthouse Issue 629](http://play.lighthouseapp.com/projects/57987-play-framework/tickets/629-eclipsify-log4jproperties-are-not-recognized-in-test-mode-because-conf-folder-is-too-late-on-classpath)

Same change as 129f13b59aa75f60d36c0672327805d30cda7e4e but now for the test launcher.
