### PR TITLE
[#939] Fixed a missing checkAndParse in get when the class type is specif

### DIFF
--- a/framework/src/play/mvc/Scope.java
+++ b/framework/src/play/mvc/Scope.java
@@ -403,6 +403,9 @@ public class Scope {
 
         @SuppressWarnings("unchecked")
         public <T> T get(String key, Class<T> type) {
+             if (!_contains(key)) {
+                checkAndParse();
+            }
             try {
                 // TODO: This is used by the test, but this is not the most convenient.
                 return (T) Binder.bind(key, type, type, null, data);
@@ -414,6 +417,9 @@ public class Scope {
 
         @SuppressWarnings("unchecked")
         public <T> T get(Annotation[] annotations, String key, Class<T> type) {
+            if (!_contains(key)) {
+                checkAndParse();
+            }
             try {
                 return (T) Binder.directBind(key, annotations, get(key), type);
             } catch (Exception e) {


### PR DESCRIPTION
[#939] Fixed a missing checkAndParse in get when the class type is specified
