### PR TITLE
Lighthouse #1014 - Extra space in currency display

### DIFF
--- a/framework/src/play/templates/JavaExtensions.java
+++ b/framework/src/play/templates/JavaExtensions.java
@@ -263,7 +263,7 @@ public class JavaExtensions {
         numberFormat.setCurrency(currency);
         numberFormat.setMaximumFractionDigits(currency.getDefaultFractionDigits());
         String s = numberFormat.format(number);
-        s = s.replace(currencyCode, I18N.getCurrencySymbol(currencyCode));
+        s = s.replace(currencyCode + " ", I18N.getCurrencySymbol(currencyCode));
         return s;
     }
 
@@ -273,7 +273,7 @@ public class JavaExtensions {
         numberFormat.setCurrency(currency);
         numberFormat.setMaximumFractionDigits(currency.getDefaultFractionDigits());
         String s = numberFormat.format(number);
-        s = s.replace(currency.getCurrencyCode(), currency.getSymbol(locale));
+        s = s.replace(currency.getCurrencyCode() + " ", currency.getSymbol(locale));
         return s;
     }
 


### PR DESCRIPTION
This patch removes the extra space between the currency symbol and the currency value. Currently, play displays this as "$ 50.00" when it should be "$50.00". This patch makes the appropriate change.
