### PR TITLE
[#798] session is not lost anymore when a maxAge is set.

### DIFF
--- a/framework/src/play/mvc/Scope.java
+++ b/framework/src/play/mvc/Scope.java
@@ -194,6 +194,11 @@ public class Scope {
                         }
                         session.put(TS_KEY, System.currentTimeMillis() + (Time.parseDuration(COOKIE_EXPIRE) * 1000));
                     }
+                } else {
+                    if (COOKIE_EXPIRE != null) {
+                        // New/empty session needs a timstamp, too
+                        session.put(TS_KEY, System.currentTimeMillis() + (Time.parseDuration(COOKIE_EXPIRE) * 1000));
+                    }
                 }
                 return session;
             } catch (Exception e) {

--- a/samples-and-tests/just-test-cases/app/controllers/SessionCookie.java
+++ b/samples-and-tests/just-test-cases/app/controllers/SessionCookie.java
@@ -1,0 +1,46 @@
+package controllers;
+
+import play.*;
+import play.mvc.*;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.*;
+
+import models.*;
+
+public class SessionCookie extends Controller {
+
+	public static void index() {
+        render();
+    }
+
+	public static void put() {
+        session.put("msg", "Yop");
+        render("@index");
+    }
+
+	public static void remove() {
+        session.remove("msg");
+        render("@index");
+    }
+
+	public static void changeMaxAgeConstant(String maxAge) {
+    	try {
+	    	/*
+	    	 * Set the final static value Scope.COOKIE_EXPIRE using reflection.
+	    	 */
+	        Field field = Scope.class.getField("COOKIE_EXPIRE");
+	        field.setAccessible(true);
+	        Field modifiersField = Field.class.getDeclaredField("modifiers");
+	        modifiersField.setAccessible(true);
+	        modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+
+	        // Set the new value
+	        field.set(null, maxAge);
+    	} catch(Exception e) {
+    		throw new RuntimeException(e);
+    	}
+    }
+}
+

--- a/samples-and-tests/just-test-cases/app/views/SessionCookie/index.html
+++ b/samples-and-tests/just-test-cases/app/views/SessionCookie/index.html
@@ -1,0 +1,1 @@
+${session['msg']}

--- a/samples-and-tests/just-test-cases/test/SessionCookieTest.java
+++ b/samples-and-tests/just-test-cases/test/SessionCookieTest.java
@@ -1,0 +1,52 @@
+import org.junit.*;
+
+import java.lang.reflect.*;
+import play.*;
+import play.test.*;
+import play.mvc.*;
+import play.mvc.Http.*;
+import models.*;
+import controllers.*;
+
+public class SessionCookieTest extends FunctionalTest {
+
+	@Test
+    public void testSessionCookieMaxAge() throws InterruptedException {
+    	Response response;
+    	clearCookies();
+
+    	changeMaxAgeConstant("1s");
+    	
+    	response = GET("/sessioncookie/put");
+    	assertTrue(response.out.toString().contains("Yop"));
+
+    	response = GET("/sessioncookie/index");
+    	assertTrue("expected session data", response.out.toString().contains("Yop"));
+
+    	Thread.sleep(1000);
+
+    	response = GET("/sessioncookie/index");
+    	assertFalse("session cookie should be expired", response.out.toString().contains("Yop"));
+
+    	// Restore configuration
+    	changeMaxAgeConstant(Play.configuration.getProperty("application.session.maxAge"));
+    }
+
+	private static void changeMaxAgeConstant(String maxAge) {
+    	try {
+	    	/*
+	    	 * Set the final static value Scope.COOKIE_EXPIRE using reflection.
+	    	 */
+	        Field field = Scope.class.getField("COOKIE_EXPIRE");
+	        field.setAccessible(true);
+	        Field modifiersField = Field.class.getDeclaredField("modifiers");
+	        modifiersField.setAccessible(true);
+	        modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+
+	        // Set the new value
+	        field.set(null, maxAge);
+    	} catch(Exception e) {
+    		fail(e.getMessage());
+    	}
+    }
+}


### PR DESCRIPTION
Fixed constant session-loss when 'application.session.maxAge' is set.

Cause:
- check the timestamp
- not setting a timestamp for new/empty sessions

The use of maxAge was not tested before. Added a FunctionalTest.
