### PR TITLE
"Extreme" Lighthouse 1319 patch: Removed class Mail.Mock from Mail

### DIFF
--- a/framework/src/play/Play.java
+++ b/framework/src/play/Play.java
@@ -803,5 +803,8 @@ public class Play {
         }
     }
 
+    public static boolean useDefaultMockMailSystem() {
+        return configuration.getProperty("mail.smtp", "").equals("mock") && mode == Mode.DEV;
+    }
 
 }

--- a/framework/src/play/libs/mail/AbstractMailSystemFactory.java
+++ b/framework/src/play/libs/mail/AbstractMailSystemFactory.java
@@ -1,0 +1,9 @@
+package play.libs.mail;
+
+public abstract class AbstractMailSystemFactory {
+
+    public static final AbstractMailSystemFactory DEFAULT = new DefaultMailSystemFactory();
+
+    public abstract MailSystem currentMailSystem();
+
+}

--- a/framework/src/play/libs/mail/DefaultMailSystemFactory.java
+++ b/framework/src/play/libs/mail/DefaultMailSystemFactory.java
@@ -1,0 +1,20 @@
+package play.libs.mail;
+
+import play.Play;
+import play.libs.mail.test.LegacyMockMailSystem;
+
+class DefaultMailSystemFactory extends AbstractMailSystemFactory {
+
+    private static final MailSystem LEGACY_MOCK_MAIL_SYSTEM = new LegacyMockMailSystem();
+    private static final MailSystem PRODUCTION_MAIL_SYSTEM  = new ProductionMailSystem();
+
+    @Override
+    public MailSystem currentMailSystem() {
+        if (Play.useDefaultMockMailSystem()) {
+            return LEGACY_MOCK_MAIL_SYSTEM;
+        } else {
+            return PRODUCTION_MAIL_SYSTEM;
+        }
+    }
+
+}

--- a/framework/src/play/libs/mail/MailSystem.java
+++ b/framework/src/play/libs/mail/MailSystem.java
@@ -1,0 +1,11 @@
+package play.libs.mail;
+
+import java.util.concurrent.Future;
+
+import org.apache.commons.mail.Email;
+
+public interface MailSystem {
+
+    Future<Boolean> sendMessage(Email email);
+
+}

--- a/framework/src/play/libs/mail/ProductionMailSystem.java
+++ b/framework/src/play/libs/mail/ProductionMailSystem.java
@@ -1,0 +1,17 @@
+package play.libs.mail;
+
+import java.util.concurrent.Future;
+
+import org.apache.commons.mail.Email;
+
+import play.libs.Mail;
+
+class ProductionMailSystem implements MailSystem {
+
+    @Override
+    public Future<Boolean> sendMessage(Email email) {
+        email.setMailSession(Mail.getSession());
+        return Mail.sendMessage(email);
+    }
+
+}

