### PR TITLE
[#351] @OnApplicationStop for Jobs

### DIFF
--- a/framework/src/play/Play.java
+++ b/framework/src/play/Play.java
@@ -550,8 +550,8 @@ public class Play {
     public static synchronized void stop() {
         if (started) {
             Logger.trace("Stopping the play application");
-            started = false;
             pluginCollection.onApplicationStop();
+            started = false;
             Cache.stop();
             Router.lastLoading = 0L;
         }

--- a/framework/src/play/jobs/OnApplicationStop.java
+++ b/framework/src/play/jobs/OnApplicationStop.java
@@ -1,0 +1,16 @@
+package play.jobs;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * A job run when the application is stopped under graceful circumstances.
+ *
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface OnApplicationStop {
+
+}


### PR DESCRIPTION
I just wrote a first implementation of a fix for #351 (@OnApplicationStop for Jobs).

It works for "play stop" as well as Strc+C when running "play run". Could only test it on OSX though.

I had to move the "Play.started = false" assignment in Play.stop below the "pluginCollection.onApplicationStop()", because otherwise the execution of the shutdown-jobs would re-init/restart the play internals due to a "if(!Play.started)" check in Job.call().
