### PR TITLE
Add jvm.memory to parameters for nb run targets

### DIFF
--- a/framework/build.xml
+++ b/framework/build.xml
@@ -154,6 +154,7 @@
             <jvmarg value="-Xdebug"/>
             <jvmarg value="-Xrunjdwp:transport=dt_socket,address=${jpda.port},server=y,suspend=n"/>
             <jvmarg value="${profiler.info.jvmargs.agent}"/>
+            <jvmarg value="${jvm.memory}"/>
         </java>	
     </target>
 
@@ -177,6 +178,7 @@
             <jvmarg value="-javaagent:${basedir}/play-${version}.jar" />
             <jvmarg value="-Xdebug"/>
             <jvmarg value="-Xrunjdwp:transport=dt_socket,address=${jpda.port},server=y,suspend=n"/>
+            <jvmarg value="${jvm.memory}"/>
         </java>	
     </target>
 


### PR DESCRIPTION
Change to use the jvm.memory parameters also when running from within a netbeans build
