### PR TITLE
[#1683] Add multipart/mixed support

### DIFF
--- a/framework/src/play/data/parsing/DataParser.java
+++ b/framework/src/play/data/parsing/DataParser.java
@@ -17,6 +17,7 @@ public abstract class DataParser {
     static {
         parsers.put("application/x-www-form-urlencoded", new UrlEncodedParser());
         parsers.put("multipart/form-data", new ApacheMultipartParser());
+        parsers.put("multipart/mixed", new ApacheMultipartParser());
         parsers.put("application/xml", new TextParser());
         parsers.put("application/json", new TextParser());
     }


### PR DESCRIPTION
Hi,

It seems "mutlipart/mixed" content type is not bound by default in DataParser but it's fully supported by the ApacheMultipartParser class. 

Cheers,
Jérôme.
