### PR TITLE
[#905] WAR Packaging : Copy local modules defined by relative path '/..'

### DIFF
--- a/framework/pym/play/utils.py
+++ b/framework/pym/play/utils.py
@@ -202,7 +202,9 @@ def copy_directory(source, target, exclude = None):
         os.makedirs(target)
     for root, dirs, files in os.walk(source):
         path_from_source = root[len(source):]
-        if path_from_source.find('/.') > -1 or path_from_source.find('\\.') > -1:
+        # Ignore path containing '.' in path
+        # But keep those with relative path '..'
+        if re.search(r'/\.[^\.]|\\\.[^\.]', path_from_source):
             continue
         for file in files:
             if file.find('~') == 0 or file.startswith('.'):


### PR DESCRIPTION
While packaging WAR, copy local modules defined by relative path '/..'
But skip files when the path matches '/.' or '.' like '.svn' or '.idea'
