### PR TITLE
[#1699] Stop play netbeansify ignoring framework ID.

### DIFF
--- a/framework/pym/play/commands/netbeans.py
+++ b/framework/pym/play/commands/netbeans.py
@@ -32,6 +32,7 @@ def execute(**kargs):
     replaceAll(os.path.join(nbproject, 'project.xml'), r'%ANT_SCRIPT%', os.path.normpath(os.path.join(play_env["basedir"], 'framework/build.xml')))
     replaceAll(os.path.join(nbproject, 'project.xml'), r'%APPLICATION_PATH%', os.path.normpath(app.path))
     replaceAll(os.path.join(nbproject, 'project.xml'), r'%PLAY_CLASSPATH%', ';'.join(classpath + ['nbproject%sclasses'%os.sep, '%s%sframework%ssrc'%(play_env["basedir"], os.sep, os.sep)]))
+    replaceAll(os.path.join(nbproject, 'project.xml'), r'%PLAY_ID%', play_env["id"])
     mr = ""
     for module in modules:
         mr += "<package-root>%s</package-root>" % os.path.normpath(os.path.join(module, 'app'))

--- a/resources/_nbproject/project.xml
+++ b/resources/_nbproject/project.xml
@@ -12,6 +12,7 @@
                 <property name="ant.script">%ANT_SCRIPT%</property>
                 <property name="application.path">%APPLICATION_PATH%</property>
                 <property name="application.name">%APPLICATION_NAME%</property>
+                <property name="play.id">%PLAY_ID%</property>
             </properties>
             <folders>
                 <source-folder>
@@ -52,17 +53,20 @@
                     <script>${ant.script}</script>
                     <target>nb-run-application</target>
                     <property name="application.path">${application.path}</property>
+                    <property name="play.id">${play.id}</property>
                 </action>
                 <action name="debug">
                     <script>${ant.script}</script>
                     <target>nb-debug</target>
                     <property name="application.name">${application.name}</property>
                     <property name="application.path">${application.path}</property>
+                    <property name="play.id">${play.id}</property>
                 </action>
                 <action name="test">
                     <script>${ant.script}</script>
                     <target>test-application</target>
                     <property name="application.path">${application.path}</property>
+                    <property name="play.id">${play.id}</property>
                 </action>
             </ide-actions>
             <view>


### PR DESCRIPTION
**play netbeansify --%fwk_id** ignores the framework ID parameter that is mentioned in the documentation. See http://play.lighthouseapp.com/projects/57987-play-framework/tickets/1699-play-netbeansify-ignores-specified-framework-id for details.

This is just a bugfix.
