### PR TITLE
[#810] configurable safe message using 'application.messages.safe'

### DIFF
--- a/framework/src/play/templates/GroovyTemplate.java
+++ b/framework/src/play/templates/GroovyTemplate.java
@@ -1,7 +1,5 @@
 package play.templates;
 
-import com.jamonapi.Monitor;
-import com.jamonapi.MonitorFactory;
 import groovy.lang.Binding;
 import groovy.lang.Closure;
 import groovy.lang.GroovyClassLoader;
@@ -9,13 +7,20 @@ import groovy.lang.GroovyObjectSupport;
 import groovy.lang.GroovyShell;
 import groovy.lang.MissingPropertyException;
 import groovy.lang.Script;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
 
 import org.codehaus.groovy.control.CompilationUnit;
 import org.codehaus.groovy.control.CompilationUnit.GroovyClassOperation;
@@ -27,6 +32,7 @@ import org.codehaus.groovy.control.messages.SyntaxErrorMessage;
 import org.codehaus.groovy.runtime.InvokerHelper;
 import org.codehaus.groovy.syntax.SyntaxException;
 import org.codehaus.groovy.tools.GroovyClass;
+
 import play.Logger;
 import play.Play;
 import play.Play.Mode;
@@ -45,12 +51,15 @@ import play.exceptions.UnexpectedException;
 import play.i18n.Lang;
 import play.i18n.Messages;
 import play.libs.Codec;
-import play.mvc.Http;
-import play.utils.Java;
 import play.mvc.ActionInvoker;
+import play.mvc.Http;
 import play.mvc.Http.Request;
 import play.mvc.Router;
 import play.utils.HTML;
+import play.utils.Java;
+
+import com.jamonapi.Monitor;
+import com.jamonapi.MonitorFactory;
 
 /**
  * A template
@@ -399,11 +408,18 @@ public class GroovyTemplate extends BaseTemplate {
         }
 
         public String __getMessage(Object[] val) {
+        	String message = null;
             if (val.length == 1) {
-                return Messages.get(val[0]);
+            	message = Messages.get(val[0]);
             } else {
-                return Messages.get(val[0], Arrays.copyOfRange(val,1,val.length));
+            	message = Messages.get(val[0], Arrays.copyOfRange(val,1,val.length));
             }
+            
+            if(Play.configuration.getProperty("application.messages.safe", "false").equals("true")) {
+            	message = __safeFaster(message);
+            }
+            
+            return message;
         }
 
         public String __reverseWithCheck_absolute_true(String action) {


### PR DESCRIPTION
I could not find the default configuration file that comes with Play!

The following should be added to the application.conf

```
# i18n
# ~~~~~
# Define if localization messages inserted by &{...} will be HTML escaped. (default false)
# NOTE! If this property is set to false you must manually HTML escape parameters 
# injected into a message like &{..., param1, param2} otherwise your application
# might be sensitive to the code injection exploit.
# application.messages.safe=true
```
