### PR TITLE
[#992] Add completion for Zsh

### DIFF
--- a/support/zsh/_play
+++ b/support/zsh/_play
@@ -62,11 +62,20 @@ _play() {
         (build-module|list-modules|lm|check|id)
           _message 'no more arguments' && ret=0
         ;;
-        (auto-test|classpath|cp|clean|eclipsify|ec|idealize|idea|javadoc|jd|modules|netbeansify|nb|out|pid|secret|stop)
+        (dependencies|deps)
+          _arguments \
+            '1:: :_play_apps' \
+            '(--debug)--debug[Debug mode (even more informations logged than in verbose mode)]' \
+            '(--jpda)--jpda[Listen for JPDA connection. The process will  suspended until a client is plugged to the JPDA port.]' \
+            '(--sync)--sync[Keep lib/ and modules/ directory synced. Delete unknow dependencies.]' \
+            '(--verbose)--verbose[Verbose Mode]' \
+          && ret=0
+        ;;
+        (clean|javadoc|jd|out|pid|secret|stop)
           _arguments '1:: :_play_apps' && ret=0
         ;;
         (help)
-          _arguments '1: :_play_cmds -F "(cp ec idea jd st lm nb nm help)"' && ret=0
+          _arguments '1: :_play_cmds -F "(cp deps ec idea jd st lm nb nm help antify evolutions evolutions:apply evolutions:markApplied evolutions:resolve)"' && ret=0
         ;;
         (status|st)
           _arguments \
@@ -87,7 +96,7 @@ _play() {
         (new-module)
           _arguments '1:Module directory:_files -/' && ret=0
         ;;
-        (test|precompile|run|start|war)
+        (test|precompile|run|start|war|auto-test|classpath|cp|eclipsify|ec|idealize|idea|modules|netbeansify|nb)
           local cmd_args; cmd_args=(
             '1:: :_play_apps'
             '(--deps)--deps[Resolve and install dependencies before running the command]'
@@ -127,12 +136,18 @@ _play() {
 # FIXME Parse 'play help' and 'play help <command>' (for aliases) instead of hard-coding.
 _play_cmds() {
   local commands; commands=(
+    'antify:Create a build.xml file for this project'
     'auto-test:Automatically run all application tests'
     'build-module:Build and package a module'
     'check:Check for a release newer than the current one'
     {classpath,cp}':Display the computed classpath'
     'clean:Delete temporary files (including the bytecode cache)'
+    {dependencies,deps}':Resolve and retrieve project dependencies'
     {eclipsify,ec}':Create all Eclipse configuration files'
+    'evolutions:Run the evolution check'
+    'evolutions\:apply:Automatically apply pending evolutions'
+    'evolutions\:mark:AppliedMark pending evolutions as manually applied'
+    'evolutions\:resolve:Resolve partially applied evolution'
     'help:Display help on a specific command'
     'id:Define the framework ID'
     {idealize,idea}':Create all IntelliJ Idea configuration files'


### PR DESCRIPTION
Here is a completion script for Zsh.

It completes all the core commands, including things like `play install <module>-<version>` or `play run --%<some framework id>`.

The original (and most up-to-date) version of this script will always be [here](https://github.com/zsh-users/zsh-completions/blob/master/_play).
