### PR TITLE
[#943] Change log line to listen for before auto-tests start

### DIFF
--- a/framework/pym/play/commands/base.py
+++ b/framework/pym/play/commands/base.py
@@ -213,7 +213,7 @@ def autotest(app, args):
         line = soutint.readline().strip()
         if line:
             print line
-            if line.find('/@tests to run the tests') > -1:
+            if line.find('Listening for HTTP') > -1:
                 soutint.close()
                 break
 


### PR DESCRIPTION
Modify base.py to wait for the line "Listening for HTTP" before the auto-test starts.  The current line listened for is output just before the server is actually ready, so fails intermittently with a ConnectException
