### PR TITLE
[#993] Fix wrong content length bug

### DIFF
--- a/framework/src/play/server/PlayHandler.java
+++ b/framework/src/play/server/PlayHandler.java
@@ -667,7 +667,7 @@ public class PlayHandler extends SimpleChannelUpstreamHandler {
         String errorHtml = TemplateLoader.load("errors/404." + format).render(binding);
         try {
             ChannelBuffer buf = ChannelBuffers.copiedBuffer(errorHtml.getBytes(Response.current().encoding));
-            setContentLength(nettyResponse, errorHtml.length());
+            setContentLength(nettyResponse, buf.array().length);
             nettyResponse.setContent(buf);
             ChannelFuture writeFuture = ctx.getChannel().write(nettyResponse);
             writeFuture.addListener(ChannelFutureListener.CLOSE);
@@ -759,7 +759,7 @@ public class PlayHandler extends SimpleChannelUpstreamHandler {
                 String errorHtml = TemplateLoader.load("errors/500." + format).render(binding);
 
                 ChannelBuffer buf = ChannelBuffers.copiedBuffer(errorHtml.getBytes(encoding));
-                setContentLength(nettyResponse, errorHtml.length());
+                setContentLength(nettyResponse, buf.array().length);
                 nettyResponse.setContent(buf);
                 ChannelFuture writeFuture = ctx.getChannel().write(nettyResponse);
                 writeFuture.addListener(ChannelFutureListener.CLOSE);
@@ -770,7 +770,7 @@ public class PlayHandler extends SimpleChannelUpstreamHandler {
                 try {
                     final String errorHtml = "Internal Error (check logs)";
                     ChannelBuffer buf = ChannelBuffers.copiedBuffer(errorHtml.getBytes(encoding));
-                    setContentLength(nettyResponse, errorHtml.length());
+                    setContentLength(nettyResponse, buf.array().length);
                     nettyResponse.setContent(buf);
                     ChannelFuture writeFuture = ctx.getChannel().write(nettyResponse);
                     writeFuture.addListener(ChannelFutureListener.CLOSE);
@@ -782,7 +782,7 @@ public class PlayHandler extends SimpleChannelUpstreamHandler {
             try {
                 final String errorHtml = "Internal Error (check logs)";
                 ChannelBuffer buf = ChannelBuffers.copiedBuffer(errorHtml.getBytes(encoding));
-                setContentLength(nettyResponse, errorHtml.length());
+                setContentLength(nettyResponse, buf.array().length);
                 nettyResponse.setContent(buf);
                 ChannelFuture writeFuture = ctx.getChannel().write(nettyResponse);
                 writeFuture.addListener(ChannelFutureListener.CLOSE);
@@ -892,7 +892,7 @@ public class PlayHandler extends SimpleChannelUpstreamHandler {
                 HttpResponse errorResponse = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.INTERNAL_SERVER_ERROR);
                 final String errorHtml = "Internal Error (check logs)";
                 ChannelBuffer buf = ChannelBuffers.copiedBuffer(errorHtml.getBytes(response.encoding));
-                setContentLength(nettyResponse, errorHtml.length());
+                setContentLength(nettyResponse, buf.array().length);
                 errorResponse.setContent(buf);
                 ChannelFuture future = ctx.getChannel().write(errorResponse);
                 future.addListener(ChannelFutureListener.CLOSE);


### PR DESCRIPTION
This fix is for:
http://play.lighthouseapp.com/projects/57987/tickets/993-playserverplayhandler-serve404-and-serve500-setcontentlength-is-mistake-when-template-contains-double-byte-char
