### PR TITLE
[#1711] "play idealize" place module sources into <SOURCES/> element of iml-file

### DIFF
--- a/framework/pym/play/commands/intellij.py
+++ b/framework/pym/play/commands/intellij.py
@@ -39,7 +39,7 @@ def execute(**kargs):
     msXML = ""
     jdXML = ""
     if os.path.exists(os.path.join(app.path, 'lib')):
-        msXML += '                  <root url="file://$MODULE_DIR$/lib" />'
+        mlXML += '<root url="file://$MODULE_DIR$/lib" />\n'
     if len(modules):
         for i, module in enumerate(modules):
             libpath = os.path.join(module, 'lib')
@@ -52,7 +52,7 @@ def execute(**kargs):
                 jdXML += '                <jarDirectory url="file://$MODULE_DIR$/%s" recursive="false"/>\n' % (app.toRelative(libpath).replace('\\', '/'))
     replaceAll(imlFile, r'%LINKS%', lXML)
     replaceAll(imlFile, r'%MODULE_LINKS%', mlXML)
-    replaceAll(imlFile, r'%MODULE_LIB_CLASSES%', msXML)
+    replaceAll(imlFile, r'%MODULE_SOURCES%', msXML)
     replaceAll(imlFile, r'%MODULE_LIBRARIES%', jdXML)
     
     iprFile = os.path.join(app.path, application_name + '.ipr')

--- a/resources/idea/imlTemplate.xml
+++ b/resources/idea/imlTemplate.xml
@@ -13,11 +13,12 @@
         <orderEntry type="module-library">
             <library name="Project Libraries">
                 <CLASSES>
-                    %MODULE_LIB_CLASSES%
                     %MODULE_LINKS%
                 </CLASSES>
                 <JAVADOC />
-                <SOURCES />
+                <SOURCES>
+                    %MODULE_SOURCES%
+                </SOURCES>
                 <jarDirectory url="file://$MODULE_DIR$/lib" recursive="false" />
                 %MODULE_LIBRARIES%
             </library>


### PR DESCRIPTION
Pre-patch behavior: lib/ and src/ module subdirectories goes to "CLASSES" element of iml-file. IntelliJ IDEA doesn't load module sources.
After-patch: src/ module subdir goes to "SOURCES" element of iml-file. IDEA loads module sources.
