### PR TITLE
Lighthouse 1240 patch

### DIFF
--- a/framework/src/play/server/PlayHandler.java
+++ b/framework/src/play/server/PlayHandler.java
@@ -1105,16 +1105,6 @@ public class PlayHandler extends SimpleChannelUpstreamHandler {
             return;
         }
 
-        if ("8".equals(version)) {
-            res.addHeader(SEC_WEBSOCKET_ORIGIN, req.getHeader(ORIGIN));
-        } else if ("13".equals(version)) {
-            res.addHeader(ORIGIN, req.getHeader(ORIGIN));
-        } else {
-            if (Logger.isDebugEnabled()) {
-                Logger.debug("Client request does not have origin header");
-            }
-        }
-
         String key = req.getHeader("Sec-WebSocket-Key");
         if(key == null) {
             res.setStatus(HttpResponseStatus.BAD_REQUEST);


### PR DESCRIPTION
This patch implements the latest WebSocket protocol (Hybi13).

It follows ths Chromium changeset : http://trac.webkit.org/changeset/97249.
The official description can be found on http://tools.ietf.org/html/draft-ietf-hybi-thewebsocketprotocol-13.
A summary of the changes is available here : http://updates.html5rocks.com/2011/10/WebSockets-updated-to-latest-version-in-Chrome-Canary

It has been tested on Chrome 16.0.912.75 (Hybi13) and Firefox 9.0.1 (Hybi 8) .

It would be great if this patch could be integrated in the 1.2.5 version of Play! since WebSockets do not work with the latest official version of Google Chrome.
