### PR TITLE
Fixing evolutions command to return a non-cero exit code when evolutions fail. This is helpful to prevent false positives when running on CI servers like jenkins.

### DIFF
--- a/framework/pym/play/commands/evolutions.py
+++ b/framework/pym/play/commands/evolutions.py
@@ -46,5 +46,6 @@ def execute(**kargs):
 
     java_cmd = [app.java_path()] + add_options + ['-classpath', app.cp_args(), 'play.db.Evolutions']
 
-    subprocess.call(java_cmd, env=os.environ)
-
+    return_code = subprocess.call(java_cmd, env=os.environ)
+    if 0 != return_code:
+        sys.exit(return_code);

--- a/framework/src/play/db/Evolutions.java
+++ b/framework/src/play/db/Evolutions.java
@@ -144,6 +144,7 @@ public class Evolutions extends PlayPlugin {
                     System.out.println("~");
                     System.out.println("~ Can't apply evolutions...");
                     System.out.println("~");
+                    System.exit(-1);
                 }
 
 
@@ -155,6 +156,7 @@ public class Evolutions extends PlayPlugin {
                 } else {
                     System.out.println("~ Can't apply evolutions...");
                     System.out.println("~");
+                    System.exit(-1);
                 }
 
             } else {


### PR DESCRIPTION
... fail. This is helpful to prevent false positives when running on CI servers like jenkins.
