### PR TITLE
releasenotes-1.2.4.textile has typo.

### DIFF
--- a/documentation/manual/releasenotes-1.2.4.textile
+++ b/documentation/manual/releasenotes-1.2.4.textile
@@ -7,7 +7,7 @@ h2. Support for Java 7
 Play now supports Java 7 out-of-the-box, so you can write the following code without any problems.
 
 bc. Map<String, List<String>> map = new HashMap();
-String version = "1.24";
+String version = "1.2.4";
 switch(version) {
 	 case "1.2.4":
 	    //code


### PR DESCRIPTION
"1.24" is a mistake in "1.2.4" at "Support for Java 7". It is lack of ".". 
