### PR TITLE
Drop revision number from sematic modules names for play-1.2.x

### DIFF
--- a/framework/src/play/Play.java
+++ b/framework/src/play/Play.java
@@ -635,7 +635,11 @@ public class Play {
                     if (!modulePath.exists() || !modulePath.isDirectory()) {
                         Logger.error("Module %s will not be loaded because %s does not exist", modulePath.getName(), modulePath.getAbsolutePath());
                     } else {
-                        addModule(modulePath.getName(), modulePath);
+                        final String modulePathName = modulePath.getName();
+                        final String moduleName = modulePathName.contains("-") ?
+                                modulePathName.substring(0, modulePathName.lastIndexOf("-")) :
+                                modulePathName;
+                        addModule(moduleName, modulePath);
                     }
                 }
             }


### PR DESCRIPTION
Due to [add46bf763e4be9a6a66](https://github.com/playframework/play/commit/add46bf763e4be9a6a6669cf65549633fff68448#framework/src/play/Play.java) my [previous](https://github.com/playframework/play/pull/234) pull request my be hard to merge into 1.2.x, so I made this one.
