### PR TITLE
[#1731] Improve error handling in onApplicationStop() method

### DIFF
--- a/framework/src/play/plugins/PluginCollection.java
+++ b/framework/src/play/plugins/PluginCollection.java
@@ -538,7 +538,9 @@ public class PluginCollection {
               plugin.onApplicationStop();
             }
             catch (Throwable t) {
-              if (Logger.isDebugEnabled())
+              if (t.getMessage() == null)
+                Logger.error(t, "Error while stopping %s", plugin);
+              else if (Logger.isDebugEnabled())
                 Logger.debug(t, "Error while stopping %s", plugin);
               else
                 Logger.info("Error while stopping %s: %s", plugin, t.toString());


### PR DESCRIPTION
If some plugin throws exception in onApplicationStop() method, onApplicationStop() is not called for other plugins.
Instead, we should log it and continue to call other plugins.
