### PR TITLE
[#621] Destroy the datasource when needed

### DIFF
--- a/framework/src/play/db/DB.java
+++ b/framework/src/play/db/DB.java
@@ -1,11 +1,13 @@
 package play.db;
 
+import java.lang.reflect.Method;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import javax.sql.DataSource;
 import play.db.jpa.JPA;
 import play.exceptions.DatabaseException;
+import play.Logger;
 
 /**
  * Database connection utilities.
@@ -16,6 +18,11 @@ public class DB {
      * The loaded datasource.
      */
     public static DataSource datasource = null;
+
+    /**
+     * The method used to destroy the datasource
+     */
+    public static String destroyMethod = "";
 
     /**
      * Close the connection opened for the current thread.
@@ -82,6 +89,24 @@ public class DB {
             return getConnection().createStatement().executeQuery(SQL);
         } catch (SQLException ex) {
             throw new DatabaseException(ex.getMessage(), ex);
+        }
+    }
+
+    /**
+     * Destroy the datasource
+     */
+    public static void destroy() {
+        try {
+            if (DB.datasource != null && DB.destroyMethod != null && !DB.destroyMethod.equals("")) {
+                Method close = DB.datasource.getClass().getMethod(DB.destroyMethod, new Class[] {});
+                if (close != null) {
+                    close.invoke(DB.datasource, new Object[] {});
+                    DB.datasource = null;
+                    Logger.info("Datasource destroyed");
+                }
+            }
+        } catch (Throwable t) {
+             Logger.error("Couldn't destroy the datasource", t);
         }
     }
 }

--- a/resources/application-skel/conf/application.conf
+++ b/resources/application-skel/conf/application.conf
@@ -95,6 +95,11 @@ date.format=yyyy-MM-dd
 #
 # If you want to reuse an existing Datasource from your application server, use:
 # db=java:/comp/env/jdbc/myDatasource
+#
+# When using an existing Datasource, it's sometimes needed to destroy it when
+# the application is stopped. Depending on the datasource, you can define a
+# generic "destroy" method :
+# db.destroyMethod=close
 
 # JPA Configuration (Hibernate)
 # ~~~~~


### PR DESCRIPTION
In PROD mode, the datasource should be destroyed on application stop.
In DEV mode, it should be destroyed before a new one is created.

Also, for JNDI datasources, a new property "db.destroyMethod" is added
to let decide if the application should destroy the datasource or not,
and how (By default, the datasource is not destroyed).
