### PR TITLE
[#188] Fix eclipsify - problem when mismatch between project name and folder name 

### DIFF
--- a/framework/pym/play/commands/eclipse.py
+++ b/framework/pym/play/commands/eclipse.py
@@ -21,7 +21,8 @@ def execute(**kargs):
         app.check_jpda()
     modules = app.modules()
     classpath = app.getClasspath()
-
+    
+    application_basename = os.path.basename(app.path)
     # determine the name of the project
     # if this is an application, the name of the project is in the application.conf file
     # if this is a module, we infer the name from the path
@@ -29,7 +30,7 @@ def execute(**kargs):
     if application_name:
         application_name = application_name.replace("/", " ")
     else:
-        application_name = os.path.basename(app.path)
+        application_name = application_basename
 
     dotProject = os.path.join(app.path, '.project')
     dotClasspath = os.path.join(app.path, '.classpath')
@@ -115,19 +116,19 @@ def execute(**kargs):
         replaceAll(dotClasspath, r'%MODULES%', '')
 
     if is_application:
-        replaceAll(os.path.join(app.path, 'eclipse/debug.launch'), r'%PROJECT_NAME%', application_name)
+        replaceAll(os.path.join(app.path, 'eclipse/debug.launch'), r'%PROJECT_BASENAME%', application_basename)
         replaceAll(os.path.join(app.path, 'eclipse/debug.launch'), r'%PLAY_BASE%', play_env["basedir"])
         replaceAll(os.path.join(app.path, 'eclipse/debug.launch'), r'%PLAY_ID%', play_env["id"])
         replaceAll(os.path.join(app.path, 'eclipse/debug.launch'), r'%JPDA_PORT%', str(app.jpda_port))
         replaceAll(os.path.join(app.path, 'eclipse/debug.launch'), r'%PLAY_VERSION%', play_env["version"])
 
-        replaceAll(os.path.join(app.path, 'eclipse/test.launch'), r'%PROJECT_NAME%', application_name)
+        replaceAll(os.path.join(app.path, 'eclipse/test.launch'), r'%PROJECT_BASENAME%', application_basename)
         replaceAll(os.path.join(app.path, 'eclipse/test.launch'), r'%PLAY_BASE%', play_env["basedir"])
         replaceAll(os.path.join(app.path, 'eclipse/test.launch'), r'%PLAY_ID%', play_env["id"])
         replaceAll(os.path.join(app.path, 'eclipse/test.launch'), r'%JPDA_PORT%', str(app.jpda_port))
         replaceAll(os.path.join(app.path, 'eclipse/test.launch'), r'%PLAY_VERSION%', play_env["version"])
 
-        replaceAll(os.path.join(app.path, 'eclipse/connect.launch'), r'%PROJECT_NAME%', application_name)
+        replaceAll(os.path.join(app.path, 'eclipse/connect.launch'), r'%PROJECT_BASENAME%', application_basename)
         replaceAll(os.path.join(app.path, 'eclipse/connect.launch'), r'%JPDA_PORT%', str(app.jpda_port))
 
         os.rename(os.path.join(app.path, 'eclipse/connect.launch'), os.path.join(app.path, 'eclipse/Connect JPDA to %s.launch' % application_name))

--- a/resources/eclipse/connect.launch
+++ b/resources/eclipse/connect.launch
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <launchConfiguration type="org.eclipse.jdt.launching.remoteJavaApplication">
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
-<listEntry value="/%PROJECT_NAME%"/>
+<listEntry value="/%PROJECT_BASENAME%"/>
 </listAttribute>
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
 <listEntry value="4"/>
@@ -11,6 +11,6 @@
 <mapEntry key="port" value="%JPDA_PORT%"/>
 <mapEntry key="hostname" value="localhost"/>
 </mapAttribute>
-<stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="%PROJECT_NAME%"/>
+<stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="%PROJECT_BASENAME%"/>
 <stringAttribute key="org.eclipse.jdt.launching.VM_CONNECTOR_ID" value="org.eclipse.jdt.launching.socketAttachConnector"/>
 </launchConfiguration>

--- a/resources/eclipse/debug.launch
+++ b/resources/eclipse/debug.launch
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <launchConfiguration type="org.eclipse.jdt.launching.localJavaApplication">
     <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
-        <listEntry value="/%PROJECT_NAME%"/>
+        <listEntry value="/%PROJECT_BASENAME%"/>
     </listAttribute>
     <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
         <listEntry value="4"/>
     </listAttribute>
     <booleanAttribute key="org.eclipse.debug.core.appendEnvironmentVariables" value="true"/>
     <listAttribute key="org.eclipse.jdt.launching.CLASSPATH">
-        <listEntry value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;&#10;&lt;runtimeClasspathEntry containerPath=&quot;org.eclipse.jdt.launching.JRE_CONTAINER&quot; javaProject=&quot;%PROJECT_NAME%&quot; path=&quot;1&quot; type=&quot;4&quot;/&gt;&#10;"/>
-        <listEntry value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;&#10;&lt;runtimeClasspathEntry internalArchive=&quot;/%PROJECT_NAME%/conf&quot; path=&quot;3&quot; type=&quot;2&quot;/&gt;&#10;"/>
-        <listEntry value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;&#10;&lt;runtimeClasspathEntry id=&quot;org.eclipse.jdt.launching.classpathentry.defaultClasspath&quot;&gt;&#10;&lt;memento exportedEntriesOnly=&quot;false&quot; project=&quot;%PROJECT_NAME%&quot;/&gt;&#10;&lt;/runtimeClasspathEntry&gt;&#10;"/>
+        <listEntry value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;&#10;&lt;runtimeClasspathEntry containerPath=&quot;org.eclipse.jdt.launching.JRE_CONTAINER&quot; javaProject=&quot;%PROJECT_BASENAME%&quot; path=&quot;1&quot; type=&quot;4&quot;/&gt;&#10;"/>
+        <listEntry value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;&#10;&lt;runtimeClasspathEntry internalArchive=&quot;/%PROJECT_BASENAME%/conf&quot; path=&quot;3&quot; type=&quot;2&quot;/&gt;&#10;"/>
+        <listEntry value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;&#10;&lt;runtimeClasspathEntry id=&quot;org.eclipse.jdt.launching.classpathentry.defaultClasspath&quot;&gt;&#10;&lt;memento exportedEntriesOnly=&quot;false&quot; project=&quot;%PROJECT_BASENAME%&quot;/&gt;&#10;&lt;/runtimeClasspathEntry&gt;&#10;"/>
     </listAttribute>
     <booleanAttribute key="org.eclipse.jdt.launching.DEFAULT_CLASSPATH" value="false"/>
     <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="play.server.Server"/>
-    <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="%PROJECT_NAME%"/>
-    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Xdebug -Xrunjdwp:transport=dt_socket,address=%JPDA_PORT%,server=y,suspend=n -Dplay.debug=yes -Dplay.id=%PLAY_ID% -Dapplication.path=&quot;${project_loc:%PROJECT_NAME%}&quot; -Djava.endorsed.dirs=&quot;%PLAY_BASE%/framework/endorsed&quot; -javaagent:&quot;%PLAY_BASE%/framework/play-%PLAY_VERSION%.jar&quot;"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="%PROJECT_BASENAME%"/>
+    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Xdebug -Xrunjdwp:transport=dt_socket,address=%JPDA_PORT%,server=y,suspend=n -Dplay.debug=yes -Dplay.id=%PLAY_ID% -Dapplication.path=&quot;${project_loc:%PROJECT_BASENAME%}&quot; -Djava.endorsed.dirs=&quot;%PLAY_BASE%/framework/endorsed&quot; -javaagent:&quot;%PLAY_BASE%/framework/play-%PLAY_VERSION%.jar&quot;"/>
 </launchConfiguration>
 

--- a/resources/eclipse/test.launch
+++ b/resources/eclipse/test.launch
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <launchConfiguration type="org.eclipse.jdt.launching.localJavaApplication">
     <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
-        <listEntry value="/%PROJECT_NAME%"/>
+        <listEntry value="/%PROJECT_BASENAME%"/>
     </listAttribute>
     <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
         <listEntry value="4"/>
     </listAttribute>
     <booleanAttribute key="org.eclipse.debug.core.appendEnvironmentVariables" value="true"/>
     <listAttribute key="org.eclipse.jdt.launching.CLASSPATH">
-        <listEntry value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;&#10;&lt;runtimeClasspathEntry containerPath=&quot;org.eclipse.jdt.launching.JRE_CONTAINER&quot; javaProject=&quot;%PROJECT_NAME%&quot; path=&quot;1&quot; type=&quot;4&quot;/&gt;&#10;"/>
-        <listEntry value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;&#10;&lt;runtimeClasspathEntry internalArchive=&quot;/%PROJECT_NAME%/conf&quot; path=&quot;3&quot; type=&quot;2&quot;/&gt;&#10;"/>
+        <listEntry value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;&#10;&lt;runtimeClasspathEntry containerPath=&quot;org.eclipse.jdt.launching.JRE_CONTAINER&quot; javaProject=&quot;%PROJECT_BASENAME%&quot; path=&quot;1&quot; type=&quot;4&quot;/&gt;&#10;"/>
+        <listEntry value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;&#10;&lt;runtimeClasspathEntry internalArchive=&quot;/%PROJECT_BASENAME%/conf&quot; path=&quot;3&quot; type=&quot;2&quot;/&gt;&#10;"/>
         <listEntry value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&#13;&#10;&lt;runtimeClasspathEntry externalArchive=&quot;%PLAY_BASE%/modules/testrunner/lib/play-testrunner.jar&quot; path=&quot;3&quot; type=&quot;2&quot;/&gt;&#13;&#10;"/>
-        <listEntry value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;&#10;&lt;runtimeClasspathEntry id=&quot;org.eclipse.jdt.launching.classpathentry.defaultClasspath&quot;&gt;&#10;&lt;memento exportedEntriesOnly=&quot;false&quot; project=&quot;%PROJECT_NAME%&quot;/&gt;&#10;&lt;/runtimeClasspathEntry&gt;&#10;"/>
+        <listEntry value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;&#10;&lt;runtimeClasspathEntry id=&quot;org.eclipse.jdt.launching.classpathentry.defaultClasspath&quot;&gt;&#10;&lt;memento exportedEntriesOnly=&quot;false&quot; project=&quot;%PROJECT_BASENAME%&quot;/&gt;&#10;&lt;/runtimeClasspathEntry&gt;&#10;"/>
     </listAttribute>
     <booleanAttribute key="org.eclipse.jdt.launching.DEFAULT_CLASSPATH" value="false"/>
     <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="play.server.Server"/>
-    <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="%PROJECT_NAME%"/>
-    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Xdebug -Xrunjdwp:transport=dt_socket,address=%JPDA_PORT%,server=y,suspend=n -Dplay.debug=yes -Dplay.id=test -Dapplication.path=&quot;${project_loc:%PROJECT_NAME%}&quot; -Djava.endorsed.dirs=&quot;%PLAY_BASE%/framework/endorsed&quot; -javaagent:&quot;%PLAY_BASE%/framework/play-%PLAY_VERSION%.jar&quot;"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="%PROJECT_BASENAME%"/>
+    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Xdebug -Xrunjdwp:transport=dt_socket,address=%JPDA_PORT%,server=y,suspend=n -Dplay.debug=yes -Dplay.id=test -Dapplication.path=&quot;${project_loc:%PROJECT_BASENAME%}&quot; -Djava.endorsed.dirs=&quot;%PLAY_BASE%/framework/endorsed&quot; -javaagent:&quot;%PLAY_BASE%/framework/play-%PLAY_VERSION%.jar&quot;"/>
 </launchConfiguration>
 


### PR DESCRIPTION
[#188] Fix eclipsify - use project folder name instead of project name in launch config files
Hi, 
I fix the problem when use eclipsify on a project with a project name different from the project base folder name.
Eclipsify now use project folder name in generated launch config files instead of the project name. I also change the variable name from %PROJECT_NAME% to %PROJECT_BASENAME% in template files in order to keep consistency.

I hope it helps.

Sylvain
