### PR TITLE
[#1152] evolutions should ignore cr & lf character

### DIFF
--- a/framework/src/play/db/Evolutions.java
+++ b/framework/src/play/db/Evolutions.java
@@ -397,7 +397,7 @@ public class Evolutions extends PlayPlugin {
                     StringBuffer sql_up = new StringBuffer();
                     StringBuffer sql_down = new StringBuffer();
                     StringBuffer current = new StringBuffer();
-                    for (String line : sql.split("[\n\r]")) {
+                    for (String line : sql.split("\r?\n")) {
                         if (line.trim().matches("^#.*[!]Ups")) {
                             current = sql_up;
                         } else if (line.trim().matches("^#.*[!]Downs")) {


### PR DESCRIPTION
This should fix the evolutions inconsistent hash problem between OS X and Win7 