--- a/framework/src/play/libs/mail/test/LegacyMockMailSystem.java
+++ b/framework/src/play/libs/mail/test/LegacyMockMailSystem.java
@@ -1,0 +1,143 @@
+package play.libs.mail.test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.Future;
+
+import javax.mail.BodyPart;
+import javax.mail.Message;
+import javax.mail.MessagingException;
+import javax.mail.Multipart;
+import javax.mail.Part;
+import javax.mail.Session;
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeMessage;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.mail.Email;
+
+import play.Logger;
+import play.libs.Mail;
+import play.libs.mail.MailSystem;
+import play.utils.ImmediateFuture;
+
+/**
+ * Just kept for compatibility reasons, use test double substitution mechanism instead.
+ *
+ * @see    Mail#Mock
+ * @see    Mail#useMailSystem(MailSystem)
+ * @author Andreas Simon <a.simon@quagilis.de>
+ */
+public class LegacyMockMailSystem implements MailSystem {
+
+    // Has to remain static to preserve the possibility of testing mail sending within Selenium tests
+    static Map<String, String> emails = new HashMap<String, String>();
+
+    @Override
+    public Future<Boolean> sendMessage(Email email) {
+        try {
+            final StringBuffer content = new StringBuffer();
+            Properties props = new Properties();
+            props.put("mail.smtp.host", "myfakesmtpserver.com");
+
+            Session session = Session.getInstance(props);
+            email.setMailSession(session);
+
+            email.buildMimeMessage();
+
+            MimeMessage msg = email.getMimeMessage();
+            msg.saveChanges();
+
+            String body = getContent(msg);
+
+            content.append("From Mock Mailer\n\tNew email received by");
+
+
+            content.append("\n\tFrom: " + email.getFromAddress().getAddress());
+            content.append("\n\tReplyTo: " + ((InternetAddress) email.getReplyToAddresses().get(0)).getAddress());
+
+            addAddresses(content, "To",  email.getToAddresses());
+            addAddresses(content, "Cc",  email.getCcAddresses());
+            addAddresses(content, "Bcc", email.getBccAddresses());
+
+            content.append("\n\tSubject: " + email.getSubject());
+            content.append("\n\t" + body);
+
+            content.append("\n");
+            Logger.info(content.toString());
+
+            for (Object add : email.getToAddresses()) {
+                content.append(", " + add.toString());
+                emails.put(((InternetAddress) add).getAddress(), content.toString());
+            }
+
+        } catch (Exception e) {
+            Logger.error(e, "error sending mock email");
+        }
+        return new ImmediateFuture();
+    }
+
+
+    private static String getContent(Part message) throws MessagingException,
+            IOException {
+
+        if (message.getContent() instanceof String) {
+            return message.getContentType() + ": " + message.getContent() + " \n\t";
+        } else if (message.getContent() != null && message.getContent() instanceof Multipart) {
+            Multipart part = (Multipart) message.getContent();
+            String text = "";
+            for (int i = 0; i < part.getCount(); i++) {
+                BodyPart bodyPart = part.getBodyPart(i);
+                if (!Message.ATTACHMENT.equals(bodyPart.getDisposition())) {
+                    text += getContent(bodyPart);
+                } else {
+                    text += "attachment: \n" +
+                   "\t\t name: " + (StringUtils.isEmpty(bodyPart.getFileName()) ? "none" : bodyPart.getFileName()) + "\n" +
+                   "\t\t disposition: " + bodyPart.getDisposition() + "\n" +
+                   "\t\t description: " +  (StringUtils.isEmpty(bodyPart.getDescription()) ? "none" : bodyPart.getDescription())  + "\n\t";
+                }
+            }
+            return text;
+        }
+        if (message.getContent() != null && message.getContent() instanceof Part) {
+            if (!Message.ATTACHMENT.equals(message.getDisposition())) {
+                return getContent((Part) message.getContent());
+            } else {
+                return "attachment: \n" +
+                       "\t\t name: " + (StringUtils.isEmpty(message.getFileName()) ? "none" : message.getFileName()) + "\n" +
+                       "\t\t disposition: " + message.getDisposition() + "\n" +
+                       "\t\t description: " + (StringUtils.isEmpty(message.getDescription()) ? "none" : message.getDescription()) + "\n\t";
+            }
+        }
+
+        return "";
+    }
+
+
+    private static void addAddresses(final StringBuffer content,
+            String header, List<?> ccAddresses) {
+        if (ccAddresses != null && !ccAddresses.isEmpty()) {
+            content.append("\n\t" + header + ": ");
+            for (Object add : ccAddresses) {
+                content.append(add.toString() + ", ");
+            }
+            removeTheLastComma(content);
+        }
+    }
+
+    private static void removeTheLastComma(final StringBuffer content) {
+        content.delete(content.length() - 2, content.length());
+    }
+
+
+    public String getLastMessageReceivedBy(String email) {
+        return emails.get(email);
+    }
+
+    public void reset(){
+        emails.clear();
+    }
+}

--- a/framework/src/play/utils/ImmediateFuture.java
+++ b/framework/src/play/utils/ImmediateFuture.java
@@ -1,0 +1,25 @@
+package play.utils;
+
+import java.util.concurrent.*;
+
+public final class ImmediateFuture implements Future<Boolean> {
+    public boolean cancel(boolean mayInterruptIfRunning) {
+        return false;
+    }
+
+    public boolean isCancelled() {
+        return false;
+    }
+
+    public boolean isDone() {
+        return true;
+    }
+
+    public Boolean get() throws InterruptedException, ExecutionException {
+        return true;
+    }
+
+    public Boolean get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+        return true;
+    }
+}

--- a/framework/test-src/play/libs/MailTest.java
+++ b/framework/test-src/play/libs/MailTest.java
@@ -1,65 +1,97 @@
 package play.libs;
 
+import static org.junit.Assert.*;
+
+import java.util.concurrent.Future;
+
 import org.apache.commons.mail.Email;
 import org.apache.commons.mail.EmailException;
 import org.apache.commons.mail.SimpleEmail;
+import org.junit.Before;
 import org.junit.Test;
 
 import play.PlayBuilder;
 import play.exceptions.MailException;
