### PR TITLE
Expose UUID of a Blob

### DIFF
--- a/framework/src/play/db/jpa/Blob.java
+++ b/framework/src/play/db/jpa/Blob.java
@@ -67,6 +67,10 @@ public class Blob implements BinaryField, UserType {
         }
         return file;
     }
+    
+    public String getUUID()  {
+        return UUID;
+    }
 
     //
 


### PR DESCRIPTION
Why is there no way to access the UUID of a Blob?
if I want to have an ID for a blob I need to use the hashCode...
Not very convenient if there already is a unique identifier.
