### PR TITLE
[#709] play.mvc.Router.routes ConcurrentModificationException fix

### DIFF
--- a/framework/src/play/server/ServletWrapper.java
+++ b/framework/src/play/server/ServletWrapper.java
@@ -58,7 +58,7 @@ public class ServletWrapper extends HttpServlet implements ServletContextListene
      */
     public static final String SERVLET_RES = "__SERVLET_RES";
 
-    private volatile boolean routerInitializedWithContext = false;
+    private static volatile boolean routerInitializedWithContext = false;
 
     public void contextInitialized(ServletContextEvent e) {
         String appDir = e.getServletContext().getRealPath("/WEB-INF/application");


### PR DESCRIPTION
Changed routerInitializedWithContext to static so that the multiple servlets will use a single initialization flag to avoid concurrentmodificationexception.