+import play.libs.mail.MailSystem;
+import play.utils.ImmediateFuture;
 
 public class MailTest {
 
-	@Test(expected = MailException.class)
-	public void buildMessageWithoutFrom() throws EmailException {
+	private static class SpyingMailSystem implements MailSystem {
+		public Email receivedEmail = null;
+
+		@Override
+		public Future<Boolean> sendMessage(Email email) {
+			receivedEmail = email;
+			return new ImmediateFuture();
+		}
+	}
+
+	private Email simpleEmail;
+	private SpyingMailSystem spyingMailSystem;
+
+	@Before
+	public void initializeFixture() throws Exception {
 		new PlayBuilder().build();
 
-		Email email = new SimpleEmail();
-		email.addTo("from@playframework.org");
-		email.setSubject("subject");
+		simpleEmail =
+			new SimpleEmail()
+				.setFrom("from@playframework.org")
+				.addTo("to@playframework.org")
+				.setSubject("subject");
+
+		spyingMailSystem = new SpyingMailSystem();
+	}
+
+	@Test(expected = MailException.class)
+	public void buildMessageWithoutFrom() throws EmailException {
+		Email emailWithoutFrom = new SimpleEmail();
+		emailWithoutFrom.addTo("from@playframework.org");
+		emailWithoutFrom.setSubject("subject");
 		Mail.buildMessage(new SimpleEmail());
 	}
 
 	@Test(expected = MailException.class)
 	public void buildMessageWithoutRecipient() throws EmailException {
-		new PlayBuilder().build();
-
-		Email email = new SimpleEmail();
-		email.setFrom("from@playframework.org");
-		email.setSubject("subject");
-		Mail.buildMessage(email);
+		Email emailWithoutRecipients =
+			new SimpleEmail()
+				.setFrom("from@playframework.org")
+				.setSubject("subject");
+		Mail.buildMessage(emailWithoutRecipients);
 	}
 
 	@Test(expected = MailException.class)
 	public void buildMessageWithoutSubject() throws EmailException {
-		new PlayBuilder().build();
-
-		Email email = new SimpleEmail();
-		email.setFrom("from@playframework.org");
-		email.addTo("to@playframework.org");
-		Mail.buildMessage(email);
+		Email emailWithoutSubject = new SimpleEmail();
+		emailWithoutSubject.setFrom("from@playframework.org");
+		emailWithoutSubject.addTo("to@playframework.org");
+		Mail.buildMessage(emailWithoutSubject);
 	}
 
 	@Test
 	public void buildValidMessages() throws EmailException {
-		new PlayBuilder().build();
-
-		Email email = new SimpleEmail();
-		email.setFrom("from@playframework.org");
-		email.addTo("to@playframework.org");
-		email.setSubject("subject");
-		Mail.buildMessage(email);
-
-		email = new SimpleEmail();
-		email.setFrom("from@playframework.org");
-		email.addCc("to@playframework.org");
-		email.setSubject("subject");
-		Mail.buildMessage(email);
-
-		email = new SimpleEmail();
-		email.setFrom("from@playframework.org");
-		email.addBcc("to@playframework.org");
-		email.setSubject("subject");
-		Mail.buildMessage(email);
+		Mail.buildMessage(
+			emailWitoutRecipients().addTo("to@playframework.org"));
+		Mail.buildMessage(
+			emailWitoutRecipients().addCc("cc@playframework.org"));
+		Mail.buildMessage(
+			emailWitoutRecipients().addBcc("bcc@playframework.org"));
 	}
+
+	protected Email emailWitoutRecipients() throws EmailException {
+		return
+			new SimpleEmail()
+				.setFrom("from@playframework.org")
+				.setSubject("subject");
+	}
+
+	@Test
+	public void mailSystemShouldBeSubstitutable() throws Exception {
+		Mail.useMailSystem(spyingMailSystem);
+
+		Mail.send(simpleEmail);
+
+		assertEquals(simpleEmail, spyingMailSystem.receivedEmail);
+	}
+
 }


### PR DESCRIPTION
Compared to andreassimon:lighthouse-1319-patch, this one goes quite a step further. The inner class Mail.Mock is extracted to a top-level class LegacyMockMailSystem. But a _constant_ named Mail.Mock is left. This way, the invocations of

`````` Mail.Mock.getLastMessageReceivedBy(String)```
and
```Mail.Mock.reset()```
remain valid.

I must admit that I encountered problems though: I wanted to assure that my modifications don't break any existing apps. Thus, I frequently ran
``````

cd framework
ant test

```
During development, test suites
 * just-test-cases,
 * i-am-a-developer, and
 * yabe
failed sometimes. Unfortunately, the test results were NOT RELIABLY REPRODUCIBLE. I would very much appreciate if some of you could help me stabilize this patch :-)
```
