### PR TITLE
Lighthouse 658 patch

### DIFF
--- a/framework/src/play/server/ServletWrapper.java
+++ b/framework/src/play/server/ServletWrapper.java
@@ -39,6 +39,9 @@ import java.util.*;
  * Thanks to Lee Breisacher.
  */
 public class ServletWrapper extends HttpServlet implements ServletContextListener {
+	
+	public static final String IF_MODIFIED_SINCE = "If-Modified-Since";
+	public static final String IF_NONE_MATCH = "If-None-Match";
 
 	/**
 	 * Constant for accessing the underlying HttpServletRequest from Play's Request
@@ -175,27 +178,39 @@ public class ServletWrapper extends HttpServlet implements ServletContextListene
         }
     }
 
-    public static boolean isModified(String etag, long last, HttpServletRequest request) {
-        if (!(request.getHeader("If-None-Match") == null && request.getHeaders("If-Modified-Since") == null)) {
-            return true;
-        } else {
-            String browserEtag = request.getHeader("If-None-Match");
-            if (!browserEtag.equals(etag)) {
-                return true;
-            } else {
-                try {
-                    Date browserDate = Utils.getHttpDateFormatter().parse(request.getHeader("If-Modified-Since"));
-                    if (browserDate.getTime() >= last) {
-                        return false;
-                    }
-                } catch (ParseException ex) {
-                    Logger.error("Can't parse date", ex);
-                }
-                return true;
-            }
-        }
-    }
+	public static boolean isModified(String etag, long last,
+			HttpServletRequest request) {
+		// See section 14.26 in rfc 2616 http://www.faqs.org/rfcs/rfc2616.html
+		String browserEtag = request.getHeader(IF_NONE_MATCH);
+		String dateString = request.getHeader(IF_MODIFIED_SINCE);
+		if (browserEtag != null) {
+			boolean etagMatches = browserEtag.equals(etag);
+			if (!etagMatches) {
+				return true;
+			}
+			if (dateString != null) {
+				return !isValidTimeStamp(last, dateString);
+			}
+			return false;
+		} else {
+			if (dateString != null) {
+				return !isValidTimeStamp(last, dateString);
+			} else {
+				return true;
+			}
+		}
+	}
 
+	private static boolean isValidTimeStamp(long last, String dateString) {
+		try {
+			long browserDate = Utils.getHttpDateFormatter().parse(dateString).getTime();
+			return browserDate >= last;
+		} catch (ParseException e) {
+			Logger.error("Can't parse date", e);
+			return false;
+		}
+	}
+    	
     public static Request parseRequest(HttpServletRequest httpServletRequest) throws Exception {
         Request request = new Http.Request();
         Request.current.set(request);

--- a/framework/test-src/play/server/ServletWrapperTest.java
+++ b/framework/test-src/play/server/ServletWrapperTest.java
@@ -1,0 +1,364 @@
+package play.server;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.security.Principal;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletInputStream;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class ServletWrapperTest {
+	private String browserEtag;
+	private String browserLastModified;
+
+	@Before
+	public void setUp() {
+		browserEtag = "\"1299752290000-1192808478\"";
+		browserLastModified = "Thu, 10 Mar 2011 10:18:10 GMT";
+	}
+
+	@Test
+	public void isNotModifiedHTTP11ClientTest() {
+		assertFalse(ServletWrapper.isModified(browserEtag, 0,
+				new HttpServletStub(createHeaderMap())));
+	}
+
+	@Test
+	public void isNotModifiedHTTP10ClientTest() {
+		HashMap<String, String> headers = createHeaderMap();
+		headers.remove(ServletWrapper.IF_NONE_MATCH);
+		assertFalse(ServletWrapper.isModified(browserEtag, 0,
+				new HttpServletStub(headers)));
+	}
+
+	@Test
+	public void isModifiedHTTP10ClientTest() {
+		HashMap<String, String> headers = createHeaderMap();
+		headers.remove(ServletWrapper.IF_NONE_MATCH);
+		assertTrue(ServletWrapper.isModified(browserEtag, Long.MAX_VALUE,
+				new HttpServletStub(headers)));
+	}
+
+	@Test
+	public void browserHasNoCache() {
+		assertTrue(ServletWrapper.isModified(browserEtag, 0,
+				new HttpServletStub(new HashMap<String, String>())));
+	}
+
+	private HashMap<String, String> createHeaderMap() {
+		HashMap<String, String> headers = new HashMap<String, String>();
+		headers.put(ServletWrapper.IF_MODIFIED_SINCE, browserLastModified);
+		headers.put(ServletWrapper.IF_NONE_MATCH, browserEtag);
+		return headers;
+	}
+
+	private static class HttpServletStub implements HttpServletRequest {
+		private final HashMap<String, String> headers;
+
+		public HttpServletStub(HashMap<String, String> headers) {
+			this.headers = headers;
+		}
+
+		@Override
+		public String getHeader(String key) {
+			return headers.get(key);
+		}
+
+		@Override
+		public String getAuthType() {
+			throw new RuntimeException("Method not implemented");
+		}
+
+		@Override
+		public String getContextPath() {
+			throw new RuntimeException("Method not implemented");
+		}
+
+		@Override
+		public Cookie[] getCookies() {
+			throw new RuntimeException("Method not implemented");
+		}
+
+		@Override
+		public long getDateHeader(String arg0) {
+			throw new RuntimeException("Method not implemented");
+		}
+
+		@Override
+		public Enumeration getHeaderNames() {
+			throw new RuntimeException("Method not implemented");
+		}
+
+		@Override
+		public Enumeration getHeaders(final String arg0) {
+			
+			return new Enumeration<Object>() {
+				String element = headers.get(arg0);
+
+				@Override
+				public boolean hasMoreElements() {
+					return element != null;
+				}
+
+				@Override
+				public Object nextElement() {
+					Object current = element;
+					current = null;
+					return current;
+				}
+			}; 
+		}
+
+		@Override
+		public int getIntHeader(String arg0) {
+			throw new RuntimeException("Method not implemented");
+		}
+
+		@Override
+		public String getMethod() {
+			throw new RuntimeException("Method not implemented");
+		}
+
+		@Override
+		public String getPathInfo() {
+			throw new RuntimeException("Method not implemented");
+		}
+
+		@Override
+		public String getPathTranslated() {
+			throw new RuntimeException("Method not implemented");
+		}
+
+		@Override
+		public String getQueryString() {
+			throw new RuntimeException("Method not implemented");
+		}
+
+		@Override
+		public String getRemoteUser() {
+			throw new RuntimeException("Method not implemented");
+		}
+
+		@Override
+		public String getRequestURI() {
+			throw new RuntimeException("Method not implemented");
+		}
+
+		@Override
+		public StringBuffer getRequestURL() {
+			throw new RuntimeException("Method not implemented");
+		}
+
+		@Override
+		public String getRequestedSessionId() {
+			throw new RuntimeException("Method not implemented");
+		}
+
+		@Override
+		public String getServletPath() {
+			throw new RuntimeException("Method not implemented");
+		}
+
+		@Override
+		public HttpSession getSession() {
+			throw new RuntimeException("Method not implemented");
+		}
+
+		@Override
+		public HttpSession getSession(boolean arg0) {
+			throw new RuntimeException("Method not implemented");
+		}
+
+		@Override
+		public Principal getUserPrincipal() {
+			throw new RuntimeException("Method not implemented");
+		}
+
+		@Override
+		public boolean isRequestedSessionIdFromCookie() {
+			throw new RuntimeException("Method not implemented");
+		}
+
+		@Override
+		public boolean isRequestedSessionIdFromURL() {
+			throw new RuntimeException("Method not implemented");
+		}
+
+		@Override
+		public boolean isRequestedSessionIdFromUrl() {
+			throw new RuntimeException("Method not implemented");
+		}
+
+		@Override
+		public boolean isRequestedSessionIdValid() {
+			throw new RuntimeException("Method not implemented");
+		}
+
+		@Override
+		public boolean isUserInRole(String arg0) {
+			throw new RuntimeException("Method not implemented");
+		}
+
+		@Override
+		public Object getAttribute(String arg0) {
+			throw new RuntimeException("Method not implemented");
+		}
+
+		@Override
+		public Enumeration getAttributeNames() {
+			throw new RuntimeException("Method not implemented");
+		}
+
+		@Override
+		public String getCharacterEncoding() {
+			throw new RuntimeException("Method not implemented");
+		}
+
+		@Override
+		public int getContentLength() {
+			throw new RuntimeException("Method not implemented");
+		}
+
+		@Override
+		public String getContentType() {
+			throw new RuntimeException("Method not implemented");
+		}
+
+		@Override
+		public ServletInputStream getInputStream() throws IOException {
+			throw new RuntimeException("Method not implemented");
+		}
+
+		@Override
+		public String getLocalAddr() {
+			throw new RuntimeException("Method not implemented");
+		}
+
+		@Override
+		public String getLocalName() {
+			throw new RuntimeException("Method not implemented");
+		}
+
+		@Override
+		public int getLocalPort() {
+			throw new RuntimeException("Method not implemented");
+		}
+
+		@Override
+		public Locale getLocale() {
+			throw new RuntimeException("Method not implemented");
+		}
+
+		@Override
+		public Enumeration getLocales() {
+			throw new RuntimeException("Method not implemented");
+		}
+
+		@Override
+		public String getParameter(String arg0) {
+			throw new RuntimeException("Method not implemented");
+		}
+
+		@Override
+		public Map getParameterMap() {
+			throw new RuntimeException("Method not implemented");
+		}
+
+		@Override
+		public Enumeration getParameterNames() {
+			throw new RuntimeException("Method not implemented");
+		}
+
+		@Override
+		public String[] getParameterValues(String arg0) {
+			throw new RuntimeException("Method not implemented");
+		}
+
+		@Override
+		public String getProtocol() {
+			throw new RuntimeException("Method not implemented");
+		}
+
+		@Override
+		public BufferedReader getReader() throws IOException {
+			throw new RuntimeException("Method not implemented");
+		}
+
+		@Override
+		public String getRealPath(String arg0) {
+			throw new RuntimeException("Method not implemented");
+		}
+
+		@Override
+		public String getRemoteAddr() {
+			throw new RuntimeException("Method not implemented");
+		}
+
+		@Override
+		public String getRemoteHost() {
+			throw new RuntimeException("Method not implemented");
+		}
+
+		@Override
+		public int getRemotePort() {
+			throw new RuntimeException("Method not implemented");
+		}
+
+		@Override
+		public RequestDispatcher getRequestDispatcher(String arg0) {
+			throw new RuntimeException("Method not implemented");
+		}
+
+		@Override
+		public String getScheme() {
+			throw new RuntimeException("Method not implemented");
+		}
+
+		@Override
+		public String getServerName() {
+			throw new RuntimeException("Method not implemented");
+		}
+
+		@Override
+		public int getServerPort() {
+			throw new RuntimeException("Method not implemented");
+		}
+
+		@Override
+		public boolean isSecure() {
+			throw new RuntimeException("Method not implemented");
+		}
+
+		@Override
+		public void removeAttribute(String arg0) {
+			throw new RuntimeException("Method not implemented");
+		}
+
+		@Override
+		public void setAttribute(String arg0, Object arg1) {
+			throw new RuntimeException("Method not implemented");
+		}
+
+		@Override
+		public void setCharacterEncoding(String arg0)
+				throws UnsupportedEncodingException {
+			throw new RuntimeException("Method not implemented");
+		}
+
+	}
+
+}


### PR DESCRIPTION
This is probably not entirely compliant with the HTTP standard, but it should be a step in that direction. If you don't like my implementation it would be nice if you could make the original implementation comply with the tests I've written. Returning 403 on static files saves the server a lot of bandwidth when people hit refresh continuously.

Personally i think the change is so small that it should be feasible to add it to a bugfix release on the 1.1 branch if you plan to make any before releasing 1.2.
