### PR TITLE
[#1570] Allow setting of SSL ciphers as configuration option

### DIFF
--- a/documentation/manual/configuration.textile
+++ b/documentation/manual/configuration.textile
@@ -821,6 +821,15 @@ HTTP server maximum content length for response streaming, in bytes.
 Default: none - no maximum.
 
 
+h3(#play.ssl.enabledCiphers). play.ssl.enabledCiphers
+
+This setting allows to specify certain SSL ciphers to be used. This might be needed in case you have to be PCI compliant, as some ciphers in the default settings are vulnerable to the so-called BEAST attack.
+
+bc. play.ssl.enabledCiphers=SSL_RSA_WITH_RC4_128_MD5,SSL_RSA_WITH_RC4_128_SHA
+
+Default: none - the default ciphers are chosen.
+
+
 h3(#play.pool). play.pool
 
 Execution pool size. Try to keep this as low as possible. Setting this to 1 thread will serialise all requests (very useful for debugging purpose). For example:

--- a/framework/src/play/server/ssl/SslHttpServerPipelineFactory.java
+++ b/framework/src/play/server/ssl/SslHttpServerPipelineFactory.java
@@ -22,12 +22,17 @@ public class SslHttpServerPipelineFactory implements ChannelPipelineFactory {
 
         Integer max = Integer.valueOf(Play.configuration.getProperty("play.netty.maxContentLength", "-1"));
         String mode = Play.configuration.getProperty("play.netty.clientAuth", "none");
+        String enabledCiphers = Play.configuration.getProperty("play.ssl.enabledCiphers", "");
 
         ChannelPipeline pipeline = pipeline();
 
         // Add SSL handler first to encrypt and decrypt everything.
         SSLEngine engine = SslHttpServerContextFactory.getServerContext().createSSLEngine();
         engine.setUseClientMode(false);
+
+        if (enabledCiphers != null && enabledCiphers.length() > 0) {
+            engine.setEnabledCipherSuites(enabledCiphers.replaceAll(" ", "").split(","));
+        }
         
         if ("want".equalsIgnoreCase(mode)) {
             engine.setWantClientAuth(true);


### PR DESCRIPTION
Hi

fix for ticket number 1570 at
https://play.lighthouseapp.com/projects/57987-play-framework/tickets/1570-playframework-does-not-pass-pci-scans-due-to-dangerous-ssl-ciphers
