### PR TITLE
[#1364] Fixed XForwardedSupport to accept commas and spaces

### DIFF
--- a/framework/src/play/mvc/Http.java
+++ b/framework/src/play/mvc/Http.java
@@ -374,7 +374,7 @@ public class Http {
 
         protected void parseXForwarded() {
             if (Play.configuration.containsKey("XForwardedSupport") && headers.get("x-forwarded-for") != null) {
-                if (!Arrays.asList(Play.configuration.getProperty("XForwardedSupport", "127.0.0.1").split(",")).contains(remoteAddress)) {
+                if (!Arrays.asList(Play.configuration.getProperty("XForwardedSupport", "127.0.0.1").split("[\\s,]+")).contains(remoteAddress)) {
                     throw new RuntimeException("This proxy request is not authorized: " + remoteAddress);
                 } else {
                     secure = isRequestSecure();

--- a/samples-and-tests/just-test-cases/conf/application.conf
+++ b/samples-and-tests/just-test-cases/conf/application.conf
@@ -159,3 +159,5 @@ utf8value = 欢迎
 
 %test.@include.filesToInclude=includedApplication.conf
 %prod.@include.filesToInclude=this-file-should-not-be-included.conf
+
+XForwardedSupport=127.0.0.1,1.2.3.4, 5.5.5.5

--- a/samples-and-tests/just-test-cases/test/XForwardedSupportTest.java
+++ b/samples-and-tests/just-test-cases/test/XForwardedSupportTest.java
@@ -1,0 +1,91 @@
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+import play.Logger;
+import play.mvc.Http.Header;
+import play.mvc.Http.Request;
+import play.mvc.Http.Response;
+import play.test.FunctionalTest;
+
+
+public class XForwardedSupportTest extends FunctionalTest {
+	private static final String xForwardedFor = "10.10.10.10";
+	private static final String PAGE_URL = "/users/list";
+	private static final String HEADER_XFORWARDED_FOR = "x-forwarded-for";
+
+    @Test
+    public void testValidXForwards() throws Exception {
+    	//Values from application.conf (with commas and comma-spaces for delimiters)
+    	//XForwardedSupport=127.0.0.1,1.2.3.4, 5.5.5.5
+    	//These are valid remoteAddresses
+
+  		String remoteAddress = "1.2.3.4";
+		assertValidTest(remoteAddress, xForwardedFor);
+
+  		remoteAddress = "127.0.0.1";
+		assertValidTest(remoteAddress, xForwardedFor);
+
+  		remoteAddress = "5.5.5.5";
+		assertValidTest(remoteAddress, xForwardedFor);
+	}
+	
+	@Test
+    public void testInvalidXForwards() throws Exception {
+  		String remoteAddress = "1.2.3.5";
+		assertInvalidTest(remoteAddress, xForwardedFor);
+
+  		remoteAddress = "6.6.6.6";
+		assertInvalidTest(remoteAddress, xForwardedFor);
+    }
+
+	private void assertValidTest(String remoteAddress, String xForwardedFor) {
+		Request request = getRequest(remoteAddress, xForwardedFor);
+		Response response = GET(request, PAGE_URL); 
+		assertIsOk(response);
+		
+		//remoteAddress should be changed to xForwardedFor address
+		assertEquals(xForwardedFor, request.remoteAddress);
+	}
+
+	private void assertInvalidTest(String remoteAddress, String xForwardedFor) {
+		try {
+			Request request = getRequest(remoteAddress, xForwardedFor);
+			Response response = GET(request, PAGE_URL);
+			fail("XForwarded request should have thrown a runtime exception.");
+		} catch (RuntimeException re) {
+			assertTrue(re.getMessage().contains(remoteAddress));
+		}
+	}
+
+	private Request getRequest(String remoteAddress, String xForwardedFor) {
+        Map<String, Header> headers = new HashMap<String, Header>();
+
+        Header header = new Header();
+        header.name = HEADER_XFORWARDED_FOR;
+        header.values = Arrays.asList(new String[]{xForwardedFor});
+
+        headers.put(HEADER_XFORWARDED_FOR, header);
+
+		Request request = Request.createRequest(
+                remoteAddress,
+                "GET",
+                "/",
+                "",
+                null,
+                null,
+                null,
+                null,
+                false,
+                80,
+                "localhost",
+                false,
+                headers,
+                null
+        );
+ 
+ 		return request;
+	}
+}


### PR DESCRIPTION
Third time is the charm.

I've included in this patch:
- The updated Http.java file with the new regex to support commas and spaces
- A new functional test to prove it is working
- The updated application.conf with a setting for XForwardedSupport set for testing purposes
