### PR TITLE
Change to help support lists in fixtures

### DIFF
--- a/framework/src/play/test/Fixtures.java
+++ b/framework/src/play/test/Fixtures.java
@@ -239,6 +239,12 @@ public class Fixtures {
                                 if (f.getType().isAssignableFrom(Map.class)) {
                                     f.set(model, objects.get(key).get(f.getName()));
                                 }
+                                if (f.getType().isAssignableFrom(List.class)) {
+				    // Each element of values is likely a LinkedHashMap.
+				    @SuppressWarnings("unchecked")
+				    List values = (List) objects.get(key).get(f.getName());
+                                    f.set(model, values);
+                                }
                                 if (f.getType().equals(byte[].class)) {
                                     f.set(model, objects.get(key).get(f.getName()));
                                 }


### PR DESCRIPTION
This step appears to be necessary but not quite sufficient to support
lists in fixtures. For example, for NoSQL backends such as MongoDB, it is
imperative that the following can be loaded as a fixture:

ShoppingList:
  name: "Groceries"
  items:
    - Item:
        price: 4.99
        name: "milk"
    - Item:
        price: 3.99
        name: "crackers"

Without this change, Morphia receives null objects in the items field.

Nevertheless, this change would benefit from review by someone who is
more familiar with the code.
