### PR TITLE
[#1692] Don't set Content-Length on a 304 response

### DIFF
--- a/framework/src/play/server/PlayHandler.java
+++ b/framework/src/play/server/PlayHandler.java
@@ -361,11 +361,12 @@ public class PlayHandler extends SimpleChannelUpstreamHandler {
         ChannelBuffer buf = ChannelBuffers.copiedBuffer(content);
         nettyResponse.setContent(buf);
 
-        if (Logger.isTraceEnabled()) {
-            Logger.trace("writeResponse: content length [" + response.out.size() + "]");
+        if (!nettyResponse.getStatus().equals(HttpResponseStatus.NOT_MODIFIED)) {
+            if (Logger.isTraceEnabled()) {
+                Logger.trace("writeResponse: content length [" + response.out.size() + "]");
+            }
+            setContentLength(nettyResponse, response.out.size());
         }
-
-        setContentLength(nettyResponse, response.out.size());
 
         ChannelFuture f = ctx.getChannel().write(nettyResponse);
 


### PR DESCRIPTION
##### Framework version: 1.2.x
##### Details:

Content-Length should not be set for a 304 response. Browsers might not render it correctly if content length is set to 0 on a 304 response.
