### PR TITLE
[#1686] Make Promise.waitAll().get(long, TimeUnit) respect timeout and throw an exception

### DIFF
--- a/framework/src/play/libs/F.java
+++ b/framework/src/play/libs/F.java
@@ -146,7 +146,10 @@ public class F {
 
                 @Override
                 public List<T> get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
-                    waitAllLock.await(timeout, unit);
+                    if(!waitAllLock.await(timeout, unit)) {
+                      throw new TimeoutException(String.format("Promises didn't redeem in %s %s", timeout, unit));
+                    }
+                    
                     return get();
                 }
             };

--- a/samples-and-tests/just-test-cases/test/Promises.java
+++ b/samples-and-tests/just-test-cases/test/Promises.java
@@ -1,6 +1,9 @@
 import org.junit.*;
 
 import java.util.*;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import play.test.*;
 import play.jobs.*;
@@ -8,15 +11,15 @@ import play.libs.*;
 import play.libs.F.*;
 
 public class Promises extends UnitTest {
-    
+
     public static class DoSomething extends play.jobs.Job<F.Option<String>> {
-        
+
         long d;
-        
+
         public DoSomething(long d) {
             this.d = d;
         }
-        
+
         public F.Option<String> doJobWithResult() throws Exception {
             Thread.sleep(d);
             if(d > 200) {
@@ -24,45 +27,45 @@ public class Promises extends UnitTest {
             }
             return F.Option.None();
         }
-        
+
     }
-    
+
     public static class DoSomething2 extends play.jobs.Job<String> {
-        
+
         long d;
-        
+
         public DoSomething2(long d) {
             this.d = d;
         }
-        
+
         public String doJobWithResult() throws Exception {
             Thread.sleep(d);
             return "-> " + d;
         }
-        
+
     }
-    
+
     @Test
     public void waitAny() throws Exception {
-        
+
         boolean p = false;
         for(String s : Promise.waitAny(new DoSomething(300).now(), new DoSomething(250).now()).get()) {
             assertEquals("-> 250", s);
             p = true;
         }
         assertTrue("Loop missed?", p);
-        
+
         for(String s : Promise.waitAny(new DoSomething(100).now(), new DoSomething(250).now()).get()) {
             fail("Oops");
         }
-        
+
     }
-    
+
     @Test
     public void waitEither() throws Exception {
-        
+
         F.Either<F.Option<String>,String> e = Promise.waitEither(new DoSomething(201).now(), new DoSomething2(300).now()).get();
-        
+
         boolean p = false;
         for(F.Option<String> o : e._1) {
             for(String s : o) {
@@ -71,73 +74,73 @@ public class Promises extends UnitTest {
             }
         }
         assertTrue("Loop missed?", p);
-        
+
         for(String s : e._2) {
             fail("Oops");
         }
-        
+
         e = Promise.waitEither(new DoSomething(201).now(), new DoSomething2(100).now()).get();
-        
+
         for(F.Option<String> o : e._1) {
             for(String s : o) {
                 fail("Oops");
             }
         }
-        
+
         p = false;
         for(String s : e._2) {
             assertEquals("-> 100", s);
             p = true;
         }
         assertTrue("Loop missed?", p);
-        
+
     }
-    
+
     @Test
     public void waitAll() throws Exception {
-        
+
         List<String> s = Promise.waitAll(new DoSomething2(200).now(), new DoSomething2(10).now()).get();
         assertEquals(2, s.size());
         assertEquals("-> 200", s.get(0));
         assertEquals("-> 10", s.get(1));
-        
+
     }
-    
+
     @Test
     public void wait2() throws Exception {
-        
+
         F.Tuple<String, F.Option<String>> t = Promise.wait2(new DoSomething2(200).now(), new DoSomething(10).now()).get();
-        
+
         assertEquals("-> 200", t._1);
         for(String s : t._2) {
             fail("Oops");
         }
-        
+
     }
-    
+
     @Test
     public void eventStream() throws Exception {
-        
+
         final EventStream<String> stream = new EventStream<String>();
-        
+
         new Thread() {
-            
+
             public void run() {
                 try {
                     Thread.sleep(300);
                     stream.publish("Héhé");
                 } catch(Exception e) {
                     throw new RuntimeException(e);
-                }                
+                }
             }
-            
+
         }.start();
-        
+
         for(int i=0; i<6; i++) {
-            
+
             String eventReceived = Promise.waitAny(stream.nextEvent(), new DoSomething2(100).now()).get();
             System.out.println(i + " -> " + eventReceived);
-            
+
             switch(i) {
                 case 0:
                     assertEquals("-> 100", eventReceived);
@@ -145,7 +148,7 @@ public class Promises extends UnitTest {
                     break;
                 case 1:
                     assertEquals("Héhé", eventReceived);
-                    break;  
+                    break;
                 case 2:
                     assertEquals("-> 100", eventReceived);
                     stream.publish("Coco");
@@ -161,36 +164,36 @@ public class Promises extends UnitTest {
                     assertEquals("-> 100", eventReceived);
                     break;
             }
-        }        
-        
+        }
+
     }
-    
+
     @Test
     public void bufferedEventStream() throws Exception {
-        
+
         IndexedEvent.resetIdGenerator();
         final ArchivedEventStream<String> stream = new ArchivedEventStream<String>(5);
-        
+
         new Thread() {
-            
+
             public void run() {
                 try {
                     Thread.sleep(300);
                     stream.publish("Héhé");
                 } catch(Exception e) {
                     throw new RuntimeException(e);
-                }                
+                }
             }
-            
+
         }.start();
-        
+
         long lastSeen = 0;
-        
+
         for(int i=0; i<10; i++) {
-            
+
             F.Either<List<IndexedEvent<String>>,String> eventReceived = Promise.waitEither(stream.nextEvents(lastSeen), new DoSomething2(100).now()).get();
             System.out.println(i + " -> " + eventReceived);
-            
+
             switch(i) {
                 case 0:
                     assertEquals("-> 100", eventReceived._2.get());
@@ -200,7 +203,7 @@ public class Promises extends UnitTest {
                     assertEquals(1, eventReceived._1.get().size());
                     assertEquals("Héhé", eventReceived._1.get().get(0).data);
                     assertEquals((Long)1L, eventReceived._1.get().get(0).id);
-                    break;  
+                    break;
                 case 2:
                     assertEquals(1, eventReceived._1.get().size());
                     assertEquals("Héhé", eventReceived._1.get().get(0).data);
@@ -247,8 +250,17 @@ public class Promises extends UnitTest {
                     break;
             }
         }
-        
+
     }
-    
-    
+
+  @Test(expected = TimeoutException.class)
+  public void waitAllTimeout() throws InterruptedException, ExecutionException, TimeoutException {
+    Promise.waitAll(new DoSomething2(200).now(), new DoSomething2(200).now()).get(100, TimeUnit.MILLISECONDS);
+  }
+
+  @Test()
+  public void waitAllNoTimeout() throws InterruptedException, ExecutionException, TimeoutException {
+    Promise.waitAll(new DoSomething2(200).now(), new DoSomething2(200).now()).get(400, TimeUnit.MILLISECONDS);
+  }
+
 }


### PR DESCRIPTION
Original pull request here: https://github.com/playframework/play1/pull/608#issuecomment-21868646

Ticket: http://play.lighthouseapp.com/projects/57987-play-framework/tickets/1686-promisewaitallgetlong-timeunit-doesnt-respect-timeout

I changed code to be more readable and added a test. 
