### PR TITLE
[#1697] Date format() java extension should honor current locale

### DIFF
--- a/framework/src/play/i18n/Lang.java
+++ b/framework/src/play/i18n/Lang.java
@@ -181,7 +181,10 @@ public class Lang {
      * associated to the current Lang.
      */
     public static Locale getLocale() {
-        String localeStr = get();
+        return getLocaleOrDefault(get());
+    }
+
+    public static Locale getLocaleOrDefault(String localeStr) {
         Locale locale = getLocale(localeStr);
         if (locale != null) {
             return locale;

--- a/framework/src/play/templates/JavaExtensions.java
+++ b/framework/src/play/templates/JavaExtensions.java
@@ -156,7 +156,7 @@ public class JavaExtensions {
     }
 
     public static String format(Number number, String pattern) {
-        DecimalFormatSymbols symbols = new DecimalFormatSymbols(new Locale(Lang.get()));
+        DecimalFormatSymbols symbols = new DecimalFormatSymbols(Lang.getLocale());
         return new DecimalFormat(pattern, symbols).format(number);
     }
 
@@ -170,11 +170,11 @@ public class JavaExtensions {
     }
 
     public static String format(Date date, String pattern, String lang) {
-        return new SimpleDateFormat(pattern, new Locale(lang)).format(date);
+        return new SimpleDateFormat(pattern, Lang.getLocaleOrDefault(lang)).format(date);
     }
 
     public static String format(Date date, String pattern, String lang, String timezone) {
-        DateFormat df = new SimpleDateFormat(pattern, new Locale(lang));
+        DateFormat df = new SimpleDateFormat(pattern, Lang.getLocaleOrDefault(lang));
         df.setTimeZone(TimeZone.getTimeZone(timezone));
         return df.format(date);
     }
@@ -224,7 +224,7 @@ public class JavaExtensions {
     }
 
     public static String asdate(Long timestamp, String pattern, String lang) {
-        return new SimpleDateFormat(pattern, new Locale(lang)).format(new Date(timestamp));
+        return new SimpleDateFormat(pattern, Lang.getLocaleOrDefault(lang)).format(new Date(timestamp));
     }
 
     public static String asdate(Long timestamp, String pattern, String lang, String timezone) {
@@ -267,7 +267,7 @@ public class JavaExtensions {
 
     public static String formatCurrency(Number number, String currencyCode) {
         Currency currency = Currency.getInstance(currencyCode);
-        NumberFormat numberFormat = NumberFormat.getCurrencyInstance(new Locale(Lang.get()));
+        NumberFormat numberFormat = NumberFormat.getCurrencyInstance(Lang.getLocale());
         numberFormat.setCurrency(currency);
         numberFormat.setMaximumFractionDigits(currency.getDefaultFractionDigits());
         String s = numberFormat.format(number);


### PR DESCRIPTION
The first commit fixes the issue.
The second and third commit are code cleanups.
See http://play.lighthouseapp.com/projects/57987-play-framework/tickets/1697-date-format-java-extension-doesnt-honor-current-locale
