### PR TITLE
Blob deepCopy issue #935

### DIFF
--- a/framework/src/play/db/jpa/Blob.java
+++ b/framework/src/play/db/jpa/Blob.java
@@ -106,7 +106,7 @@ public class Blob implements BinaryField, UserType {
         if(o == null) {
             return null;
         }
-        return new Blob(this.UUID, this.type);
+        return new Blob(((Blob)o).UUID, ((Blob)o).type);
     }
 
     public boolean isMutable() {


### PR DESCRIPTION
Fixes Blob deepCopy. Bug found while trying to audit a Blob type using Envers.
http://play.lighthouseapp.com/projects/57987-play-framework/tickets/935
