### PR TITLE
Lighthouse 663 patch

### DIFF
--- a/framework/src/play/server/PlayHandler.java
+++ b/framework/src/play/server/PlayHandler.java
@@ -483,10 +483,12 @@ public class PlayHandler extends SimpleChannelUpstreamHandler {
             uri = uri.substring(uri.indexOf("/", 9));
         }
 
-        String path = URLDecoder.decode(uri, "UTF-8");
+        String path;
         if (index != -1) {
             path = URLDecoder.decode(uri.substring(0, index), "UTF-8");
             querystring = uri.substring(index + 1);
+        } else { 
+            path = URLDecoder.decode(uri, "UTF-8");
         }
 
         final Request request = new Request();


### PR DESCRIPTION
Simple fix for passing through query string values with encoded unicode characters containing %uXXXX. 

http://play.lighthouseapp.com/projects/57987-play-framework/tickets/663-urldecoder-for-request-path-fails-when-parsing-request
