### PR TITLE
Delete temporary files for chunk streams (on close) + Memory channel buffer (with threshold)

### DIFF
--- a/framework/src/play/server/FileChannelBuffer.java
+++ b/framework/src/play/server/FileChannelBuffer.java
@@ -1,275 +1,67 @@
 package play.server;
 
 
-import org.jboss.netty.buffer.*;
-
-import java.io.*;
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.nio.channels.GatheringByteChannel;
-import java.nio.channels.ScatteringByteChannel;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
 
 
 /**
  * Useless channel buffer only used to wrap the input stream....
  */
-public class FileChannelBuffer extends AbstractChannelBuffer implements WrappedChannelBuffer {
+public class FileChannelBuffer extends InputStreamChannelBuffer {
+	
+	/**
+	 * Classe permettant d'effacer le fichier temporaire en fin de lecture
+	 * @author Nicolas DOUILLET
+	 */
+	static class TmpFileInputStream extends FileInputStream {
+		File file;
+		
+		public TmpFileInputStream(File file) throws FileNotFoundException {
+			super(file);
+			this.file = file;
+		}
+
+		@Override
+		public void close() throws IOException {
+			super.close();
+			try {
+				file.delete();
+			} catch(Exception e) 
+			{
+				e.printStackTrace();
+			}
+		}
+	}
+	
+// --------------------------->
 
     private final FileInputStream is;
+    
+// --------------------------->
 
     public FileChannelBuffer(File file) {
+        this(file, false);
+    }
+    
+    public FileChannelBuffer(File file, boolean deleteOnClose) {
         if (file == null) {
             throw new NullPointerException("file");
         }
         try {
-            this.is = new FileInputStream(file);
+        	// maintain the previous FileInputStream in case of sombedody was using it !!
+            this.is = deleteOnClose ? new TmpFileInputStream(file) : new FileInputStream(file);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
 
+// --------------------------->
 
     public InputStream getInputStream() {
         return is;
-    }
-
-    public ChannelBuffer unwrap() {
-        throw new RuntimeException();
-    }
-
-    public ChannelBufferFactory factory() {
-        throw new RuntimeException();
-    }
-
-    public ByteOrder order() {
-        throw new RuntimeException();
-    }
-
-    public boolean isDirect() {
-        return true;
-    }
-
-    public boolean hasArray() {
-        return false;
-    }
-
-    public byte[] array() {
-        throw new RuntimeException();
-    }
-
-    public int arrayOffset() {
-        throw new RuntimeException();
-    }
-
-    @Override
-    public void discardReadBytes() {
-        throw new RuntimeException();
-    }
-
-    public void setByte(int index, byte value) {
-        throw new RuntimeException();
-    }
-
-    public void setBytes(int index, ChannelBuffer src, int srcIndex, int length) {
-        throw new RuntimeException();
-    }
-
-    public void setBytes(int index, byte[] src, int srcIndex, int length) {
-        throw new RuntimeException();
-    }
-
-    public void setBytes(int index, ByteBuffer src) {
-        throw new RuntimeException();
-    }
-
-    public void setShort(int index, short value) {
-        throw new RuntimeException();
-    }
-
-    public void setMedium(int index, int value) {
-        throw new RuntimeException();
-    }
-
-    public void setInt(int index, int value) {
-        throw new RuntimeException();
-    }
-
-    public void setLong(int index, long value) {
-        throw new RuntimeException();
-    }
-
-    public int setBytes(int index, InputStream in, int length)
-            throws IOException {
-        throw new RuntimeException();
-    }
-
-    public int setBytes(int index, ScatteringByteChannel in, int length)
-            throws IOException {
-        throw new RuntimeException();
-
-    }
-
-    public int readerIndex() {
-        return 0;
-    }
-
-
-    public int getBytes(int index, GatheringByteChannel out, int length)
-            throws IOException {
-        byte[] b = new byte[length];
-        is.read(b, index, length);
-        ByteBuffer bb = ByteBuffer.wrap(b);
-        return out.write(bb);
-    }
-
-    public void setByte(int i, int i1) {
-        throw new RuntimeException();
-    }
-
-    public void getBytes(int index, OutputStream out, int length)
-            throws IOException {
-        byte[] b = new byte[length];
-        is.read(b, index, length);
-        out.write(b, index, length);
-    }
-
-    public void getBytes(int index, byte[] dst, int dstIndex, int length) {
-        try {
-            byte[] b = new byte[length];
-            is.read(b, index, length);
-            System.arraycopy(b, 0, dst, dstIndex, length);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    public void getBytes(int index, ChannelBuffer dst, int dstIndex, int length) {
-        try {
-            byte[] b = new byte[length];
-            is.read(b, index, length);
-            dst.writeBytes(b, dstIndex, length);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    public void getBytes(int index, ByteBuffer dst) {
-        try {
-            byte[] b = new byte[is.available() - index];
-            is.read(b, index, is.available() - index);
-            dst.put(b);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    public ChannelBuffer duplicate() {
-        throw new RuntimeException();
-    }
-
-    public ChannelBuffer copy(int index, int length) {
-        throw new RuntimeException();
-    }
-
-    public ChannelBuffer slice(int index, int length) {
-        throw new RuntimeException();
-    }
-
-    public byte getByte(int index) {
-        throw new RuntimeException();
-    }
-
-    public short getShort(int index) {
-        throw new RuntimeException();
-    }
-
-    public int getUnsignedMedium(int index) {
-        throw new RuntimeException();
-
-    }
-
-    public int getInt(int index) {
-        throw new RuntimeException();
-
-    }
-
-    public long getLong(int index) {
-        throw new RuntimeException();
-
-    }
-
-    public ByteBuffer toByteBuffer(int index, int length) {
-        throw new RuntimeException();
-    }
-
-    @Override
-    public ByteBuffer[] toByteBuffers(int index, int length) {
-        throw new RuntimeException();
-    }
-
-    public int capacity() {
-        try {
-            return is.available();
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-
-    }
-
-    public ChannelBuffer readBytes(int length) {
-//          ChannelBuffer buf = ChannelBuffers.buffer(length);
-//          getBytes(0, buf);
-//          return buf;
-        throw new RuntimeException();
-    }
-
-    public ChannelBuffer readSlice(int length) {
-        throw new RuntimeException();
-    }
-
-    public void readBytes(byte[] dst, int dstIndex, int length) {
-        checkReadableBytes(length);
-        getBytes(0, dst, dstIndex, length);
-    }
-
-    public void readBytes(byte[] dst) {
-        readBytes(dst, 0, dst.length);
-    }
-
-    public void readBytes(ChannelBuffer dst) {
-        readBytes(dst, dst.writableBytes());
-    }
-
-    public void readBytes(ChannelBuffer dst, int length) {
-        if (length > dst.writableBytes()) {
-            throw new IndexOutOfBoundsException();
-        }
-        readBytes(dst, dst.writerIndex(), length);
-        dst.writerIndex(dst.writerIndex() + length);
-    }
-
-    public void readBytes(ChannelBuffer dst, int dstIndex, int length) {
-        getBytes(0, dst, dstIndex, length);
-    }
-
-    public void readBytes(ByteBuffer dst) {
-        int length = dst.remaining();
-        checkReadableBytes(length);
-        getBytes(0, dst);
-    }
-
-    public int readBytes(GatheringByteChannel out, int length)
-            throws IOException {
-        checkReadableBytes(length);
-        return getBytes(0, out, length);
-    }
-
-    public void readBytes(OutputStream out, int length) throws IOException {
-        checkReadableBytes(length);
-        getBytes(0, out, length);
-    }
-
-    public void setShort(int a, int b) {
-        throw new RuntimeException();
     }
 }

--- a/framework/src/play/server/HttpServerPipelineFactory.java
+++ b/framework/src/play/server/HttpServerPipelineFactory.java
@@ -1,26 +1,27 @@
     package play.server;
 
+import static org.jboss.netty.channel.Channels.pipeline;
+
 import org.jboss.netty.channel.ChannelPipeline;
 import org.jboss.netty.channel.ChannelPipelineFactory;
-import org.jboss.netty.handler.codec.http.HttpChunkAggregator;
 import org.jboss.netty.handler.codec.http.HttpRequestDecoder;
 import org.jboss.netty.handler.codec.http.HttpResponseEncoder;
-import play.Play;
 
-import static org.jboss.netty.channel.Channels.pipeline;
+import play.Play;
 
 public class HttpServerPipelineFactory implements ChannelPipelineFactory {
 
     public ChannelPipeline getPipeline() throws Exception {
 
-        Integer max = Integer.valueOf(Play.configuration.getProperty("play.netty.maxContentLength", "-1"));
+        Integer max 		= Integer.valueOf(Play.configuration.getProperty("play.netty.maxContentLength", "-1"));
+        Integer threshold 	= Integer.valueOf(Play.configuration.getProperty("play.netty.memoryThreshold", 	"1024")); //1kB by default
            
         ChannelPipeline pipeline = pipeline();
         PlayHandler playHandler = new PlayHandler();
         
         pipeline.addLast("flashPolicy", new FlashPolicyHandler()); 
         pipeline.addLast("decoder", new HttpRequestDecoder());
-        pipeline.addLast("aggregator", new StreamChunkAggregator(max));
+        pipeline.addLast("aggregator", new StreamChunkAggregator(max, threshold));
         pipeline.addLast("encoder", new HttpResponseEncoder());
         pipeline.addLast("chunkedWriter", playHandler.chunkedWriteHandler);
         pipeline.addLast("handler", playHandler);

--- a/framework/src/play/server/InputStreamChannelBuffer.java
+++ b/framework/src/play/server/InputStreamChannelBuffer.java
@@ -1,0 +1,262 @@
+package play.server;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.GatheringByteChannel;
+import java.nio.channels.ScatteringByteChannel;
+
+import org.jboss.netty.buffer.AbstractChannelBuffer;
+import org.jboss.netty.buffer.ChannelBuffer;
+import org.jboss.netty.buffer.ChannelBufferFactory;
+import org.jboss.netty.buffer.WrappedChannelBuffer;
+
+/**
+ * Useless channel buffer only used to wrap the input stream....
+ */
+public abstract class InputStreamChannelBuffer extends AbstractChannelBuffer implements WrappedChannelBuffer {
+	
+    public abstract InputStream getInputStream();
+
+    public ChannelBuffer unwrap() {
+        throw new RuntimeException();
+    }
+
+    public ChannelBufferFactory factory() {
+        throw new RuntimeException();
+    }
+
+    public ByteOrder order() {
+        throw new RuntimeException();
+    }
+
+    public boolean isDirect() {
+        return true;
+    }
+
+    public boolean hasArray() {
+        return false;
+    }
+
+    public byte[] array() {
+        throw new RuntimeException();
+    }
+
+    public int arrayOffset() {
+        throw new RuntimeException();
+    }
+
+    @Override
+    public void discardReadBytes() {
+        throw new RuntimeException();
+    }
+
+    public void setByte(int index, byte value) {
+        throw new RuntimeException();
+    }
+
+    public void setBytes(int index, ChannelBuffer src, int srcIndex, int length) {
+        throw new RuntimeException();
+    }
+
+    public void setBytes(int index, byte[] src, int srcIndex, int length) {
+        throw new RuntimeException();
+    }
+
+    public void setBytes(int index, ByteBuffer src) {
+        throw new RuntimeException();
+    }
+
+    public void setShort(int index, short value) {
+        throw new RuntimeException();
+    }
+
+    public void setMedium(int index, int value) {
+        throw new RuntimeException();
+    }
+
+    public void setInt(int index, int value) {
+        throw new RuntimeException();
+    }
+
+    public void setLong(int index, long value) {
+        throw new RuntimeException();
+    }
+
+    public int setBytes(int index, InputStream in, int length)
+            throws IOException {
+        throw new RuntimeException();
+    }
+
+    public int setBytes(int index, ScatteringByteChannel in, int length)
+            throws IOException {
+        throw new RuntimeException();
+
+    }
+
+    public int readerIndex() {
+        return 0;
+    }
+
+
+    public int getBytes(int index, GatheringByteChannel out, int length)
+            throws IOException {
+        byte[] b = new byte[length];
+        getInputStream().read(b, index, length);
+        ByteBuffer bb = ByteBuffer.wrap(b);
+        return out.write(bb);
+    }
+
+    public void setByte(int i, int i1) {
+        throw new RuntimeException();
+    }
+
+    public void getBytes(int index, OutputStream out, int length)
+            throws IOException {
+        byte[] b = new byte[length];
+        getInputStream().read(b, index, length);
+        out.write(b, index, length);
+    }
+
+    public void getBytes(int index, byte[] dst, int dstIndex, int length) {
+        try {
+            byte[] b = new byte[length];
+            getInputStream().read(b, index, length);
+            System.arraycopy(b, 0, dst, dstIndex, length);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void getBytes(int index, ChannelBuffer dst, int dstIndex, int length) {
+        try {
+            byte[] b = new byte[length];
+            getInputStream().read(b, index, length);
+            dst.writeBytes(b, dstIndex, length);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void getBytes(int index, ByteBuffer dst) {
+        try {
+            byte[] b = new byte[getInputStream().available() - index];
+            getInputStream().read(b, index, getInputStream().available() - index);
+            dst.put(b);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public ChannelBuffer duplicate() {
+        throw new RuntimeException();
+    }
+
+    public ChannelBuffer copy(int index, int length) {
+        throw new RuntimeException();
+    }
+
+    public ChannelBuffer slice(int index, int length) {
+        throw new RuntimeException();
+    }
+
+    public byte getByte(int index) {
+        throw new RuntimeException();
+    }
+
+    public short getShort(int index) {
+        throw new RuntimeException();
+    }
+
+    public int getUnsignedMedium(int index) {
+        throw new RuntimeException();
+
+    }
+
+    public int getInt(int index) {
+        throw new RuntimeException();
+
+    }
+
+    public long getLong(int index) {
+        throw new RuntimeException();
+
+    }
+
+    public ByteBuffer toByteBuffer(int index, int length) {
+        throw new RuntimeException();
+    }
+
+    @Override
+    public ByteBuffer[] toByteBuffers(int index, int length) {
+        throw new RuntimeException();
+    }
+
+    public int capacity() {
+        try {
+            return getInputStream().available();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+    }
+
+    public ChannelBuffer readBytes(int length) {
+//          ChannelBuffer buf = ChannelBuffers.buffer(length);
+//          getBytes(0, buf);
+//          return buf;
+        throw new RuntimeException();
+    }
+
+    public ChannelBuffer readSlice(int length) {
+        throw new RuntimeException();
+    }
+
+    public void readBytes(byte[] dst, int dstIndex, int length) {
+        checkReadableBytes(length);
+        getBytes(0, dst, dstIndex, length);
+    }
+
+    public void readBytes(byte[] dst) {
+        readBytes(dst, 0, dst.length);
+    }
+
+    public void readBytes(ChannelBuffer dst) {
+        readBytes(dst, dst.writableBytes());
+    }
+
+    public void readBytes(ChannelBuffer dst, int length) {
+        if (length > dst.writableBytes()) {
+            throw new IndexOutOfBoundsException();
+        }
+        readBytes(dst, dst.writerIndex(), length);
+        dst.writerIndex(dst.writerIndex() + length);
+    }
+
+    public void readBytes(ChannelBuffer dst, int dstIndex, int length) {
+        getBytes(0, dst, dstIndex, length);
+    }
+
+    public void readBytes(ByteBuffer dst) {
+        int length = dst.remaining();
+        checkReadableBytes(length);
+        getBytes(0, dst);
+    }
+
+    public int readBytes(GatheringByteChannel out, int length)
+            throws IOException {
+        checkReadableBytes(length);
+        return getBytes(0, out, length);
+    }
+
+    public void readBytes(OutputStream out, int length) throws IOException {
+        checkReadableBytes(length);
+        getBytes(0, out, length);
+    }
+
+    public void setShort(int a, int b) {
+        throw new RuntimeException();
+    }
+}

--- a/framework/src/play/server/MemoryChannelBuffer.java
+++ b/framework/src/play/server/MemoryChannelBuffer.java
@@ -1,0 +1,31 @@
+package play.server;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+/**
+ * Useless channel buffer only used to wrap the input stream....
+ */
+public class MemoryChannelBuffer extends InputStreamChannelBuffer {
+	
+    private final ByteArrayInputStream is;
+    
+// --------------------------->
+
+    public MemoryChannelBuffer(byte[] data) {
+        if (data == null) {
+            throw new NullPointerException("data");
+        }
+        try {
+            this.is = new ByteArrayInputStream(data);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+    
+// --------------------------->
+
+    public InputStream getInputStream() {
+        return is;
+    }
+}

--- a/framework/src/play/server/PlayHandler.java
+++ b/framework/src/play/server/PlayHandler.java
@@ -517,8 +517,8 @@ public class PlayHandler extends SimpleChannelUpstreamHandler {
 
         InputStream body = null;
         ChannelBuffer b = nettyRequest.getContent();
-        if (b instanceof FileChannelBuffer) {
-            FileChannelBuffer buffer = (FileChannelBuffer) b;
+        if (b instanceof InputStreamChannelBuffer) {
+            InputStreamChannelBuffer buffer = (InputStreamChannelBuffer) b;
             // An error occurred
             Integer max = Integer.valueOf(Play.configuration.getProperty("play.netty.maxContentLength", "-1"));
 

--- a/framework/src/play/server/StreamChunkAggregator.java
+++ b/framework/src/play/server/StreamChunkAggregator.java
@@ -1,29 +1,55 @@
 package play.server;
 
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.List;
+import java.util.UUID;
+
 import org.apache.commons.io.IOUtils;
 import org.jboss.netty.buffer.ChannelBufferInputStream;
-import org.jboss.netty.channel.*;
+import org.jboss.netty.channel.ChannelHandlerContext;
+import org.jboss.netty.channel.Channels;
+import org.jboss.netty.channel.MessageEvent;
+import org.jboss.netty.channel.SimpleChannelUpstreamHandler;
 import org.jboss.netty.handler.codec.http.HttpChunk;
 import org.jboss.netty.handler.codec.http.HttpHeaders;
 import org.jboss.netty.handler.codec.http.HttpMessage;
-import play.Play;
 
-import java.io.*;
-import java.util.List;
-import java.util.UUID;
+import play.Play;
 
 public class StreamChunkAggregator extends SimpleChannelUpstreamHandler {
 
     private volatile HttpMessage currentMessage;
     private volatile OutputStream out;
     private final int maxContentLength;
+    private final int memoryThreshold;
+    
+    // used to read large body
     private volatile File file;
+    // used to write into memory (until the content length is over the threshold)
+    private ByteArrayOutputStream buf = null;
 
     /**
      * Creates a new instance.
      */
     public StreamChunkAggregator(int maxContentLength) {
+        this(maxContentLength, -1);
+    }
+    
+    /**
+     * Creates a new instance.
+     */
+    public StreamChunkAggregator(int maxContentLength, int memoryThreshold) {
         this.maxContentLength = maxContentLength;
+        this.memoryThreshold = memoryThreshold;
+        
+        if ( memoryThreshold > 0 ) {
+        	// FIXME init with a shortness capacity ???
+        	buf = new ByteArrayOutputStream(memoryThreshold);
+        }
     }
 
     @Override
@@ -39,7 +65,6 @@ public class StreamChunkAggregator extends SimpleChannelUpstreamHandler {
         if (currentMessage == null) {
             HttpMessage m = (HttpMessage) msg;
             if (m.isChunked()) {
-                final String localName = UUID.randomUUID().toString();
                 // A chunked message - remove 'Transfer-Encoding' header,
                 // initialize the cumulative buffer, and wait for incoming chunks.
                 List<String> encodings = m.getHeaders(HttpHeaders.Names.TRANSFER_ENCODING);
@@ -48,8 +73,12 @@ public class StreamChunkAggregator extends SimpleChannelUpstreamHandler {
                     m.removeHeader(HttpHeaders.Names.TRANSFER_ENCODING);
                 }
                 this.currentMessage = m;
-                this.file = new File(Play.tmpDir, localName);
-                this.out = new FileOutputStream(file, true);
+                if ( buf != null ) {
+                	this.out = buf;
+                	buf.reset(); // in theory already reseted but : twice is better than once
+                } else { 
+                	initTemporaryFile(false);
+                }
             } else {
                 // Not a chunked message - pass through.
                 ctx.sendUpstream(e);
@@ -58,28 +87,59 @@ public class StreamChunkAggregator extends SimpleChannelUpstreamHandler {
             // TODO: If less that threshold then in memory
             // Merge the received chunk into the content of the current message.
             final HttpChunk chunk = (HttpChunk) msg;
-            if (maxContentLength != -1 && (localFile.length() > (maxContentLength - chunk.getContent().readableBytes()))) {
+            if (maxContentLength != -1 && (contentLength() > (maxContentLength - chunk.getContent().readableBytes()))) {
                 currentMessage.setHeader(HttpHeaders.Names.WARNING, "play.netty.content.length.exceeded");
             } else {
+            	
+            	// switch to file if out of memory buffer
+            	if ( localFile == null && (buf.size() + chunk.getContent().readableBytes()) > memoryThreshold ) {
+            		localFile = initTemporaryFile(true);
+            	}
+            	
                 IOUtils.copyLarge(new ChannelBufferInputStream(chunk.getContent()), this.out);
 
                 if (chunk.isLast()) {
                     this.out.flush();
-                    this.out.close();
+                    this.out.close(); // has no effect on the ByteArrayOutputStream
 
                     currentMessage.setHeader(
                             HttpHeaders.Names.CONTENT_LENGTH,
-                            String.valueOf(localFile.length()));
+                            String.valueOf(contentLength()));
 
-                    currentMessage.setContent(new FileChannelBuffer(localFile));
+                    currentMessage.setContent(localFile == null ? new MemoryChannelBuffer(buf.toByteArray()) : new FileChannelBuffer(localFile, true));
                     this.out = null;
                     this.currentMessage = null;
                     this.file = null;
+                    if  ( buf != null ) buf.reset();
+                    
                     Channels.fireMessageReceived(ctx, currentMessage, e.getRemoteAddress());
                 }
             }
         }
-
+    }
+    
+    /**
+     * Init the temporary file and recopy already grabbed data into memory into this new temporary file. 
+     */
+    private final File initTemporaryFile(boolean recopy) throws IOException {
+    	final String localName = UUID.randomUUID().toString();
+    	
+    	file = new File(Play.tmpDir, localName);
+        out = new FileOutputStream(file, true);
+        
+        if ( recopy && buf != null && buf.size() > 0 ) {
+        	buf.writeTo(out);
+        }
+        
+        return file;
+    }
+    
+    /**
+     * Get the length of the read content
+     */
+    private final long contentLength()
+    {
+    	return file != null ? file.length() : buf.size(); 
     }
 }
 

--- a/framework/src/play/server/ssl/SslHttpServerPipelineFactory.java
+++ b/framework/src/play/server/ssl/SslHttpServerPipelineFactory.java
@@ -20,8 +20,9 @@ public class SslHttpServerPipelineFactory implements ChannelPipelineFactory {
 
     public ChannelPipeline getPipeline() throws Exception {
 
-        Integer max = Integer.valueOf(Play.configuration.getProperty("play.netty.maxContentLength", "-1"));
-        String mode = Play.configuration.getProperty("play.netty.clientAuth", "none");
+        Integer max 		= Integer.valueOf(Play.configuration.getProperty("play.netty.maxContentLength", "-1"));
+        Integer threshold 	= Integer.valueOf(Play.configuration.getProperty("play.netty.memoryThreshold", 	"1024"));  //1kB by default
+        String mode 		= Play.configuration.getProperty("play.netty.clientAuth", "none");
 
         ChannelPipeline pipeline = pipeline();
 
@@ -40,7 +41,7 @@ public class SslHttpServerPipelineFactory implements ChannelPipelineFactory {
         pipeline.addLast("flashPolicy", new FlashPolicyHandler());
         pipeline.addLast("ssl", new SslHandler(engine));
         pipeline.addLast("decoder", new HttpRequestDecoder());
-        pipeline.addLast("aggregator", new StreamChunkAggregator(max));
+        pipeline.addLast("aggregator", new StreamChunkAggregator(max, threshold));
         pipeline.addLast("encoder", new HttpResponseEncoder());
         pipeline.addLast("chunkedWriter", new ChunkedWriteHandler());
 


### PR DESCRIPTION
On my applications I handle with a lot of chunked streams, and so a lot of temporary files are created. So the "use a cron to delete periodically the temporary files" is not a good workaround for me. 

So I've implemented the automatic deletion of temporary files used for a chunked stream on closing the request body. May be improved by closing the body input stream on request finalization.

To avoid temporary files creation for short contents, I've implemented a temporary buffer, that may be turned into a temporary file for large contents.

It works for me, what do you think ?
