### PR TITLE
Fix invalid JSON syntax

### DIFF
--- a/framework/templates/errors/500.json
+++ b/framework/templates/errors/500.json
@@ -1,4 +1,4 @@
 {
-    type:   '${exception?.class.name}',
-    message: '${exception?.message?.replace("'", "\'")}'
+    "type":   "${exception?.class.name}",
+    "message": "${exception?.message?.replace("'", "\'")}"
 }


### PR DESCRIPTION
Correct the syntax, which was invalid, preventing methods like JSON.parse in javascript from understanding the structure and causing errors in applications depending on it.
