### PR TITLE
[#1696] Non-argument version of asdate() java extension

### DIFF
--- a/framework/src/play/templates/JavaExtensions.java
+++ b/framework/src/play/templates/JavaExtensions.java
@@ -219,6 +219,10 @@ public class JavaExtensions {
         return Messages.get("since.years", years, pluralize(years));
     }
 
+    public static String asdate(Long timestamp) {
+        return asdate(timestamp, I18N.getDateFormat());
+    }
+    
     public static String asdate(Long timestamp, String pattern) {
         return asdate(timestamp, pattern, Lang.get());
     }


### PR DESCRIPTION
See http://play.lighthouseapp.com/projects/57987-play-framework/tickets/1696-non-argument-version-of-asdate-java-extension-doesnt-exist
