### PR TITLE
[#63] fix regression with eclipsify on modules

### DIFF
--- a/framework/pym/play/commands/eclipse.py
+++ b/framework/pym/play/commands/eclipse.py
@@ -15,8 +15,9 @@ def execute(**kargs):
     args = kargs.get("args")
     play_env = kargs.get("env")
 
+    # check to see if application.conf exists... do not use app.check() because
+    # that will cause eclipsify to fail if run on a module
     is_application = os.path.exists(os.path.join(app.path, 'conf', 'application.conf'))
-    app.check()
     if is_application:
         app.check_jpda()
     modules = app.modules()


### PR DESCRIPTION
this should be reopened. eclipsify was broken for modules. the call to app.check() asserts that some files exist that would only exist for applications.
