### PR TITLE
[#1705] Fallback to directly accessing a field when an enhanced getter isn't found

### DIFF
--- a/framework/src/play/classloading/enhancers/PropertiesEnhancer.java
+++ b/framework/src/play/classloading/enhancers/PropertiesEnhancer.java
@@ -220,7 +220,7 @@ public class PropertiesEnhancer extends Enhancer {
                 Object result = getterMethod.invoke(o);
                 return result;
             } catch (NoSuchMethodException e) {
-                throw e;
+                return o.getClass().getField(property).get(o);
             } catch (InvocationTargetException e) {
                 throw e.getCause();
             }


### PR DESCRIPTION
This prevents NoSuchMethodExceptions when fields were not enhanced.  This happens, for example, when a field was declared in a class that the compiler does not have the source for.
