### PR TITLE
Fix lighthouse-131-patch

### DIFF
--- a/framework/src/play/mvc/results/RenderJson.java
+++ b/framework/src/play/mvc/results/RenderJson.java
@@ -50,7 +50,7 @@ public class RenderJson extends Result {
     //
     static Method getMethod(Class<?> clazz, String name) {
         for (Method m : clazz.getDeclaredMethods()) {
-            if (m.getName().equals(name)) {
+            if (m.getName().equals(name) && !m.isBridge()) {
                 return m;
             }
         }


### PR DESCRIPTION
RenderJson when registering adapters now ensure that type of the adapter is taken not from a bridge method. 
