### PR TITLE
[#974] String.format uses current locale for message formatting

### DIFF
--- a/framework/src/play/i18n/Messages.java
+++ b/framework/src/play/i18n/Messages.java
@@ -104,7 +104,7 @@ public class Messages {
     }
 
     public static String formatString(String value, Object... args) {
-        String message = String.format(value, coolStuff(value, args));
+        String message = String.format(Lang.getLocale(), value, coolStuff(value, args));
         Matcher matcher = recursive.matcher(message);
         StringBuffer sb = new StringBuffer();
         while(matcher.find()) {


### PR DESCRIPTION
See http://play.lighthouseapp.com/projects/57987/tickets/974-locale-should-be-passed-with-stringformat-used-for-message-formatting
