### PR TITLE
[#699] Fix to wrap source code/stack traces appearing in xUnit test output in CDATA sections

### DIFF
--- a/modules/testrunner/app/views/TestRunner/results-xunit.xml
+++ b/modules/testrunner/app/views/TestRunner/results-xunit.xml
@@ -6,27 +6,35 @@
     #{if !result.passed}
       #{if result.error?.startsWith("Failure")}
         <failure type="" message="${result.error}">
-          ${result.sourceInfos}
-          ${play.utils.Utils.open(result.sourceFile, result.sourceLine) ? ('<a href="' + play.utils.Utils.open(result.sourceFile, result.sourceLine) + '">').raw() : ''}
-              ${result.sourceCode} :
-          ${play.utils.Utils.open(result.sourceFile, result.sourceLine) ? '</a>'.raw() : ''}
+          <![CDATA[
+            ${result.sourceInfos}
+            ${play.utils.Utils.open(result.sourceFile, result.sourceLine) ? ('<a href="' + play.utils.Utils.open(result.sourceFile, result.sourceLine) + '">').raw() : ''}
+                ${result.sourceCode} :
+            ${play.utils.Utils.open(result.sourceFile, result.sourceLine) ? '</a>'.raw() : ''}
+          ]]>
         </failure>
         #{if result.trace}
           <system-err>
-            ${result.trace.raw()}
+            <![CDATA[
+              ${result.trace.raw()}
+            ]]>
           </system-err>  
         #{/if}}
       #{/if}
       #{else}
         <error type="" message="${result.error}">
-          ${result.sourceInfos}
-          ${play.utils.Utils.open(result.sourceFile, result.sourceLine) ? ('<a href="' + play.utils.Utils.open(result.sourceFile, result.sourceLine) + '">').raw() : ''}
-              ${result.sourceCode} :
-          ${play.utils.Utils.open(result.sourceFile, result.sourceLine) ? '</a>'.raw() : ''}
+          <![CDATA[
+            ${result.sourceInfos}
+            ${play.utils.Utils.open(result.sourceFile, result.sourceLine) ? ('<a href="' + play.utils.Utils.open(result.sourceFile, result.sourceLine) + '">').raw() : ''}
+                ${result.sourceCode} :
+            ${play.utils.Utils.open(result.sourceFile, result.sourceLine) ? '</a>'.raw() : ''}
+          ]]>
         </error>
         #{if result.trace}
           <system-err>
-            ${result.trace.raw()}
+            <![CDATA[
+              ${result.trace.raw()}
+            ]]>
           </system-err>  
         #{/if}}
       #{/else}


### PR DESCRIPTION
Hi,
This is a fix for an issue described in the group post linked below - I first encountered it using Jenkins to parse the new xUnit test reports, which it seems can be invalid XML under some circumstances. There haven't been any replies to my post, but I believe this is something which would affect any project using Play+Hudson or Jenkins at some point.

  http://groups.google.com/group/play-framework/browse_thread/thread/ca0d9919ff2c4537

This change makes (I believe) the simplest change possible to resolve the issue; simply wrapping raw stacktraces/source code in CDATA.

If you need anything else please let me know.
Many thanks
Richard

Prevents the xUnit output from becoming malformed XML when a test failure occurs and either:
  (a) source code snippet has strings/comments containing XML
  (b) when a stack trace contains an entry resembling an XML tag (e.g. <init>)
  (c) when an exception message in a stack trace contains XML
