### PR TITLE
[#1743] rememberme cookie has a wrong expiration

### DIFF
--- a/modules/secure/app/controllers/Secure.java
+++ b/modules/secure/app/controllers/Secure.java
@@ -87,7 +87,7 @@ public class Secure extends Controller {
         if(remember) {
             Date expiration = new Date();
             String duration = Play.configuration.getProperty("secure.rememberme.duration","30d"); 
-            expiration.setTime(expiration.getTime() + Time.parseDuration(duration) * 1000 );
+            expiration.setTime(expiration.getTime() + ((long)Time.parseDuration(duration)) * 1000L );
             response.setCookie("rememberme", Crypto.sign(username + "-" + expiration.getTime()) + "-" + username + "-" + expiration.getTime(), duration);
 
         }


### PR DESCRIPTION
The result of "Time.parseDuration(duration)" was treated as an Integer, and this can exceed the limit of Integer.MAX_VALUE very easily, we can cast to Long to prevent this issue.
