### PR TITLE
[#744] fixed proper escaping of content in surefire reports

### DIFF
--- a/modules/testrunner/app/views/TestRunner/results-xunit.xml
+++ b/modules/testrunner/app/views/TestRunner/results-xunit.xml
@@ -5,28 +5,32 @@
   <testcase classname="${test.cut(".class")}" name="${result.name}" time="${result.time/1000}">
     #{if !result.passed}
       #{if result.error?.startsWith("Failure")}
-        <failure type="" message="${result.error}">
+        <failure type="" message="${result.error.escapeXml().raw()}">
+        <![CDATA[
           ${result.sourceInfos}
           ${play.utils.Utils.open(result.sourceFile, result.sourceLine) ? ('<a href="' + play.utils.Utils.open(result.sourceFile, result.sourceLine) + '">').raw() : ''}
               ${result.sourceCode} :
           ${play.utils.Utils.open(result.sourceFile, result.sourceLine) ? '</a>'.raw() : ''}
+        ]]>
         </failure>
         #{if result.trace}
           <system-err>
-            ${result.trace.raw()}
+            ${result.trace.escapeXml().raw()}
           </system-err>  
         #{/if}}
       #{/if}
       #{else}
-        <error type="" message="${result.error}">
+        <error type="" message="${result.error.escapeXml()}">
+        <![CDATA[
           ${result.sourceInfos}
           ${play.utils.Utils.open(result.sourceFile, result.sourceLine) ? ('<a href="' + play.utils.Utils.open(result.sourceFile, result.sourceLine) + '">').raw() : ''}
               ${result.sourceCode} :
           ${play.utils.Utils.open(result.sourceFile, result.sourceLine) ? '</a>'.raw() : ''}
+        ]]>
         </error>
         #{if result.trace}
           <system-err>
-            ${result.trace.raw()}
+            ${result.trace.escapeXml().raw()}
           </system-err>  
         #{/if}}
       #{/else}


### PR DESCRIPTION
Hi There,

This fixes the xml escaping issue as described in #744 . I couldn't find an exact reference to the xunit 'standard', so I'm not completely sure - but at lease the error itself and the stacktraces are now proper xml escaped.
