### PR TITLE
[#1626] Allow plugins to add Unit and Functional tests that do not extend Assert/FunctionalTest class

### DIFF
--- a/framework/src/play/PlayPlugin.java
+++ b/framework/src/play/PlayPlugin.java
@@ -5,6 +5,8 @@ import com.google.gson.JsonObject;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.HashMap;
@@ -352,5 +354,36 @@ public abstract class PlayPlugin implements Comparable<PlayPlugin> {
     public Object willBeValidated(Object value) {
         return null;
     }
-    
+
+    /**
+     * Implement to add some classes that should be considered unit tests but do not extend
+     * {@link org.junit.Assert} to tests that can be executed by test runner (will be visible in test UI).
+     * <p/>
+     * <strong>Note:</strong>You probably will also need to override {@link PlayPlugin#runTest(java.lang.Class)} method
+     * to handle unsupported tests execution properly.
+     * <p/>
+     * Keep in mind that this method can only add tests to currently loaded ones.
+     * You cannot disable tests this way. You should also make sure you do not duplicate already loaded tests.
+     * 
+     * @return list of plugin supported unit test classes (empty list in default implementation)
+     */
+    public Collection<Class> getUnitTests() {
+        return Collections.emptyList();
+    }
+
+    /**
+     * Implement to add some classes that should be considered functional tests but do not extend
+     * {@link play.test.FunctionalTest} to tests that can be executed by test runner (will be visible in test UI).
+     * <p/>
+     * <strong>Note:</strong>You probably will also need to override {@link PlayPlugin#runTest(java.lang.Class)} method
+     * to handle unsupported tests execution properly.
+     * <p/>
+     * Keep in mind that this method can only add tests to currently loaded ones.
+     * You cannot disable tests this way. You should also make sure you do not duplicate already loaded tests.
+     *
+     * @return list of plugin supported functional test classes (empty list in default implementation)
+     */
+    public Collection<Class> getFunctionalTests() {
+        return Collections.emptyList();
+    }
 }

--- a/framework/src/play/plugins/PluginCollection.java
+++ b/framework/src/play/plugins/PluginCollection.java
@@ -735,18 +735,27 @@ public class PluginCollection {
         return null;
     }
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+    public Collection<Class> getUnitTests() {
+        Set<Class> allPluginTests = new HashSet<Class>();
+        for (PlayPlugin plugin : getEnabledPlugins()) {
+            Collection<Class> unitTests = plugin.getUnitTests();
+            if(unitTests != null) {
+                allPluginTests.addAll(unitTests);
+            }
+        }
+        
+        return allPluginTests;
+    }
+    
+    public Collection<Class> getFunctionalTests() {
+        Set<Class> allPluginTests = new HashSet<Class>();
+        for (PlayPlugin plugin : getEnabledPlugins()) {
+            Collection<Class> funcTests = plugin.getFunctionalTests();
+            if(funcTests != null) {
+                allPluginTests.addAll(funcTests);
+            }
+        }
+        
+        return allPluginTests;
+    }
 }

--- a/framework/src/play/test/TestEngine.java
+++ b/framework/src/play/test/TestEngine.java
@@ -3,6 +3,7 @@ package play.test;
 import java.io.File;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -36,6 +37,8 @@ public class TestEngine {
 
     public static List<Class> allUnitTests() {
         List<Class> classes = Play.classloader.getAssignableClasses(Assert.class);
+        Collection<Class> pluginClasses = Play.pluginCollection.getUnitTests();
+        classes.addAll(pluginClasses);
         for (ListIterator<Class> it = classes.listIterator(); it.hasNext();) {
             Class c = it.next();
             if (Modifier.isAbstract(c.getModifiers())) {
@@ -52,6 +55,8 @@ public class TestEngine {
 
     public static List<Class> allFunctionalTests() {
         List<Class> classes = Play.classloader.getAssignableClasses(FunctionalTest.class);
+        Collection<Class> pluginClasses = Play.pluginCollection.getFunctionalTests();
+        classes.addAll(pluginClasses);
         for (ListIterator<Class> it = classes.listIterator(); it.hasNext();) {
             if (Modifier.isAbstract(it.next().getModifiers())) {
                 it.remove();

--- a/framework/test-src/play/plugins/PluginCollectionTest.java
+++ b/framework/test-src/play/plugins/PluginCollectionTest.java
@@ -1,5 +1,7 @@
 package play.plugins;
 
+import java.util.Arrays;
+import java.util.Collection;
 import org.junit.Test;
 import play.CorePlugin;
 import play.Play;
@@ -14,6 +16,8 @@ import play.db.jpa.JPAPlugin;
 import play.i18n.MessagesPlugin;
 import play.jobs.JobsPlugin;
 import play.libs.WS;
+import play.test.TestEngine;
+import play.test.UnitTest;
 
 import static org.fest.assertions.Assertions.assertThat;
 
@@ -147,6 +151,25 @@ public class PluginCollectionTest {
 
     }
 
+    @Test
+    public void verifyThatPluginsCanAddUnitTests() {
+        PluginCollection pc = new PluginCollection();
+        Play.pluginCollection = pc;
+
+        assertThat(TestEngine.allUnitTests()).isEmpty();
+        assertThat(TestEngine.allFunctionalTests()).isEmpty();
+
+        PluginWithTests p1 = new PluginWithTests();
+        PluginWithTests2 p2 = new PluginWithTests2();
+        pc.addPlugin(p1);
+        pc.addPlugin(p2);
+
+        pc.initializePlugin(p1);
+        pc.initializePlugin(p2);
+
+        assertThat(TestEngine.allUnitTests()).contains(PluginUnitTest.class, PluginUnitTest2.class);
+        assertThat(TestEngine.allFunctionalTests()).contains(PluginFuncTest.class, PluginFuncTest2.class);
+    }
 }
 
 
@@ -165,4 +188,36 @@ class LegacyPlugin extends PlayPlugin {
         }
         Play.plugins.remove( pluginToRemove);
     }
+
 }
+
+class PluginWithTests extends PlayPlugin {
+
+    @Override
+    public Collection<Class> getUnitTests() {
+        return Arrays.asList(new Class[]{PluginUnitTest.class});
+    }
+
+    @Override
+    public Collection<Class> getFunctionalTests() {
+        return Arrays.asList(new Class[]{PluginFuncTest.class});
+    }
+}
+
+class PluginWithTests2 extends PlayPlugin {
+
+    @Override
+    public Collection<Class> getUnitTests() {
+        return Arrays.asList(new Class[]{PluginUnitTest2.class});
+    }
+
+    @Override
+    public Collection<Class> getFunctionalTests() {
+        return Arrays.asList(new Class[]{PluginFuncTest2.class});
+    }
+}
+
+class PluginUnitTest {}
+class PluginUnitTest2 {}
+class PluginFuncTest {}
+class PluginFuncTest2 {}


### PR DESCRIPTION
Added functionality for plugins to add test classes that do not extend from Assert class. I need it to cleanly add support for Geb and Spock tests in Play.
