### PR TITLE
[#1678] Fix @db redirect from MOVED to FOUND

### DIFF
--- a/framework/src/play/db/DBPlugin.java
+++ b/framework/src/play/db/DBPlugin.java
@@ -26,7 +26,7 @@ public class DBPlugin extends PlayPlugin {
     @Override
     public boolean rawInvocation(Request request, Response response) throws Exception {
         if (Play.mode.isDev() && request.path.equals("/@db")) {
-            response.status = Http.StatusCode.MOVED;
+            response.status = Http.StatusCode.FOUND;
             String serverOptions[] = new String[] { };
 
             // For H2 embeded database, we'll also start the Web console


### PR DESCRIPTION
MOVED was being cached by safari, so after a play restart, when a user goes to /@db safari instead sends the user to the h2 webserver endpoint, which has not been started, since /@db is not hit.  This forces safari to not cache the redirect.
