### PR TITLE
Fix Fixtures.load() so that ManyToMany works

### DIFF
--- a/framework/src/play/db/jpa/JPAPlugin.java
+++ b/framework/src/play/db/jpa/JPAPlugin.java
@@ -557,32 +557,28 @@ public class JPAPlugin extends PlayPlugin {
             if (Collection.class.isAssignableFrom(field.getType())) {
                 final Class<?> fieldType = (Class<?>) ((ParameterizedType) field.getGenericType()).getActualTypeArguments()[0];
                 if (field.isAnnotationPresent(OneToMany.class)) {
-                    if (field.getAnnotation(OneToMany.class).mappedBy().equals("")) {
-                        modelProperty.isRelation = true;
-                        modelProperty.isMultiple = true;
-                        modelProperty.relationType = fieldType;
-                        modelProperty.choices = new Model.Choices() {
+                    modelProperty.isRelation = true;
+                    modelProperty.isMultiple = true;
+                    modelProperty.relationType = fieldType;
+                    modelProperty.choices = new Model.Choices() {
 
-                            @SuppressWarnings("unchecked")
-                            public List<Object> list() {
-                                return JPA.em().createQuery("from " + fieldType.getName()).getResultList();
-                            }
-                        };
-                    }
+                        @SuppressWarnings("unchecked")
+                        public List<Object> list() {
+                            return JPA.em().createQuery("from " + fieldType.getName()).getResultList();
+                        }
+                    };
                 }
                 if (field.isAnnotationPresent(ManyToMany.class)) {
-                    if (field.getAnnotation(ManyToMany.class).mappedBy().equals("")) {
-                        modelProperty.isRelation = true;
-                        modelProperty.isMultiple = true;
-                        modelProperty.relationType = fieldType;
-                        modelProperty.choices = new Model.Choices() {
+                    modelProperty.isRelation = true;
+                    modelProperty.isMultiple = true;
+                    modelProperty.relationType = fieldType;
+                    modelProperty.choices = new Model.Choices() {
 
-                            @SuppressWarnings("unchecked")
-                            public List<Object> list() {
-                                return JPA.em().createQuery("from " + fieldType.getName()).getResultList();
-                            }
-                        };
-                    }
+                        @SuppressWarnings("unchecked")
+                        public List<Object> list() {
+                            return JPA.em().createQuery("from " + fieldType.getName()).getResultList();
+                        }
+                    };
                 }
             }
             if (field.getType().isEnum()) {

--- a/framework/src/play/test/Fixtures.java
+++ b/framework/src/play/test/Fixtures.java
@@ -6,14 +6,11 @@ import java.lang.reflect.Field;
 import java.sql.ResultSet;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -30,6 +27,7 @@ import play.data.binding.types.DateBinder;
 import play.db.DB;
 import play.db.DBPlugin;
 import play.db.Model;
+import play.db.Model.Property;
 import play.exceptions.UnexpectedException;
 import play.exceptions.YAMLException;
 import play.vfs.VirtualFile;
@@ -59,19 +57,19 @@ public class Fixtures {
     public static void deleteAllModels() {
         List<Class<? extends Model>> classes = new ArrayList<Class<? extends Model>>();
         for (ApplicationClasses.ApplicationClass c : Play.classes.getAssignableClasses(Model.class)) {
-            classes.add((Class<? extends Model>)c.javaClass);
+            classes.add((Class<? extends Model>) c.javaClass);
         }
         Fixtures.delete(classes);
     }
 
     private static void disableForeignKeyConstraints() {
         if (DBPlugin.url.startsWith("jdbc:oracle:")) {
-            DB.execute("begin\n" +
-                    "for i in (select constraint_name, table_name from user_constraints where constraint_type ='R'\n" +
-                    "and status = 'ENABLED') LOOP\n" +
-                    "execute immediate 'alter table '||i.table_name||' disable constraint '||i.constraint_name||'';\n" +
-                    "end loop;\n" +
-                    "end;");
+            DB
+                    .execute("begin\n"
+                            + "for i in (select constraint_name, table_name from user_constraints where constraint_type ='R'\n"
+                            + "and status = 'ENABLED') LOOP\n"
+                            + "execute immediate 'alter table '||i.table_name||' disable constraint '||i.constraint_name||'';\n"
+                            + "end loop;\n" + "end;");
             return;
         }
 
@@ -86,17 +84,18 @@ public class Fixtures {
         }
 
         // Maybe Log a WARN for unsupported DB ?
-        Logger.warn("Fixtures : unable to disable constraints, unsupported database : " + DBPlugin.url);
+        Logger.warn("Fixtures : unable to disable constraints, unsupported database : "
+                + DBPlugin.url);
     }
 
     private static void enableForeignKeyConstraints() {
         if (DBPlugin.url.startsWith("jdbc:oracle:")) {
-             DB.execute("begin\n" +
-                     "for i in (select constraint_name, table_name from user_constraints where constraint_type ='R'\n" +
-                     "and status = 'DISABLED') LOOP\n" +
-                     "execute immediate 'alter table '||i.table_name||' enable constraint '||i.constraint_name||'';\n" +
-                     "end loop;\n" +
-                     "end;");
+            DB
+                    .execute("begin\n"
+                            + "for i in (select constraint_name, table_name from user_constraints where constraint_type ='R'\n"
+                            + "and status = 'DISABLED') LOOP\n"
+                            + "execute immediate 'alter table '||i.table_name||' enable constraint '||i.constraint_name||'';\n"
+                            + "end loop;\n" + "end;");
             return;
         }
 
@@ -111,12 +110,12 @@ public class Fixtures {
         }
 
         // Maybe Log a WARN for unsupported DB ?
-        Logger.warn("Fixtures : unable to enable constraints, unsupported database : " + DBPlugin.url);
+        Logger.warn("Fixtures : unable to enable constraints, unsupported database : "
+                + DBPlugin.url);
     }
 
-
     static String getDeleteTableStmt(String name) {
-        if (DBPlugin.url.startsWith("jdbc:mysql:") ) {
+        if (DBPlugin.url.startsWith("jdbc:mysql:")) {
             return "TRUNCATE TABLE " + name;
         } else if (DBPlugin.url.startsWith("jdbc:postgresql:")) {
             return "TRUNCATE TABLE " + name + " cascade";
@@ -129,7 +128,8 @@ public class Fixtures {
     public static void deleteAll() {
         try {
             List<String> names = new ArrayList<String>();
-            ResultSet rs = DB.getConnection().getMetaData().getTables(null, null, null, new String[]{"TABLE"});
+            ResultSet rs = DB.getConnection().getMetaData().getTables(null, null, null,
+                    new String[] { "TABLE" });
             while (rs.next()) {
                 String name = rs.getString("TABLE_NAME");
                 names.add(name);
@@ -140,12 +140,17 @@ public class Fixtures {
                 DB.execute(getDeleteTableStmt(name) + ";");
             }
             enableForeignKeyConstraints();
-            for(PlayPlugin plugin : Play.plugins) {
+            for (PlayPlugin plugin : Play.plugins) {
                 plugin.afterFixtureLoad();
             }
         } catch (Exception e) {
             throw new RuntimeException("Cannot delete all table data : " + e.getMessage(), e);
         }
+    }
+
+    private static class UnresolvedField {
+        public Model object;
+        public List<Model.Property> fields;
     }
 
     public static void load(String name) {
@@ -159,51 +164,18 @@ public class Fixtures {
             }
             InputStream is = Play.classloader.getResourceAsStream(name);
             if (is == null) {
-                throw new RuntimeException("Cannot load fixture " + name + ", the file was not found");
+                throw new RuntimeException("Cannot load fixture " + name
+                        + ", the file was not found");
             }
             Yaml yaml = new Yaml();
             Object o = yaml.load(is);
             if (o instanceof LinkedHashMap<?, ?>) {
-                @SuppressWarnings("unchecked") LinkedHashMap<Object, Map<?, ?>> objects = (LinkedHashMap<Object, Map<?, ?>>) o;
-                Map<String, Object> idCache = new HashMap<String, Object>();
-                for (Object key : objects.keySet()) {
-                    Matcher matcher = keyPattern.matcher(key.toString().trim());
-                    if (matcher.matches()) {
-                        String type = matcher.group(1);
-                        String id = matcher.group(2);
-                        if (!type.startsWith("models.")) {
-                            type = "models." + type;
-                        }
-                        if (idCache.containsKey(type + "-" + id)) {
-                            throw new RuntimeException("Cannot load fixture " + name + ", duplicate id '" + id + "' for type " + type);
-                        }
-                        Map<String, String[]> params = new HashMap<String, String[]>();
-                        if (objects.get(key) == null) {
-                            objects.put(key, new HashMap<Object, Object>());
-                        }
-                        serialize(objects.get(key), "object", params);
-                        @SuppressWarnings("unchecked")
-                        Class<Model> cType = (Class<Model>)Play.classloader.loadClass(type);
-                        resolveDependencies(cType, params, idCache);
-                        Model model = (Model)Binder.bind("object", cType, cType, null, params);
-                        for(Field f : model.getClass().getFields()) {
-                            // TODO: handle something like FileAttachment
-                            if (f.getType().isAssignableFrom(Map.class)) {
-                                f.set(model, objects.get(key).get(f.getName()));
-                            }
-
-                        }
-                        model._save();
-                        Class<?> tType = cType;
-                        while (!tType.equals(Object.class)) {
-                            idCache.put(tType.getName() + "-" + id, Model.Manager.factoryFor(cType).keyValue(model));
-                            tType = tType.getSuperclass();
-                        }
-                    }
-                }
+                @SuppressWarnings("unchecked")
+                LinkedHashMap<Object, Map<?, ?>> objects = (LinkedHashMap<Object, Map<?, ?>>) o;
+                loadObjects(name, objects);
             }
             // Most persistence engine will need to clear their state
-            for(PlayPlugin plugin : Play.plugins) {
+            for (PlayPlugin plugin : Play.plugins) {
                 plugin.afterFixtureLoad();
             }
         } catch (ClassNotFoundException e) {
@@ -212,6 +184,123 @@ public class Fixtures {
             throw new YAMLException(e, yamlFile);
         } catch (Throwable e) {
             throw new RuntimeException("Cannot load fixture " + name + ": " + e.getMessage(), e);
+        }
+    }
+
+    private static void loadObjects(String fileName, LinkedHashMap<Object, Map<?, ?>> objects)
+            throws ClassNotFoundException, IllegalAccessException {
+
+        Map<String, List<String>> resolved = new HashMap<String, List<String>>();
+        Map<String, UnresolvedField> unresolved = new HashMap<String, UnresolvedField>();
+        Map<String, Object> idCache = new HashMap<String, Object>();
+
+        for (Object key : objects.keySet()) {
+            Matcher matcher = keyPattern.matcher(key.toString().trim());
+            if (matcher.matches()) {
+                // eg Farmer
+                String type = matcher.group(1);
+                // eg bob
+                String id = matcher.group(2);
+                if (!type.startsWith("models.")) {
+                    type = "models." + type;
+                }
+
+                // eg Farmer-bob
+                String idCacheKey = type + "-" + id;
+                if (idCache.containsKey(idCacheKey)) {
+                    throw new RuntimeException("Cannot load fixture " + fileName
+                            + ", duplicate id '" + id + "' for type " + type);
+                }
+
+                if (objects.get(key) == null) {
+                    objects.put(key, new HashMap<Object, Object>());
+                }
+
+                //
+                // Convert the YAML object fields into serialized
+                // strings
+                // eg
+                // {
+                // object.name => ["Bob"],
+                // object.fruits => ["pear", "apple", ...]
+                // object.created => ["ISO8601:2010-10-01T12:56:32Z"]
+                // ...
+                // }
+                //
+                Map<String, String[]> params = new HashMap<String, String[]>();
+                serialize(objects.get(key), "object", params);
+
+                //
+                // Convert YAML ids into Model ids
+                // eg
+                // object.fruits.id => [7, 12]
+                //
+                @SuppressWarnings("unchecked")
+                Class<Model> cType = (Class<Model>) Play.classloader.loadClass(type);
+                List<Property> unresolvedFields = new ArrayList<Property>();
+                resolveDependencies(idCacheKey, cType, params, idCache, resolved, unresolvedFields);
+
+                // Create the model object using Play's binding mechanism
+                Model model = (Model) Binder.bind("object", cType, cType, null, params);
+                for (Field f : model.getClass().getFields()) {
+                    // TODO: handle something like FileAttachment
+                    if (f.getType().isAssignableFrom(Map.class)) {
+                        f.set(model, objects.get(key).get(f.getName()));
+                    }
+
+                }
+                model._save();
+
+                // Keep track of unresolved object fields so that we can resolve
+                // them later
+                if (unresolvedFields.size() > 0) {
+                    UnresolvedField unresolvedRef = new UnresolvedField();
+                    unresolvedRef.object = model;
+                    unresolvedRef.fields = unresolvedFields;
+                    unresolved.put(idCacheKey, unresolvedRef);
+                }
+
+                // Now that the model has been created, add its id to the id
+                // cache
+                // eg { Farmer-bob => 7, Farmer-jim => 9 ... }
+                Class<?> tType = cType;
+                while (!tType.equals(Object.class)) {
+                    idCache.put(tType.getName() + "-" + id, Model.Manager.factoryFor(cType)
+                            .keyValue(model));
+                    tType = tType.getSuperclass();
+                }
+            }
+        }
+
+        // Resolve any references that could not be resolved in the first
+        // pass
+        String objName = "object";
+        for (String idCacheKey : unresolved.keySet()) {
+            UnresolvedField ref = unresolved.get(idCacheKey);
+            Map<String, String[]> bindParams = new HashMap<String, String[]>();
+            for (Property field : ref.fields) {
+                // eg Farmer->Fruit-pear
+                String refTarget = field.relationType.getName() + "->" + idCacheKey;
+
+                // Convert from YAML ids to Model ids
+                List<String> yamlIds = resolved.get(refTarget);
+                if (yamlIds != null) {
+                    String[] modelIds = new String[yamlIds.size()];
+                    for (int i = 0; i < yamlIds.size(); i++) {
+                        modelIds[i] = idCache.get(yamlIds.get(i)).toString();
+                    }
+
+                    // Use play's binding mechanism to resolve the model objects
+                    String fieldName = objName + "." + field.name;
+                    String idFieldName = getIdFieldName(field, fieldName);
+
+                    // eg object.farmers=[5, 7]
+                    bindParams.put(idFieldName, modelIds);
+                }
+            }
+
+            Binder.bind(ref.object, objName, bindParams);
+            ref.object._save();
         }
     }
 
@@ -224,7 +313,8 @@ public class Fixtures {
             if (value instanceof Map<?, ?>) {
                 serialize((Map<?, ?>) value, prefix + "." + key, serialized);
             } else if (value instanceof Date) {
-                serialized.put(prefix + "." + key.toString(), new String[]{new SimpleDateFormat(DateBinder.ISO8601).format(((Date) value))});
+                serialized.put(prefix + "." + key.toString(), new String[] { new SimpleDateFormat(
+                        DateBinder.ISO8601).format(((Date) value)) });
             } else if (value instanceof List<?>) {
                 List<?> l = (List<?>) value;
                 String[] r = new String[l.size()];
@@ -239,38 +329,75 @@ public class Fixtures {
                 String file = m.group(1);
                 VirtualFile f = Play.getVirtualFile(file);
                 if (f != null && f.exists()) {
-                    serialized.put(prefix + "." + key.toString(), new String[]{f.contentAsString()});
+                    serialized.put(prefix + "." + key.toString(), new String[] { f
+                            .contentAsString() });
                 }
             } else {
-                serialized.put(prefix + "." + key.toString(), new String[]{value.toString()});
+                serialized.put(prefix + "." + key.toString(), new String[] { value.toString() });
             }
         }
     }
 
-    static void resolveDependencies(Class<Model> type, Map<String, String[]> serialized, Map<String, Object> idCache) {
-        Set<Field> fields = new HashSet<Field>();
-        Class<?> clazz = type;
-        while (!clazz.equals(Object.class)) {
-            Collections.addAll(fields, clazz.getDeclaredFields());
-            clazz = clazz.getSuperclass();
-        }
+    static void resolveDependencies(String idCacheKey, Class<Model> type,
+            Map<String, String[]> serialized, Map<String, Object> idCache,
+            Map<String, List<String>> resolved, List<Property> unresolvedDeps) {
         for (Model.Property field : Model.Manager.factoryFor(type).listProperties()) {
             if (field.isRelation) {
-                String[] ids = serialized.get("object." + field.name);
-                if (ids != null) {
-                    for (int i = 0; i < ids.length; i++) {
-                        String id = ids[i];
-                        id = field.relationType.getName() + "-" + id;
-                        if (!idCache.containsKey(id)) {
-                            throw new RuntimeException("No previous reference found for object of type " + field.name + " with key " + ids[i]);
+                String fieldName = "object." + field.name;
+                String[] modelIds = null;
+                String[] yamlIds = serialized.get(fieldName);
+
+                if (yamlIds != null) {
+                    modelIds = new String[yamlIds.length];
+
+                    // Convert from YAML id into model id
+                    // eg from ["bob", "jim"] into ["7", "9"]
+                    for (int i = 0; i < yamlIds.length; i++) {
+                        String yamlId = yamlIds[i];
+                        String relatedIdCacheKey = field.relationType.getName() + "-" + yamlId;
+                        if (!idCache.containsKey(relatedIdCacheKey)) {
+                            throw new RuntimeException(
+                                    "No previous reference found for object of type " + field.name
+                                            + " with key " + yamlId);
                         }
-                        ids[i] = idCache.get(id).toString();
+
+                        modelIds[i] = idCache.get(relatedIdCacheKey).toString();
+
+                        // Keep track of which source objects reference which
+                        // target objects
+                        // eg Fruit-pear is referred to by Farmer-bob and
+                        // Farmer-jim
+
+                        // eg "Farmer->Fruit-pear"
+                        String refTarget = type.getName() + "->" + relatedIdCacheKey;
+                        List<String> refSources = resolved.get(refTarget);
+                        if (refSources == null) {
+                            refSources = new ArrayList<String>();
+                            resolved.put(refTarget, refSources);
+                        }
+                        // eg
+                        // {
+                        // "Farmer->Fruit-pear" => ["Farmer-bob", "Farmer-jim"],
+                        // "Farmer->Fruit-kiwi" => ["Farmer-jim", "Farmer-dan"],
+                        // ...
+                        // }
+                        refSources.add(idCacheKey);
                     }
+
+                } else {
+                    // We need to save the field as being unresolved so we can
+                    // resolve it later once the model object has been created
+                    unresolvedDeps.add(field);
                 }
-                serialized.remove("object." + field.name);
-                serialized.put("object." + field.name + "." + Model.Manager.factoryFor((Class<? extends Model>)field.relationType).keyName(), ids);
+                serialized.remove(fieldName);
+                serialized.put(getIdFieldName(field, fieldName), modelIds);
             }
         }
+    }
+
+    private static String getIdFieldName(Model.Property field, String fieldName) {
+        return fieldName + "."
+                + Model.Manager.factoryFor((Class<? extends Model>) field.relationType).keyName();
     }
 
     public static void deleteDirectory(String path) {

--- a/samples-and-tests/just-test-cases/app/models/Farmer.java
+++ b/samples-and-tests/just-test-cases/app/models/Farmer.java
@@ -1,0 +1,22 @@
+package models;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.persistence.Entity;
+import javax.persistence.ManyToMany;
+
+import play.data.validation.Required;
+import play.db.jpa.Model;
+
+@Entity
+public class Farmer extends Model {
+    @Required
+    public String name;
+    @ManyToMany
+    public List<Fruit> fruits = new ArrayList<Fruit>();
+
+    public String toString() {
+        return name;
+    }
+}

--- a/samples-and-tests/just-test-cases/app/models/Fruit.java
+++ b/samples-and-tests/just-test-cases/app/models/Fruit.java
@@ -1,0 +1,22 @@
+package models;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.persistence.Entity;
+import javax.persistence.ManyToMany;
+
+import play.data.validation.Required;
+import play.db.jpa.Model;
+
+@Entity
+public class Fruit extends Model {
+    @Required
+    public String name;
+    @ManyToMany
+    public List<Farmer> farmers = new ArrayList<Farmer>();
+
+    public String toString() {
+        return name;
+    }
+}

--- a/samples-and-tests/just-test-cases/app/models/Municipality.java
+++ b/samples-and-tests/just-test-cases/app/models/Municipality.java
@@ -1,0 +1,22 @@
+package models;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.persistence.Entity;
+import javax.persistence.OneToMany;
+
+import play.data.validation.Required;
+import play.db.jpa.Model;
+
+@Entity
+public class Municipality extends Model {
+    @Required
+    public String name;
+    @OneToMany(mappedBy="municipality")
+    public List<Neighborhood> neighborhoods = new ArrayList<Neighborhood>();
+
+    public String toString() {
+        return name;
+    }
+}

--- a/samples-and-tests/just-test-cases/app/models/Neighborhood.java
+++ b/samples-and-tests/just-test-cases/app/models/Neighborhood.java
@@ -1,0 +1,23 @@
+package models;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.persistence.Entity;
+import javax.persistence.ManyToMany;
+import javax.persistence.ManyToOne;
+
+import play.data.validation.Required;
+import play.db.jpa.Model;
+
+@Entity
+public class Neighborhood extends Model {
+    @Required
+    public String name;
+    @ManyToOne
+    public Municipality municipality = null;
+
+    public String toString() {
+        return name;
+    }
+}

--- a/samples-and-tests/just-test-cases/test/FixturesTest.java
+++ b/samples-and-tests/just-test-cases/test/FixturesTest.java
@@ -1,14 +1,11 @@
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 
-import javax.management.RuntimeErrorException;
-
 import models.Bloc;
 import models.vendor.Vendor;
 import models.vendor.tag.AreaTag;
 import models.vendor.tag.FunctionTag;
 import models.vendor.tag.Tag;
-import models.Base;
 import models.*;
 
 import org.junit.Before;
@@ -80,4 +77,35 @@ public class FixturesTest extends UnitTest {
 		assertFalse(parent.children.isEmpty());
 	}
 
+    @Test
+    public void manyToMany() {
+        Fixtures.load("manyToMany.yml");
+        Farmer fred = Farmer.find("name = ?", "Fred").first();
+        assertEquals(2, fred.fruits.size());
+
+        Fruit pear = Fruit.find("name = ?", "Pear").first();
+        assertEquals(2, pear.farmers.size());
+    }
+
+    @Test
+    public void oneToMany() {
+        Fixtures.load("oneToMany.yml");
+        Municipality ba = Municipality.find("name = ?", "Buenos Aires").first();
+        assertEquals(2, ba.neighborhoods.size());
+
+        Neighborhood almagro = Neighborhood.find("name = ?", "Almagro").first();
+        assertNotNull(almagro.municipality);
+        assertEquals("Buenos Aires", almagro.municipality.name);
+    }
+
+    @Test
+    public void manyToOne() {
+        Fixtures.load("manyToOne.yml");
+        Municipality ba = Municipality.find("name = ?", "Buenos Aires").first();
+        assertEquals(2, ba.neighborhoods.size());
+
+        Neighborhood almagro = Neighborhood.find("name = ?", "Almagro").first();
+        assertNotNull(almagro.municipality);
+        assertEquals("Buenos Aires", almagro.municipality.name);
+    }
 }

--- a/samples-and-tests/just-test-cases/test/manyToMany.yml
+++ b/samples-and-tests/just-test-cases/test/manyToMany.yml
@@ -1,0 +1,29 @@
+# Many to Many
+Fruit(orange):
+    name: "Orange"
+
+Fruit(apple):
+    name: "Apple"
+
+Fruit(pear):
+    name: "Pear"
+
+Farmer(rob):
+    name: "Rob"
+    fruits:
+        - orange
+        - apple
+
+Farmer(fred):
+    name: "Fred"
+    fruits:
+        - apple
+        - pear
+
+Farmer(john):
+    name: "John"
+    fruits:
+        - orange
+        - apple
+        - pear
+

--- a/samples-and-tests/just-test-cases/test/manyToOne.yml
+++ b/samples-and-tests/just-test-cases/test/manyToOne.yml
@@ -1,0 +1,11 @@
+# Many to one
+Municipality(ba):
+    name: "Buenos Aires"
+
+Neighborhood(almagro):
+    name: "Almagro"
+    municipality: ba
+
+Neighborhood(chacarita):
+    name: "Chacarita"
+    municipality: ba

--- a/samples-and-tests/just-test-cases/test/oneToMany.yml
+++ b/samples-and-tests/just-test-cases/test/oneToMany.yml
@@ -1,0 +1,12 @@
+# One to many
+Neighborhood(almagro):
+    name: "Almagro"
+
+Neighborhood(chacarita):
+    name: "Chacarita"
+
+Municipality(ba):
+    name: "Buenos Aires"
+    neighborhoods:
+        - almagro
+        - chacarita


### PR DESCRIPTION
The first pass over the object graph we make a record of which fields could not resolved, and then make a second pass that resolves them.

The only thing I wasn't sure about is that in JPAPlugin.java there's a couple of lines like this:
    if (field.getAnnotation(OneToMany.class).mappedBy().equals("")) {
This doesn't make much sense to me (why should we not recognize the relation if there's a mappedBy?) so I removed them.
