### PR TITLE
[#1644] using Codec.hexSHA1() to hash the urlcache key

### DIFF
--- a/framework/src/play/mvc/ActionInvoker.java
+++ b/framework/src/play/mvc/ActionInvoker.java
@@ -32,6 +32,7 @@ import play.mvc.results.NoResult;
 import play.mvc.results.Result;
 import play.utils.Java;
 import play.utils.Utils;
+import play.libs.Codec;
 
 import com.jamonapi.Monitor;
 import com.jamonapi.MonitorFactory;
@@ -150,7 +151,7 @@ public class ActionInvoker {
                 if ((request.method.equals("GET") || request.method.equals("HEAD")) && actionMethod.isAnnotationPresent(CacheFor.class)) {
                     cacheKey = actionMethod.getAnnotation(CacheFor.class).id();
                     if ("".equals(cacheKey)) {
-                        cacheKey = "urlcache:" + request.url + request.querystring;
+                        cacheKey = "urlcache:" + Codec.hexSHA1(request.url + request.querystring);
                     }
                     actionResult = (Result) play.cache.Cache.get(cacheKey);
                 }


### PR DESCRIPTION
To avoid hitting the memcache max key length limit (250 chars) for the URL cache (@CacheFor).

More about this in the ticket: https://play.lighthouseapp.com/projects/57987-play-framework/tickets/1644-cachefor-hitting-memcache-key-length-limit

If possible, I'd like to see this also in the 1.2 branch.
