### PR TITLE
[#1087] Add .jar files from depency modules into the classpath

### DIFF
--- a/resources/module-skel/build.xml
+++ b/resources/module-skel/build.xml
@@ -17,6 +17,9 @@
         <fileset dir="lib">
             <include name="*.jar"/>
         </fileset>
+        <fileset dir="modules/">
+            <filename name="**/lib/*.jar"/>
+        </fileset>
     </path>
 
     <target name="build" depends="compile">


### PR DESCRIPTION
Add .jar files from dependency modules when you run build-module.

Details:
For example, if you create a new module that depends on "moduleX", you will get in your modules folder the moduleX, after run play deps command.

Then, you create into the src folder (from moduleX) a new class that depends on some library (libraryY.jar), that its included by moduleX into its lib folder, for example it will be here -> new-module/name/modules/moduleX/lib/libraryY.jar

If you try to run play build-module, it will fail because it doesn't find the libraryY.jar into the classpath.

[Solution]
I've written a little patch, to solve this situation. The patch only modify the build.xml file from the module-skel.
