### PR TITLE
Lighthouse 1009 patch

### DIFF
--- a/documentation/commands/cmd-version.txt
+++ b/documentation/commands/cmd-version.txt
@@ -1,0 +1,12 @@
+~ Name:
+~ ~~~~~
+~ version -- Print the framework version
+~ 
+~ Synopsis:
+~ ~~~~~~~~~
+~ play version
+~
+~ Description:
+~ ~~~~~~~~~~~~
+~ Prints the version of the Play framework currently being used.
+~

--- a/framework/pym/play/commands/version.py
+++ b/framework/pym/play/commands/version.py
@@ -1,0 +1,14 @@
+
+COMMANDS = ['version']
+
+HELP = {
+    'version': 'Print the framework version'
+}
+
+def execute(**kargs):
+    version = kargs.get("version")
+    showLogo = kargs.get("showLogo")
+
+    # If we've shown the logo, then the version has already been printed
+    if not showLogo:
+        print version

--- a/play
+++ b/play
@@ -132,6 +132,11 @@ try:
 
     cmdloader = CommandLoader(play_env["basedir"])
 
+    # ~~~~~~~~~~~~~~~~~ Run version command right away
+    if play_command == 'version':
+      cmdloader.commands['version'].execute(command='version', version=play_env["version"], showLogo=showLogo)
+      sys.exit(0)
+
     # ~~~~~~~~~~~~~~~~~ Resolve dependencies if needed
     if remaining_args.count('--deps') == 1:
         cmdloader.commands['dependencies'].execute(command='dependencies', app=play_app, args=['--sync'], env=play_env, cmdloader=cmdloader)


### PR DESCRIPTION
This adds a 'play version' command which simply prints out the current version of the framework.  E.g.:

$ play version
~
~ ...[Play logo]...
~
~ play! 1.2.x-8b489a0, http://www.playframework.org
~
$ play version --silent
1.2.x-8b489a0
