### PR TITLE
use realistic values for accept-language header

### DIFF
--- a/framework/src/play/i18n/Lang.java
+++ b/framework/src/play/i18n/Lang.java
@@ -181,21 +181,29 @@ public class Lang {
      * associated to the current Lang.
      */
     public static Locale getLocale() {
-        String lang = get();
-        Locale locale = getLocale(lang);
+        String localeStr = get();
+        Locale locale = getLocale(localeStr);
         if (locale != null) {
             return locale;
         }
         return Locale.getDefault();
     }
 
-     public static Locale getLocale(String lang) {
+     public static Locale getLocale(String localeStr) {
+        Locale langMatch = null;
         for (Locale locale : Locale.getAvailableLocales()) {
-            if (locale.getLanguage().equals(lang)) {
+            String lang = localeStr;
+            int splitPos = lang.indexOf("_");
+            if (splitPos > 0) {
+                lang = lang.substring(0, splitPos);
+            }
+            if (locale.toString().equalsIgnoreCase(localeStr)) {
                 return locale;
+            } else if (locale.getLanguage().equalsIgnoreCase(lang)) {
+                langMatch = locale;
             }
         }
-        return null;
+        return langMatch;
     }
 
 }

--- a/framework/test-src/play/i18n/LangTest.java
+++ b/framework/test-src/play/i18n/LangTest.java
@@ -1,15 +1,16 @@
 package play.i18n;
 
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.Locale;
+
 import org.junit.Test;
+
 import play.Play;
 import play.PlayBuilder;
 import play.mvc.Http;
 import play.test.FunctionalTest;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-
-import static org.fest.assertions.Assertions.*;
 
 public class LangTest {
 
@@ -61,50 +62,50 @@ public class LangTest {
         Http.Request req = FunctionalTest.newRequest();
         Http.Request.current.set(req);
         Lang.current.set(null);
-        assertThat(Lang.get()).isEqualTo("no");
+        assertLocale(new Locale("no"));
 
         // check only with accept-language,  without cookie value
         req = FunctionalTest.newRequest();
         req.headers.put("accept-language", new Http.Header("accept-language", "x"));
         Http.Request.current.set(req);
         Lang.current.set(null);
-        assertThat(Lang.get()).isEqualTo("no");
+        assertLocale(new Locale("no"));
 
         req = FunctionalTest.newRequest();
         req.headers.put("accept-language", new Http.Header("accept-language", "no"));
         Http.Request.current.set(req);
         Lang.current.set(null);
-        assertThat(Lang.get()).isEqualTo("no");
+        assertLocale(new Locale("no"));
 
         req = FunctionalTest.newRequest();
         req.headers.put("accept-language", new Http.Header("accept-language", "en"));
         Http.Request.current.set(req);
         Lang.current.set(null);
-        assertThat(Lang.get()).isEqualTo("en");
+        assertLocale(new Locale("en"));
 
         req = FunctionalTest.newRequest();
         req.headers.put("accept-language", new Http.Header("accept-language", "x,en"));
         Http.Request.current.set(req);
         Lang.current.set(null);
-        assertThat(Lang.get()).isEqualTo("en");
+        assertLocale(new Locale("en"));
 
         req = FunctionalTest.newRequest();
         req.headers.put("accept-language", new Http.Header("accept-language", "en-GB"));
         Http.Request.current.set(req);
         Lang.current.set(null);
-        assertThat(Lang.get()).isEqualTo("en_GB");
+        assertLocale(new Locale("en", "GB"));
 
         req = FunctionalTest.newRequest();
         req.headers.put("accept-language", new Http.Header("accept-language", "x,en-GB"));
         Http.Request.current.set(req);
         Lang.current.set(null);
-        assertThat(Lang.get()).isEqualTo("en_GB");
+        assertLocale(new Locale("en", "GB"));
 
         req = FunctionalTest.newRequest();
         req.headers.put("accept-language", new Http.Header("accept-language", "x,en-US"));
         Http.Request.current.set(req);
         Lang.current.set(null);
-        assertThat(Lang.get()).isEqualTo("en");
+        assertLocale(new Locale("en"));
 
         // check with cookie value
 
@@ -117,7 +118,7 @@ public class LangTest {
         req.headers.put("accept-language", new Http.Header("accept-language", "en"));
         Http.Request.current.set(req);
         Lang.current.set(null);
-        assertThat(Lang.get()).isEqualTo("en");
+        assertLocale(new Locale("en"));
 
         cookie = new Http.Cookie();
         cookie.name = "PLAY_LANG";
@@ -125,7 +126,7 @@ public class LangTest {
         req.cookies.put(cookie.name, cookie);
         Http.Request.current.set(req);
         Lang.current.set(null);
-        assertThat(Lang.get()).isEqualTo("en");
+        assertLocale(new Locale("en"));
 
         cookie = new Http.Cookie();
         cookie.name = "PLAY_LANG";
@@ -133,7 +134,7 @@ public class LangTest {
         req.cookies.put(cookie.name, cookie);
         Http.Request.current.set(req);
         Lang.current.set(null);
-        assertThat(Lang.get()).isEqualTo("en");
+        assertLocale(new Locale("en"));
 
         cookie = new Http.Cookie();
         cookie.name = "PLAY_LANG";
@@ -141,8 +142,13 @@ public class LangTest {
         req.cookies.put(cookie.name, cookie);
         Http.Request.current.set(req);
         Lang.current.set(null);
-        assertThat(Lang.get()).isEqualTo("en_GB");
+        assertLocale(new Locale("en", "GB"));
 
 
+    }
+
+    private void assertLocale(Locale locale) {
+      assertThat(Lang.get()).isEqualTo(locale.toString());
+      assertThat(Lang.getLocale()).isEqualTo(locale);
     }
 }


### PR DESCRIPTION
Fix for "Accept-Language" header value parsing (when country is included). Currently Play assumes that "Accept-Language" header values have the same format as Java locale (e.g. "en_GB") while the real format uses a dash instead of an underscore (e.g. "en-GB").
