### PR TITLE
Added possiblity to disable evolutions in application.conf

### DIFF
--- a/documentation/manual/evolutions.textile
+++ b/documentation/manual/evolutions.textile
@@ -40,6 +40,9 @@ DROP TABLE User;
 
 As you see you have to delimitate the both *Ups* and *Downs* section by using comments in your SQL script.
 
+Evolutions are automatically activated if a database is configured in application.conf and evolution scripts are present. You can disable them by setting **evolutions.enabled=false** in application.conf.
+For example when tests set up their own database you can disable evolutions for the test environment.
+
 When **evolutions** are activated, Play will check your database schema state before each request in DEV mode, or before starting the application in PROD mode. In DEV mode, if your database schema is not up to date, an error page will suggest that you synchronise your database schema by running the appropriate SQL script.
 
 !images/evolutions!

--- a/framework/src/play/db/Evolutions.java
+++ b/framework/src/play/db/Evolutions.java
@@ -194,6 +194,9 @@ public class Evolutions extends PlayPlugin {
 
     @Override
     public void beforeInvocation() {
+        if(isDisabled()) {
+            return;
+        }
         try {
             checkEvolutionsState();
         } catch (InvalidDatabaseRevision e) {
@@ -208,7 +211,7 @@ public class Evolutions extends PlayPlugin {
 
     @Override
     public void onApplicationStart() {
-        if (Play.mode.isProd()) {
+        if (! isDisabled() && Play.mode.isProd()) {
             try {
                 checkEvolutionsState();
             } catch (InvalidDatabaseRevision e) {
@@ -220,6 +223,13 @@ public class Evolutions extends PlayPlugin {
         }
     }
 
+    /**
+     * Checks if evolutions is disabled in application.conf (property "evolutions.enabled")
+     */
+    private boolean isDisabled() {
+        return "false".equals(Play.configuration.getProperty("evolutions.enabled", "true"));
+    }
+    
     public static synchronized void resolve(int revision) {
         try {
             execute("update play_evolutions set state = 'applied' where state = 'applying_up' and id = " + revision);


### PR DESCRIPTION
Fix for ticket [#910]

evolutions.enabled=false can be used in application.conf to disable evolutions for a specific environment.
