### PR TITLE
[#1427] Add support for getting HTTP status message from HttpResponse

### DIFF
--- a/framework/src/play/libs/WS.java
+++ b/framework/src/play/libs/WS.java
@@ -539,6 +539,12 @@ public class WS extends PlayPlugin {
         public abstract Integer getStatus();
 
         /**
+         * The HTTP status text
+         * @return the status text of the http response
+         */
+        public abstract String getStatusText();
+
+        /**
          * @return true if the status code is 20x, false otherwise
          */
         public boolean success() {

--- a/framework/src/play/libs/ws/WSAsync.java
+++ b/framework/src/play/libs/ws/WSAsync.java
@@ -555,6 +555,15 @@ public class WSAsync implements WSImpl {
             return this.response.getStatusCode();
         }
 
+        /**
+         * the HTTP status text
+         * @return the status text of the http response
+         */
+        @Override
+        public String getStatusText() {
+            return this.response.getStatusText();
+        }
+
         @Override
         public String getHeader(String key) {
             return response.getHeader(key);

--- a/framework/src/play/libs/ws/WSUrlFetch.java
+++ b/framework/src/play/libs/ws/WSUrlFetch.java
@@ -266,6 +266,7 @@ public class WSUrlFetch implements WSImpl {
 
         private String body;
         private Integer status;
+        private String statusText;
         private Map<String, List<String>> headersMap;
 
         /**
@@ -275,6 +276,7 @@ public class WSUrlFetch implements WSImpl {
         public HttpUrlfetchResponse(HttpURLConnection connection) {
             try {
                 this.status = connection.getResponseCode();
+                this.statusText = connection.getResponseMessage();
                 this.headersMap = connection.getHeaderFields();
                 InputStream is = null;
                 if (this.status >= HttpURLConnection.HTTP_BAD_REQUEST) {
@@ -298,6 +300,15 @@ public class WSUrlFetch implements WSImpl {
         @Override
         public Integer getStatus() {
             return status;
+        }
+
+        /**
+         * the HTTP status text
+         * @return the status text of the http response
+         */
+        @Override
+        public String getStatusText() {
+            return statusText;
         }
 
         @Override


### PR DESCRIPTION
It makes sense to be able to retrieve not only the status code, but also the status message. Perhaps it also makes sense to rename WS.HttpResponse.getStatus() to WS.HttpResponse.getStatusCode()? I did not do this for this commit as I wanted to keep the API backwards compatible.

Signed-off-by: Matthias van der Vlies matthias@lancelot-telecom.nl
