### PR TITLE
[#779] Fix python fatal error with module dependency and command "play build-module"

### DIFF
--- a/framework/pym/play/commands/modulesrepo.py
+++ b/framework/pym/play/commands/modulesrepo.py
@@ -273,9 +273,10 @@ def build(app, args, env):
         versionCandidate = deps["self"].split(" ").pop()
         version = versionCandidate
         for dep in deps["require"]:
-            splitted = dep.split(" ")
-            if len(splitted) == 2 and splitted[0] == "play":
-                fwkMatch = splitted[1]
+            if isinstance(dep, basestring):
+                splitted = dep.split(" ")
+                if len(splitted) == 2 and splitted[0] == "play":
+                    fwkMatch = splitted[1]
         f.close
 
     if version is None:


### PR DESCRIPTION
Fix python fatal error when declaring a require dependency in a module such as "- organization -> artifact version" and launching command "play build-module"
