### PR TITLE
[#1640] Use same connection in order to apply all DB evolutions

### DIFF
--- a/framework/src/play/db/Evolutions.java
+++ b/framework/src/play/db/Evolutions.java
@@ -352,7 +352,7 @@ public class Evolutions extends PlayPlugin {
                             if (StringUtils.isEmpty(s)) {
                                 continue;
                             }
-                            execute(s);
+                            connection.createStatement().execute(s);
                         }
                     }
                     // Insert into logs


### PR DESCRIPTION
The evolutions plugins open a new connection in order to execute each SQL lines stored in one evolution file. This behavior works with DDL SQL orders but failed with DML SQL like this : 

insert into mytable values(nextval(mysequence), 'field1');
insert into my_linked_table values(currval(my_sequences), 'another_field_value');

In this example, we used sequence functions 'currval' and 'nextval' to get the sequence value. It's failed because the Evolutions plugins uses two JDBC connections.

Regards,
Jérôme BENOIS
