### PR TITLE
[#1707] output correct flash values (regression since the security fix)

### DIFF
--- a/framework/src/play/mvc/Scope.java
+++ b/framework/src/play/mvc/Scope.java
@@ -66,7 +66,7 @@ public class Scope {
                 return;
             }
             try {
-                String flashData = CookieDataCodec.encode(data);
+                String flashData = CookieDataCodec.encode(out);
                 Http.Response.current().setCookie(COOKIE_PREFIX + "_FLASH", flashData, null, "/", null, COOKIE_SECURE);
             } catch (Exception e) {
                 throw new UnexpectedException("Flash serializationProblem", e);


### PR DESCRIPTION
http://play.lighthouseapp.com/projects/57987-play-framework/tickets/1707-new-more-secure-cookie-handling-broke-flash-logic
