### PR TITLE
[#1316] play idealize in 1.2.4 assumes default Java SDK is Java 6

### DIFF
--- a/framework/pym/play/commands/intellij.py
+++ b/framework/pym/play/commands/intellij.py
@@ -56,8 +56,10 @@ def execute(**kargs):
     replaceAll(imlFile, r'%MODULE_LIBRARIES%', jdXML)
     
     iprFile = os.path.join(app.path, application_name + '.ipr')
-    shutil.copyfile(os.path.join(play_env["basedir"], 'resources/idea/iprTemplate.xml'), iprFile)
-    replaceAll(iprFile, r'%PROJECT_NAME%', application_name)
+    # Only copy/create if missing to avoid overwriting customizations
+    if not os.path.exists(iprFile):
+        shutil.copyfile(os.path.join(play_env["basedir"], 'resources/idea/iprTemplate.xml'), iprFile)
+        replaceAll(iprFile, r'%PROJECT_NAME%', application_name)
     
 
     print "~ OK, the application is ready for Intellij Idea"


### PR DESCRIPTION
- Only copy/create IPR if missing to avoid overwriting customizations.
  This avoids loosing any manual changes.
- # 1246 already fixes the missing Java SDK setting.
