### PR TITLE
[#690] Fix parent path detection

### DIFF
--- a/framework/pym/play/utils.py
+++ b/framework/pym/play/utils.py
@@ -36,7 +36,7 @@ def secretKey():
 
 def isParentOf(path1, path2):
     relpath = os.path.relpath(path1, path2)
-    ptn = '^\.\.(' + os.sep + '\.\.)*$'
+    ptn = '^\.\.(' + ('\\\\' if os.sep == '\\' else os.sep)  + '\.\.)*$'
     return re.match(ptn, relpath) != None
 
 def getWithModules(args, env):


### PR DESCRIPTION
with os.path.relpath(path1, path2), only when it returns '..', or '../..', etc.
then we know path1 is parent of path2

regarding the pattern '^..(' + os.sep + '..)*$', if os.sep is '\', 
we need to escape it once more
