### PR TITLE
[#1295] Don't require a request in JavaExtensions.urlEncode

### DIFF
--- a/framework/src/play/templates/JavaExtensions.java
+++ b/framework/src/play/templates/JavaExtensions.java
@@ -237,7 +237,11 @@ public class JavaExtensions {
 
     public static String urlEncode(String entity) {
         try {
-            return URLEncoder.encode(entity, Http.Response.current().encoding);
+            String encoding = play.Play.defaultWebEncoding;
+            if (Http.Response.current() != null) {
+                encoding = Http.Response.current().encoding;
+            }
+            return URLEncoder.encode(entity, encoding);
         } catch (UnsupportedEncodingException e) {
             Logger.error(e, entity);
         }


### PR DESCRIPTION
Framework version: 1.2.x

JavaExtensions.urlEncode should fall back to default encoding if there are no current request (e.g. rendering a template in a job) otherwise it would cause a NPE.

https://play.lighthouseapp.com/projects/57987-play-framework/tickets/1295
