### PR TITLE
[#687] Shutdown the CacheManager on application stop in PROD mode

### DIFF
--- a/framework/src/play/cache/EhCacheImpl.java
+++ b/framework/src/play/cache/EhCacheImpl.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import net.sf.ehcache.CacheManager;
 import net.sf.ehcache.Element;
 import play.Logger;
+import play.Play;
 
 /**
  * EhCache implementation.
@@ -145,5 +146,8 @@ public class EhCacheImpl implements CacheImpl {
 
     public void stop() {
         cache.removeAll();
+        if (Play.mode.isProd()) {
+            cacheManager.shutdown();
+        }
     }
 }


### PR DESCRIPTION
EHCache : in a servlet container, we should call CacheManager.shutdown() to stop its Thread, which prevents the classloader from being garbaged.
