### PR TITLE
NPE fix

### DIFF
--- a/framework/src/play/db/jpa/JPAConfig.java
+++ b/framework/src/play/db/jpa/JPAConfig.java
@@ -91,7 +91,7 @@ public class JPAConfig {
             // This is the first time someone tries to use JPA in this thread.
             // we must initialize it
 
-            if(Invoker.InvocationContext.current().getAnnotation(NoTransaction.class) != null ) {
+            if(Invoker.InvocationContext.current() != null && Invoker.InvocationContext.current().getAnnotation(NoTransaction.class) != null ) {
                 //Called method or class is annotated with @NoTransaction telling us that
                 //we should not start a transaction
                 throw new JPAException("Cannot create JPAContext due to @NoTransaction");
@@ -101,10 +101,13 @@ public class JPAConfig {
             if (manualReadOnly!=null) {
                 readOnly = manualReadOnly;
             } else {
-                Transactional tx = Invoker.InvocationContext.current().getAnnotation(Transactional.class);
-                if (tx != null) {
-                    readOnly = tx.readOnly();
-                }
+               Invoker.InvocationContext invocationContext = Invoker.InvocationContext.current();
+               if (invocationContext != null) {
+                  Transactional tx = invocationContext.getAnnotation(Transactional.class);
+                  if (tx != null) {
+                     readOnly = tx.readOnly();
+                  }
+               }
             }
             context = new JPAContext(this, readOnly, JPAPlugin.autoTxs);
 


### PR DESCRIPTION
I am initializing a camelcontext in a Bootstrap class (annotated with @OnApplicationStart) and I configured a route like

```
from("sftp://someftphost").to(new FileProcessor());
```

The FileProcessor simply implements the Processor interface and in the process implementation I tried to manipulate entities by using JPA.em() and Entity.save() et.c. This failed due to NPEs two places in the JPAConfig file. Something is still not quite right since I have to manage transactions myself, but I can live with that for now.
