### PR TITLE
[#924] Fixes for internationalization and fallbacks when retrieving messages

### DIFF
--- a/framework/src/play/data/binding/types/LocaleBinder.java
+++ b/framework/src/play/data/binding/types/LocaleBinder.java
@@ -1,6 +1,7 @@
 package play.data.binding.types;
 
 import play.data.binding.TypeBinder;
+import play.i18n.Lang;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.Locale;
@@ -13,14 +14,7 @@ public class LocaleBinder implements TypeBinder<Locale> {
     public Locale bind(String name, Annotation[] annotations, String value, Class actualClass, Type genericType) {
         if( value == null )
             return null;
-        if (value.length() == 2) {
-            return new Locale(value);
-        }
-        if (value.length() == 5) {
-            return new Locale(value.substring(0, 1), value.substring(3, 4));
-        }
-        return Locale.getDefault();
+        
+        return Lang.getLocale(value);
     }
-    
 }
-

--- a/framework/src/play/i18n/Lang.java
+++ b/framework/src/play/i18n/Lang.java
@@ -137,21 +137,50 @@ public class Lang {
      * associated to the current Lang.
      */
     public static Locale getLocale() {
-        String lang = get();
+        return getLocaleOrDefault(get());
+    }
+
+    public static Locale getLocaleOrDefault(String lang) {
         Locale locale = getLocale(lang);
         if (locale != null) {
             return locale;
         }
-        return Locale.getDefault();
+        return Locale.getDefault(); 
     }
-
-     public static Locale getLocale(String lang) {
-        for (Locale locale : Locale.getAvailableLocales()) {
-            if (locale.getLanguage().equals(lang)) {
-                return locale;
+    
+    public static Locale getLocale(String lang) {
+        if(lang == null) {
+            return null;
+        }
+        
+        //Only language (eg. fr)
+        if (lang.length() == 2) {
+            lang = lang.toLowerCase();
+            for (Locale locale : Locale.getAvailableLocales()) {
+                if(locale.getLanguage().equals(lang) && 
+                   "".equals(locale.getCountry()))
+                {
+                    return locale;
+                }
             }
         }
+        
+        //language and country (eg. fr_FR)
+        if (lang.length() == 5) {
+            if(lang.charAt(2) != '_') {
+                return null;
+            }
+            String language = lang.substring(0, 2).toLowerCase();
+            String country = lang.substring(3, 5).toUpperCase();
+            for (Locale locale : Locale.getAvailableLocales()) {            
+                if(locale.getLanguage().equals(language) &&
+                   locale.getCountry().equals(country))
+                {
+                    return locale;
+                }
+            }
+        }
+        
         return null;
     }
-
 }

--- a/framework/src/play/i18n/Messages.java
+++ b/framework/src/play/i18n/Messages.java
@@ -96,6 +96,9 @@ public class Messages {
         if (locales.containsKey(locale)) {
             value = locales.get(locale).getProperty(key.toString());
         }
+        if (value == null && locale != null && locale.length() == 5 && locales.containsKey(locale.substring(0, 2))) {
+            value = locales.get(locale.substring(0, 2)).getProperty(key.toString());
+        }
         if (value == null) {
             value = defaults.getProperty(key.toString());
         }
@@ -171,7 +174,15 @@ public class Messages {
     public static Properties all(String locale) {
         if(locale == null || "".equals(locale))
             return defaults;
-        return locales.get(locale);
+        
+        Properties messages = new Properties();
+        
+        messages.putAll(defaults);
+        if (locale.length() == 5 && locales.containsKey(locale.substring(0, 2))) {
+            messages.putAll(locales.get(locale.substring(0, 2)));
+        }
+        messages.putAll(locales.get(locale));
+        
+        return messages;
     }
-
 }

--- a/framework/src/play/templates/JavaExtensions.java
+++ b/framework/src/play/templates/JavaExtensions.java
@@ -156,13 +156,13 @@ public class JavaExtensions {
     }
 
     public static String format(Number number, String pattern) {
-        DecimalFormatSymbols symbols = new DecimalFormatSymbols(new Locale(Lang.get()));
+        DecimalFormatSymbols symbols = new DecimalFormatSymbols(Lang.getLocale());
         return new DecimalFormat(pattern, symbols).format(number);
     }
 
     public static String format(Date date) {
         // Get the pattern from the configuration
-        return new SimpleDateFormat(I18N.getDateFormat()).format(date);
+        return format(date, I18N.getDateFormat());
     }
 
     public static String format(Date date, String pattern) {
@@ -170,11 +170,11 @@ public class JavaExtensions {
     }
 
     public static String format(Date date, String pattern, String lang) {
-        return new SimpleDateFormat(pattern, new Locale(lang)).format(date);
+        return new SimpleDateFormat(pattern, Lang.getLocaleOrDefault(lang)).format(date);
     }
 
     public static String format(Date date, String pattern, String lang, String timezone) {
-        DateFormat df = new SimpleDateFormat(pattern, new Locale(lang));
+        DateFormat df = new SimpleDateFormat(pattern, Lang.getLocaleOrDefault(lang));
         df.setTimeZone(TimeZone.getTimeZone(timezone));
         return df.format(date);
     }
@@ -219,12 +219,16 @@ public class JavaExtensions {
         return Messages.get("since.years", years, pluralize(years));
     }
 
+    public static String asdate(Long timestamp) {
+        return asdate(timestamp, I18N.getDateFormat());
+    }
+    
     public static String asdate(Long timestamp, String pattern) {
         return asdate(timestamp, pattern, Lang.get());
     }
 
     public static String asdate(Long timestamp, String pattern, String lang) {
-        return new SimpleDateFormat(pattern, new Locale(lang)).format(new Date(timestamp));
+        return new SimpleDateFormat(pattern, Lang.getLocaleOrDefault(lang)).format(new Date(timestamp));
     }
 
     public static String asdate(Long timestamp, String pattern, String lang, String timezone) {
@@ -256,10 +260,10 @@ public class JavaExtensions {
         }
         return bytes / 1073741824L + "GB";
     }
-
+    
     public static String formatCurrency(Number number, String currencyCode) {
         Currency currency = Currency.getInstance(currencyCode);
-        NumberFormat numberFormat = NumberFormat.getCurrencyInstance(new Locale(Lang.get()));
+        NumberFormat numberFormat = NumberFormat.getCurrencyInstance(Lang.getLocale());
         numberFormat.setCurrency(currency);
         numberFormat.setMaximumFractionDigits(currency.getDefaultFractionDigits());
         String s = numberFormat.format(number);

--- a/resources/application-skel/conf/application.conf
+++ b/resources/application-skel/conf/application.conf
@@ -19,7 +19,7 @@ application.secret=%SECRET_KEY%
 # ~~~~~
 # Define locales used by your application.
 # You can then place localized messages in conf/messages.{locale} files
-# application.langs=fr,en,ja
+# application.langs=fr,fr_FR,fr_BE,en,ja
 
 # Date format
 # ~~~~~


### PR DESCRIPTION
[#924] Fixes for internationalization and fallbacks when retrieving messages
- Fixed LocaleBinder to now correctly accept locales containing a country (e.g. "fr_FR"). The current implementation never worked
- Fixed Lang.getLocale() to accept locales containing a country (e.g. "fr_FR")
- Fixed the non-argument version of the format() java extension to use the current locale to translate month and week day names
- Fixed all asdate() and format() java extensions to correctly translate month and week day names when using locales containing country codes (e.g. "fr_FR")
- Added a non-argument version of the asdate() Java extension as equivalent to .format()
- Enhanced the way Messages.getMessage() and Messages.all() retrieve messages. Now fallbacks from specific message files to more general message files occur
- Added "fr_FR" and "fr_BE" as comment for the application.langs key in the default application.conf
