### PR TITLE
[#1558] i18n tag does not always include default messages

### DIFF
--- a/framework/src/play/i18n/Messages.java
+++ b/framework/src/play/i18n/Messages.java
@@ -171,7 +171,10 @@ public class Messages {
     public static Properties all(String locale) {
         if(locale == null || "".equals(locale))
             return defaults;
-        return locales.get(locale);
+        Properties mergedMessages = new Properties();
+        mergedMessages.putAll(defaults);
+        mergedMessages.putAll(locales.get(locale));
+        return mergedMessages;
     }
 
 }


### PR DESCRIPTION
When querying Messages.all(), it will only give you keys for the specific locale.  I believe expected behaviour is that it will give you a merge of defaults + locale specific strings
