### PR TITLE
[#1130] documentation: Ivy settings example  

### DIFF
--- a/documentation/manual/dependency.textile
+++ b/documentation/manual/dependency.textile
@@ -349,7 +349,7 @@ bc. Example3, reuse local maven repo and repository manager
         <ivy pattern="${local-maven2-pattern}.pom" />
         <artifact pattern="${local-maven2-pattern}(-[classifier]).[ext]" />
       </filesystem>
-      <!-- use repository manager as proxy to maven-central (and alle other repositories)--> 
+      <!-- use repository manager as proxy to maven-central (and all other repositories)--> 
       <ibiblio name="repomanager" m2compatible="true"root="http://your.repomanager.intra/path/to/repo" cache="default"/>
     </chain>
   </resolvers>


### PR DESCRIPTION
Example ivysettings to reuse:
- maven repo manager (no need to manage company internal repos in dependency.yml)
- local .m2 repo: saves discspace and bandwith
  -- with disable caching:locally deployed SNAPSHOT deps are resolved correctly

propably this configuration is relevant to a couple of users (and not easily found)
