### PR TITLE
Fix timeout was ignored in get method of a Promise

### DIFF
--- a/framework/src/play/libs/F.java
+++ b/framework/src/play/libs/F.java
@@ -146,8 +146,11 @@ public class F {
 
                 @Override
                 public List<T> get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
-                    waitAllLock.await(timeout, unit);
-                    return get();
+                    if (waitAllLock.await(timeout, unit)){
+                        return get();
+                    } else {
+                        throw new TimeoutException();
+                    }
                 }
             };
             final F.Action<Promise<T>> action = new F.Action<Promise<T>>() {


### PR DESCRIPTION
The timeout defined as parameter of the 'get' method of a Promise was ignored : waitAllLock.await(timeout, unit) did its job but next we called the 'get' method without timeout which calls waitAllLock.await(). We need to exit the method with TimeoutException if waitAllLock.await(timeout, unit) returns false.
