### PR TITLE
[#954] Enhance FunctionalTest to give access to renderArgs

### DIFF
--- a/documentation/manual/test.textile
+++ b/documentation/manual/test.textile
@@ -32,7 +32,7 @@ public class MyTest extends UnitTest {
 
 h3. Functional test
 
-A functional test is written using JUnit. In this kind of test you can test your application by accessing directly the controller objects. 
+A functional test is written using JUnit. In this kind of test you can test your application by accessing directly the controller objects.
 
 Here is an example of a Functional test:
 
@@ -49,6 +49,16 @@ public class ApplicationTest extends FunctionalTest {
         assertStatus(200, response);
     }
      
+}
+
+Using the @renderArgs()@ method, you can also get direct access to the arguments passed to the view, instead of having to make assertions about the response itself.  For example:
+
+bc. @Test
+public void testUserIsFoundAndPassedToView() {
+    Response response = POST("/user/find?name=mark&dob=18011977")
+    assertThat(renderArgs("user"), is(notNullValue());
+    User user = (User) renderArgs("user");
+    assertThat(user.name, is("mark"));
 }
 
 h3. Selenium test

--- a/framework/src/play/test/FunctionalTest.java
+++ b/framework/src/play/test/FunctionalTest.java
@@ -23,6 +23,7 @@ import play.mvc.ActionInvoker;
 import play.mvc.Http;
 import play.mvc.Http.Request;
 import play.mvc.Http.Response;
+import play.mvc.Scope.RenderArgs;
 
 import com.ning.http.multipart.FilePart;
 import com.ning.http.multipart.MultipartRequestEntity;
@@ -44,6 +45,8 @@ public abstract class FunctionalTest extends BaseTest {
 
     private static Map<String, Http.Cookie> savedCookies; // cookies stored between calls
 
+    private static Map<String, Object> renderArgs = new HashMap<String, Object>();
+    
     @Before
     public void clearCookies(){
         savedCookies = null;
@@ -261,8 +264,13 @@ public abstract class FunctionalTest extends BaseTest {
         final Future invocationResult = TestEngine.functionalTestsExecutor.submit(new Invoker.Invocation() {
 
             @Override
-            public void execute() throws Exception {                
+            public void execute() throws Exception {
+            	renderArgs.clear();
                 ActionInvoker.invoke(request, response);
+                
+                if(RenderArgs.current().data != null) {
+                	renderArgs.putAll(RenderArgs.current().data);
+                }
             }
 
             @Override
@@ -427,6 +435,10 @@ public abstract class FunctionalTest extends BaseTest {
         } catch (UnsupportedEncodingException ex) {
             throw new RuntimeException(ex);
         }
+    }
+    
+    public static Object renderArgs(String name) {
+    	return renderArgs.get(name);
     }
 
     // Utils

--- a/samples-and-tests/just-test-cases/test/FunctionalTestTest.java
+++ b/samples-and-tests/just-test-cases/test/FunctionalTestTest.java
@@ -87,5 +87,13 @@ public class FunctionalTestTest extends FunctionalTest {
         assertIsOk(response);
     }
     
+    @Test
+    public void canGetRenderArgs() {
+		Response response = GET("/users/edit");
+        assertIsOk(response);
+        assertNotNull(renderArgs("u"));
+        User u = (User) renderArgs("u");
+        assertEquals("Guillaume", u.name);
+    }
 }
 


### PR DESCRIPTION
Added code to allow FunctionalTests the ability to directly interrogate objects put into the renderArgs, in the same vein as assigns() in Rails.
