### PR TITLE
#972 Download source artifacts to add them in IDE project files

### DIFF
--- a/framework/pym/play/commands/eclipse.py
+++ b/framework/pym/play/commands/eclipse.py
@@ -58,9 +58,18 @@ def execute(**kargs):
         playSourcePath=playSourcePath.replace('\\','/').capitalize()
 
     cpJarToSource = {}
+    lib_src = os.path.join(app.path, 'tmp/lib-src')
     for el in classpath:
+        # library sources jars in the lib directory
         if os.path.basename(el) != "conf" and el.endswith('-sources.jar'):
             cpJarToSource[el.replace('-sources', '')] = el
+
+        # pointers to source jars produced by 'play deps'
+        src_file = os.path.join(lib_src, os.path.basename(el) + '.src')
+        if os.path.exists(src_file):
+            f = file(src_file)
+            cpJarToSource[el] = f.readline().rstrip()
+            f.close()
 
     javadocLocation = {}
     for el in classpath:


### PR DESCRIPTION
This patch allows downloading the source jars for dependencies and allows the IDE commands (eclipsify, idealize, etc) to link dependencies jar files to their source jars directly into Ivy's cache.

Since the Python commands have no knowledge of Ivy, this works as follows:
- instruct Ivy to download source jars along with code jars
- store in {app}/tmp/lib-src/{artifact}src the absolute path to the source jar in Ivy's cache
- in the "eclipsify" command, use this information to associate libraries to their source jars

I don't know the project file structure of Netbeans and Idea, so haven't updated these.

Still need to figure out how to also download the source jars for Play-provided libraries.
