### PR TITLE
[#1730] Exclude usual views folders from eclipse class path

### DIFF
--- a/resources/eclipse/.classpath
+++ b/resources/eclipse/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry excluding="views/**" kind="src" path="app"/>
+	<classpathentry excluding="japidviews/**|rythm/**|views/**" kind="src" path="app"/>
 	%TESTCLASSPATH%
 	%MODULES%
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>


### PR DESCRIPTION
Patch for http://play.lighthouseapp.com/projects/57987-play-framework/tickets/1730-exclude-usual-views-folders-from-eclipse-class-path
