### PR TITLE
[#1333] allow to throw timeout exception when await(Promise) exceeds the timeout limit

### DIFF
--- a/framework/src/play/Invoker.java
+++ b/framework/src/play/Invoker.java
@@ -381,15 +381,17 @@ public class Invoker {
                         executor.submit(invocation);
                     }
                 });
-            } else {
-                synchronized (WaitForTasksCompletion.class) {
-                    if (instance == null) {
-                        instance = new WaitForTasksCompletion();
-                        Logger.warn("Start WaitForTasksCompletion");
-                        instance.start();
-                    }
-                    instance.queue.put(task, invocation);
-                }
+            } 
+            /**
+             * all suspend task need to be added to the queue and re-invoke later
+             */
+            synchronized (WaitForTasksCompletion.class) {
+                if (instance == null) {
+                   instance = new WaitForTasksCompletion();
+                   Logger.warn("Start WaitForTasksCompletion");
+                   instance.start();
+                 }
+                instance.queue.put(task, invocation);
             }
         }
 


### PR DESCRIPTION
I am using Play-1.2.5.
The following code expects to get a time out exception. But the application/request is just suspended forever.

public class Application extends Controller {

```
public static void index() {
     F.Promise<WS.HttpResponse> remoteCall1 =  WS.url("http://localhost:9000").timeout("5s").getAsync(); 
    // http://my_webserver is designed to return /random1 in 10seconds, which means promise1 will timeout
     F.Promise<List<WS.HttpResponse>> promises = F.Promise.waitAll(remoteCall1);
     System.out.println("before await");
     await(promises);

     System.out.println("after await");
     render();
}
```

}
