### PR TITLE
[#943] Fix Autotest Connection Refused - Also when Running in test mode

### DIFF
--- a/framework/src/play/server/Server.java
+++ b/framework/src/play/server/Server.java
@@ -130,7 +130,7 @@ public class Server {
             Logger.error("Could not bind on port " + httpsPort, e);
             Play.fatalServerErrorOccurred();
         }
-        if (Play.mode == Mode.DEV) {
+        if (Play.mode == Mode.DEV || Play.runingInTestMode()) {
            // print this line to STDOUT - not using logger, so auto test runner will not block if logger is misconfigured (see #1222)     
            System.out.println("~ Server is up and running");
 	}


### PR DESCRIPTION
The previous committed fix (https://github.com/playframework/play1/commit/b13b53dd6a162756310e4051671b54ce389394ae) does not work if you want to auto run the test in prod mode.
See http://play.lighthouseapp.com/projects/57987/tickets/943
