### PR TITLE
[#1017] Add a property "%test.headlessBrowser" in application.conf to cho

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ framework/src/play/version
 framework/tests/test-application/db
 framework/play-*.jar
 framework/docs
+samples-and-tests/*/test-result/
 
 # IDE and editors
 *~

--- a/framework/pym/play/commands/base.py
+++ b/framework/pym/play/commands/base.py
@@ -220,6 +220,10 @@ def autotest(app, args):
     # Run FirePhoque
     print "~"
 
+    headless_browser = ''
+    if app.readConf('headlessBrowser'):
+        headless_browser = app.readConf('headlessBrowser')
+
     fpcp = [os.path.join(app.play_env["basedir"], 'modules/testrunner/lib/play-testrunner.jar')]
     fpcp_libs = os.path.join(app.play_env["basedir"], 'modules/testrunner/firephoque')
     for jar in os.listdir(fpcp_libs):
@@ -228,7 +232,7 @@ def autotest(app, args):
     cp_args = ':'.join(fpcp)
     if os.name == 'nt':
         cp_args = ';'.join(fpcp)    
-    java_cmd = [app.java_path(), '-classpath', cp_args, '-Dapplication.url=%s://localhost:%s' % (protocol, http_port), 'play.modules.testrunner.FirePhoque']
+    java_cmd = [app.java_path(), '-classpath', cp_args, '-Dapplication.url=%s://localhost:%s' % (protocol, http_port), '-DheadlessBrowser=%s' % (headless_browser), 'play.modules.testrunner.FirePhoque']
     try:
         subprocess.call(java_cmd, env=os.environ)
     except OSError:

--- a/modules/testrunner/public/test-runner/selenium/scripts/selenium-browserbot.js
+++ b/modules/testrunner/public/test-runner/selenium/scripts/selenium-browserbot.js
@@ -2203,7 +2203,7 @@ MozillaBrowserBot.prototype._fireEventOnElement = function(eventType, element, c
 
     // Perform the link action if preventDefault was set.
     // In chrome URL, the link action is already executed by triggerMouseEvent.
-    if (!browserVersion.isChrome && savedEvent != null && !savedEvent.getPreventDefault()) {
+    if (!browserVersion.isChrome && savedEvent != null && savedEvent.getPreventDefault && !savedEvent.getPreventDefault()) {
         var targetWindow = this.browserbot._getTargetWindow(element);
         if (element.href) {
             targetWindow.location.href = element.href;

--- a/modules/testrunner/src/play/modules/testrunner/FirePhoque.java
+++ b/modules/testrunner/src/play/modules/testrunner/FirePhoque.java
@@ -52,7 +52,22 @@ public class FirePhoque {
         }
 
         // Let's tweak WebClient
-        WebClient firephoque = new WebClient(BrowserVersion.INTERNET_EXPLORER_8);
+
+        String headlessBrowser = System.getProperty("headlessBrowser", "INTERNET_EXPLORER_8");
+        BrowserVersion browserVersion;
+        if ("FIREFOX_3".equals(headlessBrowser)) {
+            browserVersion = BrowserVersion.FIREFOX_3;
+        } else if ("FIREFOX_3_6".equals(headlessBrowser)) {
+            browserVersion = BrowserVersion.FIREFOX_3_6;
+        } else if ("INTERNET_EXPLORER_6".equals(headlessBrowser)) {
+            browserVersion = BrowserVersion.INTERNET_EXPLORER_6;
+        } else if ("INTERNET_EXPLORER_7".equals(headlessBrowser)) {
+            browserVersion = BrowserVersion.INTERNET_EXPLORER_7;
+        } else {
+            browserVersion = BrowserVersion.INTERNET_EXPLORER_8;
+        }
+
+        WebClient firephoque = new WebClient(browserVersion);
         firephoque.setPageCreator(new DefaultPageCreator() {
 
             @Override


### PR DESCRIPTION
[#1017] Add a property "%test.headlessBrowser" in application.conf to choose the browser version used by htmlunit in auto-test mode.
