### PR TITLE
[#775] Ensure session cookies are kept across FunctionalTest requests

### DIFF
--- a/framework/src/play/mvc/Scope.java
+++ b/framework/src/play/mvc/Scope.java
@@ -198,7 +198,13 @@ public class Scope {
                         // Just restored. Nothing changed. No cookie-expire.
                         session.changed = false;
                     }
+                } else {
+                    // no previous cookie to restore; but we may have to set the timestamp in the new cookie
+                    if (COOKIE_EXPIRE != null) {
+                        session.put(TS_KEY, System.currentTimeMillis() + (Time.parseDuration(COOKIE_EXPIRE) * 1000));
+                    }
                 }
+
                 return session;
             } catch (Exception e) {
                 throw new UnexpectedException("Corrupted HTTP session from " + Http.Request.current().remoteAddress, e);

--- a/framework/src/play/test/FunctionalTest.java
+++ b/framework/src/play/test/FunctionalTest.java
@@ -280,7 +280,9 @@ public abstract class FunctionalTest extends BaseTest {
                 savedCookies = new HashMap<String, Http.Cookie>();
             }
             for(Map.Entry<String,Http.Cookie> e : response.cookies.entrySet()) {
-                if(e.getValue().maxAge != null && e.getValue().maxAge > 0) {
+                // If Max-Age is unset, browsers discard on exit; if
+                // 0, they discard immediately.
+                if(e.getValue().maxAge == null || e.getValue().maxAge > 0) {
                     savedCookies.put(e.getKey(), e.getValue());
                 }
             }


### PR DESCRIPTION
This is a revision of https://github.com/playframework/play/pull/189 for comments on
http://play.lighthouseapp.com/projects/57987-play-framework/tickets/775

Because it's rebased as requested, I had to create a new branch and pull request. (or at least, I couldn't figure out how to do it otherwise.)

The change to Scope.java is modified slightly because master had changed.

Thanks
