### PR TITLE
Added a method for checking if a CtMethod has a specific Annotation 

### DIFF
--- a/framework/src/play/classloading/enhancers/Enhancer.java
+++ b/framework/src/play/classloading/enhancers/Enhancer.java
@@ -120,6 +120,23 @@ public abstract class Enhancer {
         }
         return false;
     }
+    
+    /**
+     * Test if a method has the provided annotation
+	 * @param ctMethod the javassist method representation
+	 * @param annotation fully qualified name of the annotation class eg."javax.persistence.Entity"
+	 * @return true if field has the annotation
+	 * @throws java.lang.ClassNotFoundException
+	 */
+    protected boolean hasAnnotation(CtMethod ctMethod, String annotation) throws ClassNotFoundException {
+        for (Object object : ctMethod.getAvailableAnnotations()) {
+            Annotation ann = (Annotation) object;
+            if (ann.annotationType().getName().equals(annotation)) {
+                return true;
+            }
+        }
+        return false;
+    }
 
     /**
      * Create a new annotation to be dynamically inserted in the byte code.


### PR DESCRIPTION
I'm developing a module for play that requires to check if a method has an Annotation for enhancing Models at bytecode. To my surprise, there are two methods for checking Class and Field Annotation, the only one missing is the one I needed: Method Annotation. So I added the missing method based on the other ones.
