### PR TITLE
Don't append semicolon to javascript by default

### DIFF
--- a/framework/src/play/templates/FastTags.java
+++ b/framework/src/play/templates/FastTags.java
@@ -79,7 +79,7 @@ public class FastTags {
         html += "pattern = pattern.replace(':'+key, val || '');"+ minimize;
         html += "}" + minimize;;
         html += "return pattern;" + minimize;;
-        html += "};" + minimize;
+        html += "}" + minimize;
 	out.println(html);
     }
 


### PR DESCRIPTION
Remove the trailing semicolon. It's not part of the Javascript statement and restricts the usage of the jsAction tag to single-line assignments. You can't use the tag in Javascript maps (objects) or lists, e.g.

```
var options = {editUrl: #{jsAction @edit(":id") /}, bar: true, listUrl: #{jsAction @list(":id") /}, baz: "ADMIN"}
```
