### PR TITLE
[#909] Changed JDPA port checking to use wildcard address

### DIFF
--- a/framework/pym/play/application.py
+++ b/framework/pym/play/application.py
@@ -200,7 +200,7 @@ class PlayApplication(object):
         self.jpda_port = self.readConf('jpda.port')
         try:
             s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            s.bind(('127.0.0.1', int(self.jpda_port)))
+            s.bind(('', int(self.jpda_port)))
             s.close()
         except socket.error, e:
             print 'JPDA port %s is already used. Will try to use any free port for debugging' % self.jpda_port


### PR DESCRIPTION
[#909] Changed JDPA port availability checking to look on the wildcard address. The other option would be to update the address field of the -Xrunjdwp parameter to use the host `127.0.0.1`.
