### PR TITLE
Secure header 1.2.x

### DIFF
--- a/framework/src/play/mvc/Http.java
+++ b/framework/src/play/mvc/Http.java
@@ -405,7 +405,12 @@ public class Http {
             if (xForwardedSslHeader != null && "on".equals(xForwardedSslHeader.value())) {
                 return true;
             }
-        	
+			
+            Header frontEndHttpsHeader = request.headers.get("front-end-https");
+            if (frontEndHttpsHeader != null && "on".equals(frontEndHttpsHeader.value().toLowerCase())) {
+                return true;
+            }
+
             return false;
         }
 


### PR DESCRIPTION
Checking the less common "Front-End-Https" header, used apparently only by "Microsoft Internet Security and Acceleration Server" and Squid when using Squid as a SSL frontend, when determining wether a request is secure.
