### PR TITLE
[#1721] Check if filename is not a directory when loading fixtures

### DIFF
--- a/framework/src/play/test/Fixtures.java
+++ b/framework/src/play/test/Fixtures.java
@@ -163,11 +163,14 @@ public class Fixtures {
         try {
             for (VirtualFile vf : Play.javaPath) {
                 yamlFile = vf.child(name);
-                if (yamlFile != null && yamlFile.exists()) {
+                // Check that the vf exist and isn't a directory
+                if (yamlFile != null && yamlFile.exists() && !yamlFile.isDirectory()) {
                     break;
                 }
             }
-            if (yamlFile == null || !yamlFile.exists()) {
+            
+            // Check again the vf exist and isn't a directory
+            if (yamlFile == null || !yamlFile.exists() || yamlFile.isDirectory()) {
                 throw new RuntimeException("Cannot load fixture " + name + ", the file was not found");
             }
 
@@ -330,7 +333,7 @@ public class Fixtures {
         try {
             for (VirtualFile vf : Play.javaPath) {
                 yamlFile = vf.child(name);
-                if (yamlFile != null && yamlFile.exists()) {
+                if (yamlFile != null && yamlFile.exists() && !yamlFile.isDirectory()) {
                     break;
                 }
             }
@@ -402,7 +405,7 @@ public class Fixtures {
                 m.find();
                 String file = m.group(1);
                 VirtualFile f = Play.getVirtualFile(file);
-                if (f != null && f.exists()) {
+                if (f != null && f.exists() && !f.isDirectory()) {
                     serialized.put(prefix + "." + key.toString(), new String[]{f.contentAsString()});
                 }
             } else {


### PR DESCRIPTION
[Lighthouse #1721](http://play.lighthouseapp.com/projects/57987-play-framework/tickets/1721-exception-not-handle-when-loading-fixture-if-file-is-a-directory)
