### PR TITLE
[#1643] Do not output null flash parameters

### DIFF
--- a/framework/src/play/mvc/Scope.java
+++ b/framework/src/play/mvc/Scope.java
@@ -75,6 +75,7 @@ public class Scope {
             try {
                 StringBuilder flash = new StringBuilder();
                 for (String key : out.keySet()) {
+                    if (out.get(key) == null) continue;
                     flash.append("\u0000");
                     flash.append(key);
                     flash.append(":");


### PR DESCRIPTION
StringBuilder will output nulls as "null", which is always not what you want.
We several bugs because of this unexpected behavior in our app.
