### PR TITLE
[#1315] @InFuture and @InPast now honor date.format in the error message

### DIFF
--- a/framework/src/play/data/validation/InFutureCheck.java
+++ b/framework/src/play/data/validation/InFutureCheck.java
@@ -10,6 +10,7 @@ import net.sf.oval.configuration.annotation.AbstractAnnotationCheck;
 import net.sf.oval.context.OValContext;
 import play.utils.Utils.AlternativeDateFormat;
 import play.exceptions.UnexpectedException;
+import play.libs.I18N;
 
 @SuppressWarnings("serial")
 public class InFutureCheck extends AbstractAnnotationCheck<InFuture> {
@@ -50,7 +51,7 @@ public class InFutureCheck extends AbstractAnnotationCheck<InFuture> {
     @Override
     public Map<String, String> createMessageVariables() {
         Map<String, String> messageVariables = new HashMap<String, String>();
-        messageVariables.put("reference", new SimpleDateFormat("yyyy-MM-dd").format(reference));
+        messageVariables.put("reference", new SimpleDateFormat(I18N.getDateFormat()).format(reference));
         return messageVariables;
     }
    

--- a/framework/src/play/data/validation/InPastCheck.java
+++ b/framework/src/play/data/validation/InPastCheck.java
@@ -10,6 +10,7 @@ import net.sf.oval.configuration.annotation.AbstractAnnotationCheck;
 import net.sf.oval.context.OValContext;
 import play.utils.Utils.AlternativeDateFormat;
 import play.exceptions.UnexpectedException;
+import play.libs.I18N;
 
 @SuppressWarnings("serial")
 public class InPastCheck extends AbstractAnnotationCheck<InPast> {
@@ -49,7 +50,7 @@ public class InPastCheck extends AbstractAnnotationCheck<InPast> {
     @Override
     public Map<String, String> createMessageVariables() {
         Map<String, String> messageVariables = new HashMap<String, String>();
-        messageVariables.put("reference", new SimpleDateFormat("yyyy-MM-dd").format(reference));
+        messageVariables.put("reference", new SimpleDateFormat(I18N.getDateFormat()).format(reference));
         return messageVariables;
     }
 }


### PR DESCRIPTION
See http://play.lighthouseapp.com/projects/57987/tickets/1315-infuture-and-inpast-validators-dont-use-the-current-locale-for-formatting-the-error-message
