### PR TITLE
[#1698] Fix select template tag to allow % and other non-String objects as label

### DIFF
--- a/framework/templates/tags/select.tag
+++ b/framework/templates/tags/select.tag
@@ -24,7 +24,7 @@
 <select name="${_name}" size="${_size?:1}" ${serializedAttrs}>
     #{doBody /}
     #{list items:_items, as:'i'}
-        #{option _valueProperty && i.hasProperty(_valueProperty) ? i[_valueProperty] : i}&{_labelProperty && i.hasProperty(_labelProperty) ? play.utils.HTML.htmlEscape(i[_labelProperty]) : i}#{/option}
+        #{option _valueProperty && i.hasProperty(_valueProperty) ? i[_valueProperty] : i}&{(_labelProperty && i.hasProperty(_labelProperty) ? play.utils.HTML.htmlEscape(i[_labelProperty]?.toString()) : i?.toString())?.replace("%", "%%")}#{/option}
     #{/list}
 </select>
 

--- a/samples-and-tests/just-test-cases/app/controllers/Application.java
+++ b/samples-and-tests/just-test-cases/app/controllers/Application.java
@@ -317,7 +317,7 @@ public class Application extends Controller {
     }
 
     public static void selectTag(){
-        List<User> users = new ArrayList<User>(10);
+        List<User> users = new ArrayList<User>(12);
         User user;
         for(long i = 0; i < 10; i++) {
         	user = new User("User-" + i);
@@ -325,6 +325,14 @@ public class Application extends Controller {
         	user.i = (int) i;
         	users.add(user);
         }
+        user = new User("User-%-10");
+        user.k = 10L;
+        user.i = (int) 10;
+        users.add(user);
+        user = new User("User-%%-11");
+        user.k = 11L;
+        user.i = (int) 11;
+        users.add(user);
         render(users);
     }
     

--- a/samples-and-tests/just-test-cases/app/views/Application/selectTag.html
+++ b/samples-and-tests/just-test-cases/app/views/Application/selectTag.html
@@ -21,3 +21,5 @@ valueProperty is a Long object, value is an Integer object: #{select 'users', it
 
 valueProperty is an Integer object, value is a Long object: #{select 'users', items:users, valueProperty:'i', labelProperty:'name', value:longValue, class:"test", id:'select_int_value_long_sel' /}<br />
 valueProperty is an Integer object, value is an Integer object: #{select 'users', items:users, valueProperty:'i', labelProperty:'name', value:intValue, class:"test", id:'select_int_value_int_sel' /}<br />
+
+labelProperty is a Long object: #{select 'users', items:users, valueProperty:'k', labelProperty:'k', value:longValue, class:"test", id:'select_long_label' /}<br />


### PR DESCRIPTION
The % character needs to be escaped when used inside a messages tag
(which the #{select} template tag does for label). In addition,
labelProperty can point to a non-String field, so toString should be
called on that before trying to HTML escape it.

http://play.lighthouseapp.com/projects/57987-play-framework/tickets/1698-fix-select-template-tag-to-allow-and-other-non-string-objects-as-label
