### PR TITLE
[#754] fix: "play deps" command runs with a classpath containing only play framework libraries

### DIFF
--- a/framework/pym/play/application.py
+++ b/framework/pym/play/application.py
@@ -163,6 +163,20 @@ class PlayApplication:
 
         return classpath
 
+    def getFrameworkClasspath(self):
+        classpath = []
+
+        # The default
+        classpath.append(os.path.normpath(os.path.join(self.path, 'conf')))
+        classpath.append(os.path.normpath(os.path.join(self.play_env["basedir"], 'framework/play-%s.jar' % self.play_env['version'])))
+
+        # The framework
+        for jar in os.listdir(os.path.join(self.play_env["basedir"], 'framework/lib')):
+            if jar.endswith('.jar'):
+                classpath.append(os.path.normpath(os.path.join(self.play_env["basedir"], 'framework/lib/%s' % jar)))
+
+        return classpath
+
     def agent_path(self):
         return os.path.join(self.play_env["basedir"], 'framework/play-%s.jar' % self.play_env['version'])
 
@@ -172,6 +186,14 @@ class PlayApplication:
         if os.name == 'nt':
             cp_args = ';'.join(classpath)
         return cp_args
+
+    def fw_cp_args(self):
+        classpath = self.getFrameworkClasspath()
+        cp_args = ':'.join(classpath)
+        if os.name == 'nt':
+            cp_args = ';'.join(classpath)
+        return cp_args
+
 
     def java_path(self):
         if not os.environ.has_key('JAVA_HOME'):

--- a/framework/pym/play/commands/deps.py
+++ b/framework/pym/play/commands/deps.py
@@ -37,7 +37,7 @@ def execute(**kargs):
         if arg.startswith("-D"):
             add_options.append(arg)
 
-    java_cmd = [app.java_path()] + add_options + ['-classpath', app.cp_args(), 'play.deps.DependenciesManager']
+    java_cmd = [app.java_path()] + add_options + ['-classpath', app.fw_cp_args(), 'play.deps.DependenciesManager']
 
     subprocess.call(java_cmd, env=os.environ)
 


### PR DESCRIPTION
 "play deps" command runs with a classpath containing only play framework libraries preventing class collisions : 2 new functions in application.py getFrameworkClasspath() and fw_cp_args().

Regards
Pascal
