### PR TITLE
[#758] Fix ignoring recordCaller with SslPlayHandler

### DIFF
--- a/framework/src/play/Logger.java
+++ b/framework/src/play/Logger.java
@@ -553,10 +553,17 @@ public class Logger {
                 errorOut.println(playException.getErrorDescription().replaceAll("</?\\w+/?>", "").replace("\n", " "));
             }
 
-            if (forceJuli || log4j == null) {
-                juli.log(toJuliLevel(level.toString()), sw.toString(), e);
-            } else {
-                log4j.log(level, sw.toString(), e);
+            try {
+              if (forceJuli || log4j == null) {
+                  juli.log(toJuliLevel(level.toString()), sw.toString(), e);
+              } else if (recordCaller) {
+                org.apache.log4j.Logger.getLogger(getCallerClassName(5)).log(level, sw.toString(), null);
+              } else {
+                log4j.log(level, sw.toString(), null);
+              }
+            }
+            catch (Exception e1) {
+              log4j.error("Oops. Error in Logger !", e1);
             }
             return true;
         }
@@ -600,6 +607,13 @@ public class Logger {
      */
     static String getCallerClassName() {
         final int level = 4;
+        return getCallerClassName(level);
+    }
+    
+    /**
+     * @return the className of the class actually logging the message
+     */
+    static String getCallerClassName(final int level) {
         CallInfo ci = getCallerInformations(level);
         return ci.className;
     }


### PR DESCRIPTION
With Play 1.2 release my product started printing pointless ClosedChannelExceptions because log4j conf did not apply due to the original caller being lost. Here is a patch that fixes that.

Let me know if something is wrong git wise, just started using it.
