### PR TITLE
compatibility fix for libraries that use the current ClassLoader directly

### DIFF
--- a/framework/src/play/Play.java
+++ b/framework/src/play/Play.java
@@ -467,6 +467,8 @@ public class Play {
             if (mode == Mode.DEV) {
                 // Need a new classloader
                 classloader = new ApplicationClassloader();
+                // Put it in the current context for any code that relies on having it there
+                Thread.currentThread().setContextClassLoader(classloader);
                 // Reload plugins
                 pluginCollection.reloadApplicationPlugins();
 


### PR DESCRIPTION
This fixes an issue between play and MyBatis 3.0.6, where after a hotload, MyBatis finds the old ClassLoader from Thread.currentThread().getContextClassLoader() and gets confused and breaks.

This patch sets the current thread's contextual ClassLoader immediately, fixing it.

Other libraries/code that do the same would also be fixed.
