### PR TITLE
[#770] Add sources when generating module for IntelliJ IDEA

### DIFF
--- a/resources/idea/imlTemplate.xml
+++ b/resources/idea/imlTemplate.xml
@@ -38,7 +38,9 @@
                     <root url="jar://%PLAYHOME%/framework/play-%PLAYVERSION%.jar!/" />
                 </CLASSES>
                 <JAVADOC />
-                <SOURCES />
+                <SOURCES>
+                    <root url="file://%PLAYHOME%/framework/src" />
+                </SOURCES>
             </library>
         </orderEntry>
     </component>


### PR DESCRIPTION
Add sources to the generated IDEA module to make Play source code navigation and Javadoc available in IDEA.
