### PR TITLE
content-type should be Content-Type? 

### DIFF
--- a/framework/src/play/libs/WS.java
+++ b/framework/src/play/libs/WS.java
@@ -557,7 +557,7 @@ public class WS extends PlayPlugin {
          * @return the content type of the http response
          */
         public String getContentType() {
-            return getHeader("content-type");
+            return getHeader("Content-Type");
         }
 
         public String getEncoding() {


### PR DESCRIPTION
content-type should be Content-Type? I've NullPointerException when using OpenId when try to get content-type.
