### PR TITLE
[#1054] Tutorial: wrong assert in tutorial code.

### DIFF
--- a/documentation/manual/guide10.textile
+++ b/documentation/manual/guide10.textile
@@ -39,7 +39,7 @@ bc. …
 public void testAdminSecurity() {
     Response response = GET("/admin");
     assertStatus(302, response);
-    assertHeaderEquals("Location", "http://localhost/login", response);
+    assertHeaderEquals("Location", "/login", response);
 }
 …
 


### PR DESCRIPTION
This had already been fixed in the actual Yabe code, but now the tutorial text has been updated.
