### PR TITLE
[#725] Give plugins a chance to serve replacements for non-existing files

### DIFF
--- a/framework/src/play/server/PlayHandler.java
+++ b/framework/src/play/server/PlayHandler.java
@@ -1251,4 +1251,3 @@ public class PlayHandler extends SimpleChannelUpstreamHandler {
         }
     }
 }
-


### PR DESCRIPTION
This patch will give PlayPlugin.serveStatic() to serve a replacement for non-existing files. Currently this method is called only if a file exists. All tests (running ant test) passed against this patch.
