### PR TITLE
[#886] Fix validation problem with exclamation marks in URLs

### DIFF
--- a/framework/src/play/data/validation/URLCheck.java
+++ b/framework/src/play/data/validation/URLCheck.java
@@ -9,7 +9,8 @@ import net.sf.oval.context.OValContext;
 public class URLCheck extends AbstractAnnotationCheck<URL> {
 
     final static String mes = "validation.url";
-    static Pattern urlPattern = Pattern.compile("^(http|https|ftp)\\://[a-zA-Z0-9\\-\\.]+\\.[a-zA-Z]{2,3}(:[a-zA-Z0-9]*)?/?([a-zA-Z0-9\\-\\._\\?\\,\\'/\\\\\\+&amp;%\\$#\\=~])*$");
+    static Pattern urlPattern = Pattern.compile("^(http|https|ftp)\\://[a-zA-Z0-9\\-\\.]+\\.[a-z" +
+            "A-Z]{2,3}(:[a-zA-Z0-9]*)?/?([a-zA-Z0-9\\-\\._\\?\\,\\'/\\\\\\+&amp;%\\$#\\=~\\!])*$");
 
     @Override
     public void configure(URL url) {
@@ -22,5 +23,5 @@ public class URLCheck extends AbstractAnnotationCheck<URL> {
         }
         return urlPattern.matcher(value.toString()).matches();
     }
-   
+
 }


### PR DESCRIPTION
Update regular expression which validates URLs to allow exclamation marks. Should be fine according to RFC 1738.
