### PR TITLE
[#1094] play.libs.XML.serialize method calls Sun proprietary API

### DIFF
--- a/framework/src/play/libs/XML.java
+++ b/framework/src/play/libs/XML.java
@@ -2,6 +2,7 @@ package play.libs;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.StringReader;
 import java.io.StringWriter;
 import java.security.Key;
 import java.security.Provider;
@@ -27,6 +28,11 @@ import javax.xml.crypto.dsig.spec.C14NMethodParameterSpec;
 import javax.xml.crypto.dsig.spec.TransformParameterSpec;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
 
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
@@ -34,9 +40,6 @@ import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
 import play.Logger;
-
-import com.sun.org.apache.xml.internal.serialize.XMLSerializer;
-import java.io.StringReader;
 
 /**
  * XML utils
@@ -51,9 +54,15 @@ public class XML {
     public static String serialize(Document document) {
         StringWriter writer = new StringWriter();
         try {
-            new XMLSerializer(writer, null).serialize(document);
-        } catch (IOException e) {
-            Logger.warn("Error when serializing xml Document.", e);
+            // Use an identity transformer to serialize.
+            TransformerFactory factory = TransformerFactory.newInstance();
+            Transformer transformer = factory.newTransformer();
+            DOMSource domSource = new DOMSource(document);
+            StreamResult streamResult = new StreamResult(writer);
+            transformer.transform(domSource, streamResult); 
+        } catch (TransformerException e) {
+            throw new RuntimeException(
+                    "Error when serializing XML document.", e);
         }
         return writer.toString();
     }

--- a/framework/test-src/play/libs/XMLTest.java
+++ b/framework/test-src/play/libs/XMLTest.java
@@ -1,0 +1,46 @@
+package play.libs;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.ByteArrayInputStream;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.w3c.dom.Document;
+
+/**
+ * Tests for {@link XML} class.
+ */
+public class XMLTest {
+
+    private static final String ORIGINAL_DOCUMENT =
+            "<?xml version=\"1.0\"?>\n" +
+            "<feed xmlns=\"http://www.w3.org/2005/Atom\">" +
+              "<title>Awesome Blog</title>" +
+              "<link href=\"http://blog.example.com/\"/>" +
+            "</feed>";
+    private Document document;
+    
+    @Before
+    public void setUp() throws Exception {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder builder = factory.newDocumentBuilder();
+        document = builder.parse(
+                new ByteArrayInputStream(ORIGINAL_DOCUMENT.getBytes("UTF-8")));
+    }
+
+    private static String stripPreamble(String text) {
+        return text.replaceFirst("<\\?[^?]+\\?>\\s*", "");
+    }
+    
+    @Test
+    public void serializeShouldReturnWellFormedXml() throws Exception {
+        String outputDocument = XML.serialize(document);
+        assertEquals(
+                stripPreamble(ORIGINAL_DOCUMENT),
+                stripPreamble(outputDocument));
+    }
+}


### PR DESCRIPTION
[#1094] Replace Sun proprietary API com.sun.org.apache.xml.internal.serialize.XMLSerializer with JAXP
