### PR TITLE
[#1081] Add flag to trim modules used in production apps

### DIFF
--- a/framework/pym/play/commands/deps.py
+++ b/framework/pym/play/commands/deps.py
@@ -22,13 +22,19 @@ def execute(**kargs):
     play_env = kargs.get("env")
 
     force = "false"
+    trim = "false"
     if args.count('--forceCopy') == 1:
         args.remove('--forceCopy')
         force = "true"
+        
+    if args.count('--forProd') == 1:
+        args.remove('--forProd')
+        force = "true"
+        trim = "true"
 
     classpath = app.getClasspath()
 
-    add_options = ['-Dapplication.path=%s' % (app.path), '-Dframework.path=%s' % (play_env['basedir']), '-Dplay.id=%s' % play_env['id'], '-Dplay.version=%s' % play_env['version'], '-Dplay.forcedeps=%s' % (force)]
+    add_options = ['-Dapplication.path=%s' % (app.path), '-Dframework.path=%s' % (play_env['basedir']), '-Dplay.id=%s' % play_env['id'], '-Dplay.version=%s' % play_env['version'], '-Dplay.forcedeps=%s' % (force), '-Dplay.trimdeps=%s' % (trim)]
     if args.count('--verbose'):
         add_options.append('-Dverbose')
     if args.count('--sync'):


### PR DESCRIPTION
Example:

$ play dependencies --forProd

This flag will trim out documentation, src, and sample/test directories from modules.
