### PR TITLE
#1727 Unbinder: handle beans with collections and arrays of other beans

### DIFF
--- a/framework/src/play/data/binding/Unbinder.java
+++ b/framework/src/play/data/binding/Unbinder.java
@@ -50,18 +50,15 @@ public class Unbinder {
             Class<?> clazz = src.getClass().getComponentType();
             int size = Array.getLength(src);
             for (int i = 0; i < size; i++) {
-                unBind(result, Array.get(src, i), clazz, name, annotations);
+                unBind(result, Array.get(src, i), clazz, name + "[" + i + "]", annotations);
             }
         } else if (Collection.class.isAssignableFrom(src.getClass())) {
             if (Map.class.isAssignableFrom(src.getClass())) {
                 throw new UnsupportedOperationException("Unbind won't work with maps yet");
             } else {
                 Collection<?> c = (Collection<?>) src;
-                List<Object> objects = new ArrayList<Object>();
-                result.put(name, objects);
-                for (Object object : c) {
-                    unBind(result, object, object.getClass(), name, annotations);
-                }
+                Object[] srcArray = c.toArray();
+                unBind(result, srcArray, srcArray.getClass(), name, annotations);
             }
         } else if (Date.class.isAssignableFrom(src.getClass()) || Calendar.class.isAssignableFrom(src.getClass())) {
             // We should use the @As annotation if there is one

--- a/framework/test-src/play/data/binding/BinderTest.java
+++ b/framework/test-src/play/data/binding/BinderTest.java
@@ -215,6 +215,38 @@ public class BinderTest {
         }
     }
 
+    @Test
+    public void test_unbinding_of_collection_of_complex_types() {
+        Data1 d1 = new Data1();
+        d1.a = "a";
+        d1.b = 1;
+
+        Data1 d2 = new Data1();
+        d2.a = "b";
+        d2.b = 2;
+
+        Data1 d3 = new Data1();
+        d3.a = "c";
+        d3.b = 3;
+
+        Data1[] datasArray = {d1, d2};
+        List<Data1> datas = Arrays.asList(new Data1[]{d2, d1, d3});
+
+        Data4 original = new Data4();
+        original.s = "some";
+        original.datas = datas;
+        original.datasArray = datasArray;
+
+        Map<String, Object> result = new HashMap<String, Object>();
+        Unbinder.unBind(result, original, "data", noAnnotations);
+
+        Map<String, String[]> r2 = fromUnbindMap2BindMap(result);
+        RootParamNode root = ParamNode.convert(r2);
+
+        Object binded = Binder.bind(root, "data", Data4.class, Data4.class, noAnnotations);
+        assertThat(binded).isEqualTo(original);
+    }
+
     /**
      * Transforms map from Unbinder to Binder
      * @param r map filled by Unbinder
@@ -229,6 +261,9 @@ public class BinderTest {
                 r2.put(key, new String[]{(String)v});
             } else if (v instanceof String[]) {
                 r2.put(key, (String[])v);
+            } else if (v instanceof Collection) {
+                Object[] array = ((Collection) v).toArray();
+                r2.put(key, Arrays.copyOf(array, array.length, String[].class));
             } else {
                 throw new RuntimeException("error");
             }

--- a/framework/test-src/play/data/binding/Data1.java
+++ b/framework/test-src/play/data/binding/Data1.java
@@ -33,4 +33,13 @@ public class Data1 {
         result = 31 * result + b;
         return result;
     }
+
+    @Override
+    public String toString() {
+        return "Data1{" +
+                "f='" + f + '\'' +
+                ", a='" + a + '\'' +
+                ", b=" + b +
+                '}';
+    }
 }

--- a/framework/test-src/play/data/binding/Data4.java
+++ b/framework/test-src/play/data/binding/Data4.java
@@ -1,0 +1,43 @@
+package play.data.binding;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class Data4 {
+
+    public String s;
+    public List<Data1> datas;
+    public Data1[] datasArray;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Data4 data4 = (Data4) o;
+
+        if (datas != null ? !datas.equals(data4.datas) : data4.datas != null) return false;
+        //asList to ignore sequence of elements. It's not mandatory in binder
+        if (datas != null ? !Arrays.asList(datas).equals(Arrays.asList(data4.datas)) : data4.datas != null) return false;
+        if (s != null ? !s.equals(data4.s) : data4.s != null) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = s != null ? s.hashCode() : 0;
+        result = 31 * result + (datas != null ? datas.hashCode() : 0);
+        result = 31 * result + (datasArray != null ? Arrays.hashCode(datasArray) : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "Data4{" +
+                "s='" + s + '\'' +
+                ", datas=" + datas +
+                ", datasArray=" + Arrays.toString(datasArray) +
+                '}';
+    }
+}


### PR DESCRIPTION
Fix for #1727:

http://play.lighthouseapp.com/projects/57987-play-framework/tickets/1727-unbinder-fails-when-serializing-bean-with-collection-of-other-beans

This fix changes way that collections are unbinded. They no longer will be serialized as `data.collection=[val1, val2]` but to `data.collection[0]=val1&data.collection[1]=val2`.

Let me know if you think it might break something.
