### PR TITLE
[#938] Added catch block for thrown Results.

### DIFF
--- a/framework/src/play/mvc/ActionInvoker.java
+++ b/framework/src/play/mvc/ActionInvoker.java
@@ -158,6 +158,12 @@ public class ActionInvoker {
                     ControllerInstrumentation.initActionCall();
                     try {
                         inferResult(invokeControllerMethod(actionMethod));
+                    } catch(Result result) {
+                        actionResult = result;
+                        // Cache it if needed
+                        if (cacheKey != null) {
+                            play.cache.Cache.set(cacheKey, actionResult, actionMethod.getAnnotation(CacheFor.class).value());
+                        }
                     } catch (InvocationTargetException ex) {
                         // It's a Result ? (expected)
                         if (ex.getTargetException() instanceof Result) {


### PR DESCRIPTION
[#938] Added catch block for thrown Results. Fixes scalas missing @After, and all controllers returning not throwing a result.
It's the same fix that is in ticket description.
