### PR TITLE
Small fix to the DBPlugin for non-localhost development...

### DIFF
--- a/framework/src/play/db/DBPlugin.java
+++ b/framework/src/play/db/DBPlugin.java
@@ -33,15 +33,21 @@ public class DBPlugin extends PlayPlugin {
             if (h2Server != null) {
                 h2Server.stop();
             }
-            if(!request.domain.equals("localhost")) {
-                serverOptions = new String[] {"-webAllowOthers"};
-            }
-            h2Server = org.h2.tools.Server.createWebServer(serverOptions);
-            h2Server.start();
 
+            // Determine if the host should be "localhost"
             String domain = request.domain;
             if (domain.equals(""))
               domain = "localhost";
+
+            // If the domain is not localhost, then turn on webAllowOthers
+            // so that other hosts may access the console
+            if(!domain.equals("localhost")) {
+                serverOptions = new String[] {"-webAllowOthers"};
+            }
+
+            h2Server = org.h2.tools.Server.createWebServer(serverOptions);
+            h2Server.start();
+
             response.setHeader("Location", "http://" + domain + ":8082/");
             return true;
         }


### PR DESCRIPTION
For situations where you are not developing on localhost (e.g. play is runnign on a local VM that you are accessing from your host machine) detect that a request for @db has come in from a host other than localhost and start up the h2 database with the correct options to allow a connection from a different machine, then redirect to the correct domain.

I ran into this situation while running my Play instance in an Ubuntu VM on my Mac.  The fix is pretty insignificant and only affects applications running in dev mode.
