### PR TITLE
[#997] Evolutions fix refinement for DO blocks

### DIFF
--- a/framework/test-src/play/db/SQLSplitterTest.java
+++ b/framework/test-src/play/db/SQLSplitterTest.java
@@ -69,6 +69,25 @@ public class SQLSplitterTest {
 		assertEquals(13, SQLSplitter.consumeQuote("$1$$f$\n$f$$1$a", 0));
 	}
 
+
+	@Test
+	public void verifySkipParentheses() {
+		assertEquals(4, SQLSplitter.consumeParentheses("(())", 0));
+		assertEquals(4, SQLSplitter.consumeParentheses("(())a", 0));
+		assertEquals(5, SQLSplitter.consumeParentheses("((b))a", 0));
+		assertEquals(7, SQLSplitter.consumeParentheses("(c(b)c)a", 0));
+		assertEquals(7, SQLSplitter.consumeParentheses("(c(\n)c)a", 0));
+		assertEquals(7, SQLSplitter.consumeParentheses("((')'))a", 0));
+		assertEquals(9, SQLSplitter.consumeParentheses("((/*)*/))a", 0));
+		assertEquals(14, SQLSplitter.consumeParentheses("(name varchar);", 0));
+	}
+
+	@Test
+	public void verifyTrailingParenthesis() {
+		assertEquals(1, SQLSplitter.consumeParentheses("(", 0));
+		assertEquals(3, SQLSplitter.consumeParentheses("(()", 0));
+	}
+
 	String readFile(final String filename) throws Exception {
 		final File src = new File(getClass().getResource(filename).toURI());
 		final byte [] srcbytes = new byte[(int)src.length()];

--- a/framework/test-src/play/db/test.out.sql
+++ b/framework/test-src/play/db/test.out.sql
@@ -20,4 +20,12 @@ BEGIN
 	RETURN;
 END;
 $function$
-LANGUAGE plpgsql;
+LANGUAGE plpgsql;===
+CREATE RULE test7
+ AS ON UPDATE to titles
+ DO ALSO (
+   INSERT INTO title_acl VALUES (DEFAULT, NEW.title_id, OLD.user_id, 'editor');
+   INSERT INTO title_acl VALUES (DEFAULT, NEW.title_id, NEW.user_id, 'owner')
+ );===
+ CREATE EXTENSION test8/**/;===
+ CREATE TABLE test9(name varchar);

--- a/framework/test-src/play/db/test.sql
+++ b/framework/test-src/play/db/test.sql
@@ -21,3 +21,11 @@ BEGIN
 END;
 $function$
 LANGUAGE plpgsql;
+CREATE RULE test7
+ AS ON UPDATE to titles
+ DO ALSO (
+   INSERT INTO title_acl VALUES (DEFAULT, NEW.title_id, OLD.user_id, 'editor');
+   INSERT INTO title_acl VALUES (DEFAULT, NEW.title_id, NEW.user_id, 'owner')
+ );
+ CREATE EXTENSION test8/**/;
+ CREATE TABLE test9(name varchar);


### PR DESCRIPTION
Our web app based on Play has this kind of code (note the semicolon inside the parenthesis):

```
CREATE RULE r
 AS ON UPDATE to table_a
 DO ALSO (
   INSERT INTO table_b VALUES (NEW.a);
   INSERT INTO table_c VALUES (NEW.a)
 );
```

Which I failed to take into account (or more like I didn't know that existed until our db programmer brought it up). This should fix it (I also threw in more test cases as a bonus).
