### PR TITLE
Lighthouse 639 patch

### DIFF
--- a/framework/src/play/data/binding/AnnotationHelper.java
+++ b/framework/src/play/data/binding/AnnotationHelper.java
@@ -59,10 +59,13 @@ public class AnnotationHelper {
             String[] commaSeparatedLang = l.split(",");
             for (String lang : commaSeparatedLang) {
                 if (Lang.get().equals(lang) || "*".equals(lang)) {
+                    Locale locale = null;
                     if ("*".equals(lang)) {
-                        lang = Locale.getDefault().getLanguage();
+                        locale = Lang.getLocale();
                     }
-                    Locale locale = Lang.getLocale(lang);
+                    if (locale == null) {
+                        locale = Lang.getLocale(lang);
+                    }
                     if (locale != null) {
                         return new Tuple(i, locale);
                     }


### PR DESCRIPTION
Fix "Binding test" NPE with russian locale set on running server. 

If @As.lang is not set explisitly play.data.binding.AnnotationHelper.getLocale(String[] langs) is ignoring value previously set by calling play.i18n.Lang.change(String locale).
