### PR TITLE
[#809] Fix module commands loading

### DIFF
--- a/framework/pym/play/cmdloader.py
+++ b/framework/pym/play/cmdloader.py
@@ -35,20 +35,21 @@ class CommandLoader:
                 self._load_cmd_from(mod)
             except Exception, e:
                 print '~'
-                print '~ !! Error whileloading %s: %s' % (commands, e)
+                print '~ !! Error while loading %s: %s' % (commands, e)
                 print '~'
                 pass # No command to load in this module
 
     def _load_cmd_from(self, mod):
-        try:
+        if 'COMMANDS' in dir(mod):
             for name in mod.COMMANDS:
-                if name in self.commands:
-                    print "~ Warning: conflict on command " + name
-                self.commands[name] = mod
-            if 'MODULE' in dir(mod):
-                self.modules[mod.MODULE] = mod
-        except Exception:
-            warnings.warn("Warning: error loading command " + name)
+                try:
+                    if name in self.commands:
+                        warnings.warn("Warning: conflict on command " + name)
+                    self.commands[name] = mod
+                except Exception:
+                    warnings.warn("Warning: error loading command " + name)
+        if 'MODULE' in dir(mod):
+            self.modules[mod.MODULE] = mod
 
 def load_python_module(name, location):
     mod_desc = imp.find_module(name, [location])


### PR DESCRIPTION
This commit fixes [#809](http://play.lighthouseapp.com/projects/57987-play-framework/tickets/809-error-when-play-command-loader-finds-an-empty-commandspy-file)
