### PR TITLE
[#1395] Fix orphan removal bug caused by bad binding of collection prope...

### DIFF
--- a/framework/src/play/db/jpa/GenericModel.java
+++ b/framework/src/play/db/jpa/GenericModel.java
@@ -160,6 +160,7 @@ public class GenericModel extends JPABase {
             }
             ParamNode beanNode = rootParamNode.getChild(name, true);
             Binder.bindBean(beanNode, o, annotations);
+            o = ((GenericModel)o).merge();
             return (T) o;
         } catch (Exception e) {
             throw new UnexpectedException(e);


### PR DESCRIPTION
...rties

Now when a collection property is going to binded instead of overwrite it's value with a new collection. The original collection is obtained and cleared. So if the collection is a persistent one the value are merged correctly. It also performs a merge of the object in the JPA Plugin so now it is not necesary to merge the object in the controller.
