### PR TITLE
Fix for http://play.lighthouseapp.com/projects/57987/tickets/569-setting-

### DIFF
--- a/framework/src/play/server/PlayHandler.java
+++ b/framework/src/play/server/PlayHandler.java
@@ -340,7 +340,7 @@ public class PlayHandler extends SimpleChannelUpstreamHandler {
             nettyResponse.addHeader(SET_COOKIE, encoder.encode());
         }
 
-        if (!response.headers.containsKey(CACHE_CONTROL)) {
+        if (!response.headers.containsKey(CACHE_CONTROL) && !response.headers.containsKey(EXPIRES)) {
             nettyResponse.setHeader(CACHE_CONTROL, "no-cache");
         }
 


### PR DESCRIPTION
Fix for http://play.lighthouseapp.com/projects/57987/tickets/569-setting-an-expires-header-should-cause-play-to-not-add-cache-control-no-cache#ticket-569-1
