### PR TITLE
Settingsparser getproperty

### DIFF
--- a/framework/pym/play/commands/deps.py
+++ b/framework/pym/play/commands/deps.py
@@ -34,6 +34,9 @@ def execute(**kargs):
     if args.count('--jpda'):
         print "~ Waiting for JPDA client to continue"
         add_options.extend(['-Xdebug', '-Xrunjdwp:transport=dt_socket,address=8888,server=y,suspend=y'])
+    for arg in args:
+        if arg.startswith("-D"):
+            add_options.append(arg)
 
     java_cmd = [app.java_path()] + add_options + ['-classpath', app.cp_args(), 'play.deps.DependenciesManager']
 


### PR DESCRIPTION
Allow the use of ${something} in settings of the dependencies.yml
## just like :

repositories:

```
- playCore:
    type:       local
    descriptor: "${play.path}/framework/dependencies.yml"
    artifact:   "${play.path}/framework/play-[revision].jar"
    contains:
        - play -> play
```

---

But no more hard-coded.
The only requirement is to provided a java property (i.e : -Dsomething="an absolute path" )
