### PR TITLE
fix OAuth2 retrieveVerificationCode looks for for existance of '?'

### DIFF
--- a/framework/src/play/libs/OAuth2.java
+++ b/framework/src/play/libs/OAuth2.java
@@ -44,7 +44,8 @@ public class OAuth2 {
      */
     public void retrieveVerificationCode(String callbackURL) {
         throw new Redirect(authorizationURL
-                + "?client_id=" + clientid
+                + (authorizationURL.contains("?") ? "&" : "?")
+                + "client_id=" + clientid
                 + "&redirect_uri=" + callbackURL);
     }
 


### PR DESCRIPTION
OAuth2.retrieveVerificationCode() does not look for existence of `?` in given callbackURL and appends `?` or `&` accordingly (fixes potential bug for the cases s.t. there are additional request params in authorization URL)
