### PR TITLE
Fix for bug 1465

### DIFF
--- a/framework/src/play/test/FunctionalTest.java
+++ b/framework/src/play/test/FunctionalTest.java
@@ -228,6 +228,7 @@ public abstract class FunctionalTest extends BaseTest {
         request.path = path;
         request.querystring = queryString;
         request.body = new ByteArrayInputStream(body.getBytes());
+	if (savedCookies != null) request.cookies = savedCookies;
         return makeRequest(request);
     }
 


### PR DESCRIPTION
https://play.lighthouseapp.com/projects/57987-play-framework/tickets/1465-put-requests-in-functional-tests-do-not-remember-saved-cookies
