### PR TITLE
Use template(String) to find template when provided as an argument to render(Object...)

### DIFF
--- a/framework/src/play/mvc/Controller.java
+++ b/framework/src/play/mvc/Controller.java
@@ -685,7 +685,7 @@ public class Controller implements ControllerSupport {
     protected static void render(Object... args) {
         String templateName = null;
         if (args.length > 0 && args[0] instanceof String && LVEnhancerRuntime.getParamNames().mergeParamsAndVarargs()[0] == null) {
-            templateName = args[0].toString();
+            templateName = template(args[0].toString());
         } else {
             templateName = template();
         }


### PR DESCRIPTION
The `render(Object...)` method in `Controller` can take the path to a template as the first argument. This changes `render(Object...)` to accept a template specification on the same form as `template(String)`, e.g., making

```
render("viewSpec", args);
```

equivalent to

```
renderTemplate(template("viewSpec"), args);
```

This is symmetrical to `render(args)` being equivalent to `renderTemplate(template(), args)`.
