### PR TITLE
[#1439] Added code branch to deal with JPA-based models separately ...

### DIFF
--- a/framework/src/play/test/Fixtures.java
+++ b/framework/src/play/test/Fixtures.java
@@ -464,10 +464,13 @@ public class Fixtures {
 
 
         // Iterate through the Entity property list
-        // @Embedded are not managed by the JPA plugin
-        // This is not the nicest way of doing things.
-         //modelFields =  Model.Manager.factoryFor(type).listProperties();
-        final List<Model.Property> modelFields =  new JPAPlugin.JPAModelLoader(type).listProperties();
+	List<Model.Property> modelFields;
+
+	if ( play.db.jpa.GenericModel.class.isAssignableFrom(type) ) {
+	    modelFields =  new JPAPlugin.JPAModelLoader(type).listProperties();
+	} else {
+	    modelFields =  Model.Manager.factoryFor(type).listProperties();
+	}
 
         for (Model.Property field : modelFields) {
             // If we have a relation, get the matching object


### PR DESCRIPTION
...from generic models; so plug-ins like Morphia can deal with their own embedded types

Basically - only uses JPAPlugin.JPAModelLoader when the fixture model is derived from GenericModel; otherwise allow embedded classes to build themselves normally. This fixes Morphia's ModelFactory as well as any other plug-in that requires relationship binding
