### PR TITLE
[#1441] The DBPlugin does not support non-localhost development... 

### DIFF
--- a/framework/src/play/db/DBPlugin.java
+++ b/framework/src/play/db/DBPlugin.java
@@ -27,17 +27,25 @@ public class DBPlugin extends PlayPlugin {
     public boolean rawInvocation(Request request, Response response) throws Exception {
         if (Play.mode.isDev() && request.path.equals("/@db")) {
             response.status = Http.StatusCode.MOVED;
+            String serverOptions[] = new String[] { };
 
             // For H2 embeded database, we'll also start the Web console
             if (h2Server != null) {
                 h2Server.stop();
             }
-            h2Server = org.h2.tools.Server.createWebServer();
-            h2Server.start();
 
             String domain = request.domain;
-            if (domain.equals(""))
-              domain = "localhost";
+            if (domain.equals("")) {
+                domain = "localhost";
+            }
+
+            if (!domain.equals("localhost")) {
+                serverOptions = new String[] {"-webAllowOthers"};
+            }
+            
+            h2Server = org.h2.tools.Server.createWebServer(serverOptions);
+            h2Server.start();
+
             response.setHeader("Location", "http://" + domain + ":8082/");
             return true;
         }


### PR DESCRIPTION
(NOTE: I have been bouncing back and forth with mbknor on this one because I am somewhat git-challenged.  I think now that I have gone through the proper steps to set up the branch, so merging the actual fix for the problem will hopefully be trivial...)

For situations where you are not developing on localhost (e.g. play is runnign on a local VM that you are accessing from your host machine) detect that a request for @db has come in from a host other than localhost and start up the h2 database with the correct options to allow a connection from a different machine, then redirect to the correct domain.

I ran into this situation while running my Play instance in an Ubuntu VM on my Mac. The fix is pretty insignificant and only affects applications running in dev mode.

Framework version: Play 1.2.4

Platform you're using: Ubuntu (on VirtualBox on my Mac)

Reproduction steps: Got to :9000/@db, you'll be redirected to localhost:8082 which won't work because Play is running on the vm!
