### PR TITLE
[#1675] Fix for exponential execution time problem in Controller.redirect()

### DIFF
--- a/framework/src/play/mvc/Controller.java
+++ b/framework/src/play/mvc/Controller.java
@@ -527,7 +527,7 @@ public class Controller implements ControllerSupport {
      * @param permanent true -> 301, false -> 302
      */
     protected static void redirect(String url, boolean permanent) {
-        if (url.matches("^([^./]+[.]?)+$")) { // fix Java !
+        if (url.indexOf("/") == -1) { // fix Java !
             redirect(url, permanent, new Object[0]);
         }
         throw new Redirect(url, permanent);


### PR DESCRIPTION
As far as I can tell the regex used in Controller.redirect() can be substituted with a simple indexOf().
