### PR TITLE
[#1466] Remove cookies with maxAge from savedCookies

### DIFF
--- a/framework/src/play/test/FunctionalTest.java
+++ b/framework/src/play/test/FunctionalTest.java
@@ -292,6 +292,10 @@ public abstract class FunctionalTest extends BaseTest {
                 // 0, they discard immediately.
                 if(e.getValue().maxAge == null || e.getValue().maxAge > 0) {
                     savedCookies.put(e.getKey(), e.getValue());
+                } else {
+                    // cookies with maxAge zero still remove a previously existing cookie,
+                    // like PLAY_FLASH.
+                    savedCookies.remove(e.getKey());
                 }
             }
             response.out.flush();


### PR DESCRIPTION
Cookies with maxAge 0 should be deleted by the browser. Scope.Flash.save() uses this to
clear the PLAY_FLASH cookie.

FunctionalTest simply ignores cookies with maxAge 0 completely. This patch ensures that
a cookie with maxAge 0 will delete a previous cookie if it exists.

The cookie emulation still ignores paths, so theoretically a maxAge zero cookie for path
/foo would delete a cookie for path /, but in practice this should not occur in test cases.
