### PR TITLE
[#718] Fixes broken proxy ssl header parsing

### DIFF
--- a/framework/src/play/mvc/Http.java
+++ b/framework/src/play/mvc/Http.java
@@ -354,22 +354,39 @@ public class Http {
 
         protected void parseXForwarded() {
 
-            if (Play.configuration.containsKey("XForwardedSupport") && headers.get("X-Forwarded-For") != null) {
+            if (Play.configuration.containsKey("XForwardedSupport") && headers.get("x-forwarded-for") != null) {
                 if (!Arrays.asList(Play.configuration.getProperty("XForwardedSupport", "127.0.0.1").split(",")).contains(remoteAddress)) {
                     throw new RuntimeException("This proxy request is not authorized: " + remoteAddress);
                 } else {
-                    secure = ("https".equals(Play.configuration.get("XForwardedProto")) || "https".equals(headers.get("X-Forwarded-Proto").value()) || "on".equals(headers.get("X-Forwarded-Ssl").value()));
+                    secure = isRequestSecure();
                     if (Play.configuration.containsKey("XForwardedHost")) {
                         host = (String) Play.configuration.get("XForwardedHost");
-                    } else if (headers.get("X-Forwarded-Host") != null) {
-                        host = headers.get("X-Forwarded-Host").value();
+                    } else if (headers.get("x-forwarded-host") != null) {
+                        host = headers.get("x-forwarded-host").value();
                     }
-                    if (headers.get("X-Forwarded-For") != null) {
-                        remoteAddress = headers.get("X-Forwarded-For").value();
+                    if (headers.get("x-forwarded-for") != null) {
+                        remoteAddress = headers.get("x-forwarded-for").value();
                     }
                 }
             }
+        }
+        
+        private boolean isRequestSecure() {
+            if ("https".equals(Play.configuration.get("XForwardedProto"))) {
+                return true;
+            }
+        	
+            Header xForwardedProtoHeader = headers.get("x-forwarded-proto");
+            if (xForwardedProtoHeader != null && "https".equals(xForwardedProtoHeader.value())) {
+                return true;
+            }
 
+            Header xForwardedSslHeader = headers.get("x-forwarded-ssl");
+            if (xForwardedSslHeader != null && "on".equals(xForwardedSslHeader.value())) {
+                return true;
+            }
+        	
+            return false;
         }
 
         /**


### PR DESCRIPTION
A fix proposal for the bug report I sent an hour ago.

This fix enables http proxying from SSL webserver to non-SSL play application, while still setting request.secure = true
