### PR TITLE
[#807] Read default ivy config

### DIFF
--- a/framework/src/play/deps/DependenciesManager.java
+++ b/framework/src/play/deps/DependenciesManager.java
@@ -292,7 +292,7 @@ public class DependenciesManager {
 
         Ivy ivy = Ivy.newInstance(ivySettings);
 
-        // Default ivy config
+        // Default ivy config see: http://play.lighthouseapp.com/projects/57987-play-framework/tickets/807
         File ivyDefaultSettings = new File(userHome, ".ivy2/ivysettings.xml");
         if(ivyDefaultSettings.exists()) {
             ivy.configure(ivyDefaultSettings);


### PR DESCRIPTION
Hi, did a simple test to get ivy to read the default .ivy2/ivysettings.xml file.
It's a good thing because you can for example configure ivy to use basic auth when fetching maven dependencies witch it the case if you hav an internal maven nexus repo. There are many things you can configure see: http://ant.apache.org/ivy/history/2.1.0/settings.html

I haven't made the path configurable through application.conf (or maybe dependencies.yml) but that would be a nice thing. If you point me i the right direction i would gladly help you with that.

Best Regards Adam  
