### PR TITLE
Lighthouse [#1337] removed ambigeous log statement

### DIFF
--- a/framework/src/play/libs/ws/WSAsync.java
+++ b/framework/src/play/libs/ws/WSAsync.java
@@ -205,7 +205,6 @@ public class WSAsync implements WSImpl {
             try {
                 return new HttpAsyncResponse(prepare(prepareGet()).execute().get());
             } catch (Exception e) {
-                Logger.error(e.toString());
                 throw new RuntimeException(e);
             }
         }


### PR DESCRIPTION
Since post(), put() etc. don't do Logger.error() I removed it from get() as well to keep consistency. Also I believe it is really up to the application to log such errors.

Signed-off-by: Matthias van der Vlies mvdvlies@gmail.com
