### PR TITLE
Additional arguments to 'play javadoc' are now passed to the javadoc exec

### DIFF
--- a/documentation/commands/cmd-javadoc.txt
+++ b/documentation/commands/cmd-javadoc.txt
@@ -8,11 +8,12 @@
 ~ 
 ~ Synopsis:
 ~ ~~~~~~~~~
-~ play javadoc [app_path]
+~ play javadoc [app_path] [additional_args]
 ~
 ~ Description:
 ~ ~~~~~~~~~~~~
 ~ Generate the Javadoc for your project, not including Play classes. Resulting
 ~ html file will be in a javadoc folder in your application directory. The
-~ commands' logs are logs/javadoc.log and logs/javadoc.err.
+~ commands' logs are logs/javadoc.log and logs/javadoc.err. Any additonal
+~ arguments provided are passed to the javadoc command.
 ~

--- a/framework/pym/play/commands/javadoc.py
+++ b/framework/pym/play/commands/javadoc.py
@@ -37,7 +37,7 @@ def execute(**kargs):
     serr = open(os.path.join(app.log_path(), 'javadoc.err'), 'w')
     if (os.path.isdir(outdir)):
         shutil.rmtree(outdir)
-    javadoc_cmd = [javadoc_path, '-classpath', app.cp_args(), '-d', outdir] + fileList
+    javadoc_cmd = [javadoc_path, '-classpath', app.cp_args(), '-d', outdir] + args + fileList
     print "Generating Javadoc in " + outdir + "..."
     subprocess.call(javadoc_cmd, env=os.environ, stdout=sout, stderr=serr)
     print "Done! You can open " + os.path.join(outdir, 'overview-tree.html') + " in your browser."


### PR DESCRIPTION
Additional arguments to 'play javadoc' are now passed to the javadoc executable.

This let's you do something like the following if you want to pimp your javadocs:

play javadocs -overview overview.html

Previously, this was impossible.
