### PR TITLE
[#760] Fixed NPE in Validation.

### DIFF
--- a/framework/src/play/data/validation/Validation.java
+++ b/framework/src/play/data/validation/Validation.java
@@ -3,6 +3,7 @@ package play.data.validation;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -35,7 +36,11 @@ public class Validation {
      */
     @SuppressWarnings({"serial", "unused"})
     public static List<Error> errors() {
-        return new ArrayList<Error>(current.get().errors) {
+        Validation validation = current.get();
+        if (validation == null)
+            return Collections.emptyList();
+        
+        return new ArrayList<Error>(validation.errors) {
 
             public Error forKey(String key) {
                 return Validation.error(key);
@@ -74,7 +79,8 @@ public class Validation {
      * @return True if the current request has errors
      */
     public static boolean hasErrors() {
-        return current.get().errors.size() > 0;
+        Validation validation = current.get();
+        return validation != null && validation.errors.size() > 0;
     }
 
     /**
@@ -82,7 +88,11 @@ public class Validation {
      * @return First error related to this field
      */
     public static Error error(String field) {
-        for (Error error : current.get().errors) {
+        Validation validation = current.get();
+        if (validation == null)
+            return null;
+          
+        for (Error error : validation.errors) {
             if (error.key!=null && error.key.equals(field)) {
                 return error;
             }
@@ -95,8 +105,12 @@ public class Validation {
      * @return All errors related to this field
      */
     public static List<Error> errors(String field) {
+        Validation validation = current.get();
+        if (validation == null)
+            return Collections.emptyList();
+      
         List<Error> errors = new ArrayList<Error>();
-        for (Error error : current.get().errors) {
+        for (Error error : validation.errors) {
             if (error.key!=null && error.key.equals(field)) {
                 errors.add(error);
             }


### PR DESCRIPTION
Fixes the Validation usage outside a request, e.g. error page template extending main.html with messages tag (called inside play.server.PlayHandler.serve404())

In addition PlayHandler.getBindingForErrors could also get rid of the catch block.
