### PR TITLE
[#95] JavaDoc should generate HTML files with UTF-8 charset 

### DIFF
--- a/framework/pym/play/commands/javadoc.py
+++ b/framework/pym/play/commands/javadoc.py
@@ -38,7 +38,7 @@ def execute(**kargs):
     serr = open(os.path.join(app.log_path(), 'javadoc.err'), 'w')
     if (os.path.isdir(outdir)):
         shutil.rmtree(outdir)
-    javadoc_cmd = [javadoc_path, '-classpath', app.cp_args(), '-d', outdir] + args + fileList
+    javadoc_cmd = [javadoc_path, '-classpath', app.cp_args(), '-d', outdir, '-encoding', 'UTF-8', '-charset', 'UTF-8'] + args + fileList
     print "Generating Javadoc in " + outdir + "..."
     subprocess.call(javadoc_cmd, env=os.environ, stdout=sout, stderr=serr)
     print "Done! You can open " + os.path.join(outdir, 'overview-tree.html') + " in your browser."


### PR DESCRIPTION
Ticket [lighthouse #95](http://play.lighthouseapp.com/projects/57987-play-framework/tickets/95)
