### PR TITLE
[#956] Set framework id to test if command = 'autotest'

### DIFF
--- a/play
+++ b/play
@@ -101,7 +101,7 @@ try:
     if remaining_args.count('--%%%s' % play_env["id"]) == 1:
         remaining_args.remove('--%%%s' % play_env["id"])
 
-    if play_command == 'test' or play_command == 'auto-test':
+    if play_command in ['test', 'auto-test', 'autotest'] :
         # If framework-id is not a valid test-id, force it to 'test'
         if not isTestFrameworkId( play_env["id"] ): 
             play_env["id"] = 'test'


### PR DESCRIPTION
framework/pym/play/commands/base.py treats "auto-test" and "autotest" as synonyms, but the main play script only sets framework ID as "test" for "auto-test".  Quick fix to do the same for "autotest"
