### PR TITLE
[#975] Fix for Map<String,String> parameter special case binding being in

### DIFF
--- a/framework/src/play/data/binding/Binder.java
+++ b/framework/src/play/data/binding/Binder.java
@@ -133,7 +133,7 @@ public class Binder {
                 // Special case Map<String, String>
                 // Multivalues composite params are binded to a Map<String, String>
                 // see http://play.lighthouseapp.com/projects/57987/tickets/443
-                if (keyClass==String.class && valueClass==String.class && isComposite(name, params)) {
+                if (keyClass==String.class && valueClass==String.class && suffix.length() == 0 && isComposite(name, params)) {
                     Map<String, String> stringMap = Utils.filterParams(params, name);
                     if (stringMap.size()>0) return stringMap;
                 }

--- a/framework/test-src/play/data/binding/BinderTest.java
+++ b/framework/test-src/play/data/binding/BinderTest.java
@@ -83,6 +83,36 @@ public class BinderTest {
 
     }
 
+
+    @Test
+    public void verifyBindingOfStringMaps() throws Exception {
+        Map<String, String[]> params = new HashMap<String, String[]>();
+
+        Map<String, String> specialCaseMap = new HashMap<String,String>();
+        params.put("specialCaseMap.a", new String[] {"AA"});
+        params.put("specialCaseMap.b", new String[] {"BB"});
+
+        specialCaseMap = (Map<String, String>)Binder.bind("specialCaseMap", specialCaseMap.getClass(), specialCaseMap.getClass(), noAnnotations, params);
+
+        assertThat(specialCaseMap.size()).isEqualTo(2);
+        assertThat(specialCaseMap.get("a")).isEqualTo("AA");
+        assertThat(specialCaseMap.get("b")).isEqualTo("BB");
+
+        Data3 data3;
+
+        params.put("data3.a", new String[] {"aAaA"});
+        params.put("data3.map[abc]", new String[] {"ABC"});
+        params.put("data3.map[def]", new String[] {"DEF"});
+
+        data3 = (Data3) Binder.bind("data3", Data3.class, Data3.class, noAnnotations, params);
+
+        assertThat(data3.a).isEqualTo("aAaA");
+        assertThat(data3.map.size()).isEqualTo(2);
+        assertThat(data3.map.get("abc")).isEqualTo("ABC");
+        assertThat(data3.map.get("def")).isEqualTo("DEF");
+    }
+
+
     /**
      * Transforms map from Unbinder to Binder
      * @param r map filled by Unbinder
@@ -177,4 +207,10 @@ class Data2 {
         result = 31 * result + (data1 != null ? data1.hashCode() : 0);
         return result;
     }
+}
+
+
+class Data3 {
+    public String a;
+    public Map<String, String> map = new HashMap<String, String>();
 }


### PR DESCRIPTION
[#975] Fix for Map<String,String> parameter special case binding being incorrectly applied to parameter class fields which are of type Map<String,String>.

Also a test included.
