### PR TITLE
[#1363] Fix reponse.writeChunk() cannot send multibyte string data when response.encoding is not UTF-8

### DIFF
--- a/framework/src/play/server/PlayHandler.java
+++ b/framework/src/play/server/PlayHandler.java
@@ -1011,7 +1011,7 @@ public class PlayHandler extends SimpleChannelUpstreamHandler {
             if (nextChunks.isEmpty()) {
                 return null;
             }
-            return wrappedBuffer(((String) nextChunks.poll()).getBytes());
+            return wrappedBuffer(((String) nextChunks.poll()).getBytes(Response.current().encoding));
         }
 
         public boolean isEndOfInput() throws Exception {


### PR DESCRIPTION
https://play.lighthouseapp.com/projects/57987/tickets/1363-reponsewritechunk-cannot-send-multibyte-string-data-when-responseencoding-is-not-utf-8
