### PR TITLE
[#1722] honour play.tmp setting in 'play clean' command

### DIFF
--- a/framework/pym/play/commands/base.py
+++ b/framework/pym/play/commands/base.py
@@ -165,7 +165,7 @@ def run(app, args):
 def clean(app):
     app.check()
     tmp = app.readConf('play.tmp')
-    if (tmp is None):
+    if tmp is None or not tmp.strip():
         tmp = 'tmp'
     print "~ Deleting %s" % os.path.normpath(os.path.join(app.path, tmp))
     if os.path.exists(os.path.join(app.path, tmp)):


### PR DESCRIPTION
when the play.tmp is defined, use `play clean` will clean the play.tmp directory
