### PR TITLE
[#1105] fix play_evolutions table creation for oracle db

### DIFF
--- a/framework/src/play/db/Evolutions.java
+++ b/framework/src/play/db/Evolutions.java
@@ -463,7 +463,6 @@ public class Evolutions extends PlayPlugin {
         String jpaDialect = Play.configuration.getProperty("jpa.dialect");
         if (jpaDialect != null) {
             try {
-                //Class<?> dialectClass = Class.forName(jpaDialect);
                 Class<?> dialectClass = Play.classloader.loadClass(jpaDialect);
 			
                 // Oracle 8i dialect is the base class for oracle dialects (at least for now)


### PR DESCRIPTION
I think I've fixed the oracle issue of the play_evolutions table not being created properly. At least in my testing the table is created and evolutions are able to be executed. Essentially I changed the "text" data type on the table to varchar(4000) and added another query to look for the table PLAY_EVOLUTIONS (oracle return uppercase table names).

I did not test this against other DBs so I don't know if varchar(4000) works for them. All the tests passed however.

Please make this part of 1.2.5!
