### PR TITLE
#1046 Enhance request: Support clearing ivy cache

### DIFF
--- a/documentation/commands/cmd-dependencies.txt
+++ b/documentation/commands/cmd-dependencies.txt
@@ -42,3 +42,6 @@
 ~ --%fwk_id:
 ~ Use this ID to run the application (override the default framework ID)
 ~
+~ --clearcache:
+~ Clear the ivy cache (equivalent to rm -r ~/.ivy2/cache)
+~

--- a/framework/pym/play/commands/deps.py
+++ b/framework/pym/play/commands/deps.py
@@ -35,6 +35,8 @@ def execute(**kargs):
         add_options.append('-Dsync')
     if args.count('--debug'):
         add_options.append('-Ddebug')
+    if args.count('--clearcache'):
+        add_options.append('-Dclearcache')
     if args.count('--jpda'):
         print "~ Waiting for JPDA client to continue"
         add_options.extend(['-Xdebug', '-Xrunjdwp:transport=dt_socket,address=8888,server=y,suspend=y'])

--- a/framework/src/play/deps/DependenciesManager.java
+++ b/framework/src/play/deps/DependenciesManager.java
@@ -1,9 +1,12 @@
 package play.deps;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+
+import org.apache.commons.io.FileUtils;
 import org.apache.ivy.Ivy;
 import org.apache.ivy.core.report.ArtifactDownloadReport;
 import org.apache.ivy.core.report.ResolveReport;
@@ -15,6 +18,7 @@ import org.apache.ivy.plugins.parser.ModuleDescriptorParserRegistry;
 import org.apache.ivy.util.DefaultMessageLogger;
 import org.apache.ivy.util.Message;
 import org.apache.ivy.util.filter.FilterHelper;
+
 import play.libs.Files;
 import play.libs.IO;
 
@@ -261,15 +265,34 @@ public class DependenciesManager {
             return null;
         }
 
-        System.out.println("~ Resolving dependencies using " + ivyModule.getAbsolutePath() + ",");
-        System.out.println("~");
 
         // Variables
         System.setProperty("play.path", framework.getAbsolutePath());
-
+        
         // Ivy
         Ivy ivy = configure();
 
+        // Clear the cache
+        boolean clearcache = System.getProperty("clearcache") != null;
+        if(clearcache){
+           System.out.println("~ Clearing cache : " + ivy.getResolutionCacheManager().getResolutionCacheRoot() + ",");
+           System.out.println("~");
+           try{
+      		   FileUtils.deleteDirectory(ivy.getResolutionCacheManager().getResolutionCacheRoot());
+      		   System.out.println("~       Clear");
+           }catch(IOException e){
+        	   System.out.println("~       Could not clear");
+        	   System.out.println("~ ");
+        	   e.printStackTrace();
+             }
+
+           System.out.println("~");
+         }
+        
+
+        System.out.println("~ Resolving dependencies using " + ivyModule.getAbsolutePath() + ",");
+        System.out.println("~");
+        
         // Resolve
         ResolveEngine resolveEngine = ivy.getResolveEngine();
         ResolveOptions resolveOptions = new ResolveOptions();


### PR DESCRIPTION
~/.ivy2/chache mechanism sometimes causes confusion about dependencies resolving.

Especially when using 'http' type in the repositories section of conf/dependencies.yml.

So, I've just now sent you this pull request that supports clearing ivy cache option on deps command.

Thanks.
