### PR TITLE
[#690] Fix parent path detection

### DIFF
--- a/framework/pym/play/utils.py
+++ b/framework/pym/play/utils.py
@@ -35,17 +35,9 @@ def secretKey():
     return ''.join([random.choice('ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789') for i in range(64)])
 
 def isParentOf(path1, path2):
-    if len(path2) < len(path1) or len(path2) < 2:
-        return False
-    if (path1 == path2):
-        return True
-    return isParentOf(path1, os.path.dirname(path2))
-
-def isParentOf(path1, path2):
-    if len(path2) < len(path1) or len(path2) < 2:
-        return False
-    if (path1 == path2):
-        return True
+    relpath = os.path.relpath(path1, path2)
+    ptn = '^\.\.(' + os.sep + '\.\.)*$'
+    return re.match(ptn, relpath) != None
 
 def getWithModules(args, env):
     withModules = []


### PR DESCRIPTION
with `os.path.relpath(path1, path2)`, only when it returns `'..'`, or `'../..'`,  etc.
then we know `path1` is parent of `path2`
