### PR TITLE
[#904] Read play id from sytem properties in JUnitTestrunner

### DIFF
--- a/framework/src/play/test/PlayJUnitRunner.java
+++ b/framework/src/play/test/PlayJUnitRunner.java
@@ -26,7 +26,7 @@ public class PlayJUnitRunner extends Runner {
     public PlayJUnitRunner(Class testClass) throws ClassNotFoundException, InitializationError {
         synchronized (Play.class) {
             if (!Play.started) {
-                Play.init(new File("."), "test");
+                Play.init(new File("."), PlayJUnitRunner.getPlayId());
                 Play.javaPath.add(Play.getVirtualFile("test"));
                 Play.start();
                 useCustomRunner = true;
@@ -36,6 +36,14 @@ public class PlayJUnitRunner extends Runner {
                 jUnit4 = new JUnit4(testClass);
             }
         }
+    }
+
+    private static String getPlayId() {
+        String playId = System.getProperty("play.id", "test");
+        if(! (playId.startsWith("test-") && playId.length() >= 6)) {
+            playId = "test";
+        }
+        return playId;
     }
 
     @Override
@@ -61,7 +69,7 @@ public class PlayJUnitRunner extends Runner {
                     public void evaluate() throws Throwable {
                         if (!Play.started) {
                             Play.forceProd = true;
-                            Play.init(new File("."), "test");
+                            Play.init(new File("."), PlayJUnitRunner.getPlayId());
                         }
 
                         try {


### PR DESCRIPTION
Read the play id from system property "play.id" when running test from the IDE.
Use default "test" when no id is specified or the specified id is not a test id.
