### PR TITLE
[#1600] Allows non-transaction JPA read-only query

### DIFF
--- a/documentation/manual/jpa.textile
+++ b/documentation/manual/jpa.textile
@@ -28,9 +28,13 @@ You can also use annotations to specify how transactions should be handled.
 
 If you annotated the method in the controller with <code>@play.db.jpa.Transactional(readOnly=true)</code>, then the transaction will be read-only.
 
+If you annotated the method in the controller with <code>@play.db.jpa.NoTransaction(readOnly=true)</code>, then Play will not create a transaction but still allows read-only query.
+
 You don't have to prevent Play from starting a transaction if you don't want any. If you do not perform any JPA actions while processing the request,
 no transaction will be created. If you would like to enforce this - you can annotate your Controller method or class with <code>@play.db.jpa.NoTransaction</code>.
 If you try to perform a JPA action in a controller annotated with <code>@play.db.jpa.NoTransaction</code>, an exception will be thrown.
+
+
 
 h2. <a name="support">The **play.db.jpa.Model** support class</a>
 

--- a/framework/src/play/db/jpa/JPAContext.java
+++ b/framework/src/play/db/jpa/JPAContext.java
@@ -14,6 +14,7 @@ public class JPAContext {
     private JPAConfig jpaConfig;
     private EntityManager entityManager;
     private boolean readonly = true;
+    private boolean beganTransaction = true;
 
     protected JPAContext(JPAConfig jpaConfig, boolean readonly, boolean beginTransaction) {
 
@@ -29,6 +30,7 @@ public class JPAContext {
 
         entityManager = manager;
         this.readonly = readonly;
+        this.beganTransaction = beginTransaction;
     }
 
     public JPAConfig getJPAConfig() {
@@ -39,9 +41,11 @@ public class JPAContext {
      * clear current JPA context and transaction
      * @param rollback shall current transaction be committed (false) or cancelled (true)
      */
-    public void closeTx(boolean rollback) {
-
+    public void closeTx(boolean rollback) {    	
         try {
+        	// We haven't started a transaction. Do nothing except finally.
+        	if (!this.beganTransaction) return;      	
+        	
             if (entityManager.getTransaction().isActive()) {
                 if (readonly || rollback || entityManager.getTransaction().getRollbackOnly()) {
                     entityManager.getTransaction().rollback();

--- a/framework/src/play/db/jpa/NoTransaction.java
+++ b/framework/src/play/db/jpa/NoTransaction.java
@@ -17,6 +17,7 @@ import java.lang.annotation.Target;
 @Inherited
 @Target(value={ElementType.METHOD,ElementType.TYPE})
 public @interface NoTransaction {
-
+	/** For making non-transaction readOnly JPA queries */ 
+	public boolean readOnly() default false;
 }
 


### PR DESCRIPTION
Adding new annotation option

@NoTransaction(readOnly=true)

allows JPA to make query having to explicitly start a transaction at the Controller level, improving performance and scalability.

All existing annotations will behave the same. Defaults readOnly to false so to not regress existing codes.

https://groups.google.com/forum/?fromgroups=#!topic/play-framework/OaQayMak9mU
