### PR TITLE
[#1217] Modified behavior of nl2br to escape html by default

### DIFF
--- a/framework/src/play/templates/JavaExtensions.java
+++ b/framework/src/play/templates/JavaExtensions.java
@@ -231,8 +231,12 @@ public class JavaExtensions {
         return format(new Date(timestamp), pattern, lang, timezone);
     }
 
-    public static RawData nl2br(Object data) {
+    public static RawData nl2br(RawData data) {
         return new RawData(data.toString().replace("\n", "<br/>"));
+    }
+
+    public static RawData nl2br(Object data) {
+        return new RawData(HTML.htmlEscape(data.toString()).replace("\n", "<br/>"));
     }
 
     public static String urlEncode(String entity) {


### PR DESCRIPTION
Modified method nl2br to:

```
public static RawData nl2br(Object data) {
    return new RawData(HTML.htmlEscape(data.toString()).replace("\n", "<br/>"));
}
```

Added method to use it also with RawData

```
public static RawData nl2br(RawData data) {
    return new RawData(data.toString().replace("\n", "<br/>"));
}
```

So it can be used as:

```
${something.raw().nl2br()}
```
