### PR TITLE
[#1720] bean binder fails on collection of parametrized types

### DIFF
--- a/framework/src/play/data/binding/Binder.java
+++ b/framework/src/play/data/binding/Binder.java
@@ -390,8 +390,14 @@ public abstract class Binder {
         }
 
         Class componentClass = String.class;
+        Type componentType = String.class;
         if (type instanceof ParameterizedType) {
-            componentClass = (Class) ((ParameterizedType) type).getActualTypeArguments()[0];
+            componentType = ((ParameterizedType) type).getActualTypeArguments()[0];
+            if(componentType instanceof ParameterizedType) {
+                componentClass = (Class) ((ParameterizedType) componentType).getRawType();
+            } else {
+                componentClass = (Class) componentType;
+            }
         }
 
         if (paramNode.getAllChildren().isEmpty()) {
@@ -417,7 +423,7 @@ public abstract class Binder {
             Collection l = (Collection) clazz.newInstance();
             for (int i = 0; i < values.length; i++) {
                 try {
-                    Object value = directBind(paramNode.getOriginalKey(), bindingAnnotations.annotations, values[i], componentClass, componentClass);
+                    Object value = directBind(paramNode.getOriginalKey(), bindingAnnotations.annotations, values[i], componentClass, componentType);
                     l.add(value);
                 } catch (Exception e) {
                     // Just ignore the exception and continue on the next item
@@ -448,7 +454,7 @@ public abstract class Binder {
 
             for (String index : indexes) {
                 ParamNode child = paramNode.getChild(index);
-                Object childValue = internalBind(child, componentClass, componentClass, bindingAnnotations);
+                Object childValue = internalBind(child, componentClass, componentType, bindingAnnotations);
                 if (childValue != NO_BINDING && childValue != MISSING) {
 
                     // must make sure we place the value at the correct position
@@ -469,7 +475,7 @@ public abstract class Binder {
         }
 
         for (ParamNode child : paramNode.getAllChildren()) {
-            Object childValue = internalBind(child, componentClass, componentClass, bindingAnnotations);
+            Object childValue = internalBind(child, componentClass, componentType, bindingAnnotations);
             if (childValue != NO_BINDING && childValue != MISSING) {
                 r.add(childValue);
             }

--- a/framework/test-src/play/data/binding/BinderTest.java
+++ b/framework/test-src/play/data/binding/BinderTest.java
@@ -199,6 +199,22 @@ public class BinderTest {
         assertThat(Validation.error("b")).isNotNull();
     }
 
+    @Test
+    public void verify_binding_collections_of_generic_types() throws Exception {
+        Map<String, String[]> params = new HashMap<String, String[]>();
+        params.put("data.genericTypeList", new String[]{"1", "2", "3"});
+
+        RootParamNode rootParamNode = ParamNode.convert(params);
+        Data3 result = (Data3) Binder.bind(rootParamNode, "data", Data3.class,
+                Data3.class, noAnnotations);
+
+        assertThat(result.genericTypeList).hasSize(3);
+
+        for (int i = 1; i < 3; i++) {
+            assertThat(result.genericTypeList.get(i - 1).value).isEqualTo(Long.valueOf(i));
+        }
+    }
+
     /**
      * Transforms map from Unbinder to Binder
      * @param r map filled by Unbinder

--- a/framework/test-src/play/data/binding/Data3.java
+++ b/framework/test-src/play/data/binding/Data3.java
@@ -1,10 +1,38 @@
 package play.data.binding;
 
 
+import java.lang.annotation.Annotation;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 class Data3 {
     public String a;
     public Map<String, String> map = new HashMap<String, String>();
+    @As(binder = TestGenericTypeBinder.class)
+    public List<GenericType<Long>> genericTypeList = new ArrayList<GenericType<Long>>();
+
+
+    public static class GenericType<T> {
+        T value;
+    }
+
+    public static class TestGenericTypeBinder implements TypeBinder<GenericType<?>> {
+
+        @Override
+        public Object bind(String name, Annotation[] annotations, String value, Class actualClass, Type genericType) throws Exception {
+            ParameterizedType pt = (ParameterizedType) genericType;
+            if (!Long.class.equals(pt.getActualTypeArguments()[0])) {
+                throw new IllegalArgumentException("Wrong generic type passed. Does not match class declatarion.");
+            }
+
+            Long longValue = Long.valueOf(value);
+            GenericType<Long> gt = new GenericType<Long>();
+            gt.value = longValue;
+            return gt;
+        }
+    }
 }


### PR DESCRIPTION
Fix for [#1720] bean binder fails on collection of parametrized types:

Using type.getRawType() as base class for binder if collection contains generic types + tests
