### PR TITLE
[#1750] Promise.get(timeout, unit) actually throws TimeoutExceptions

### DIFF
--- a/framework/src/play/libs/F.java
+++ b/framework/src/play/libs/F.java
@@ -52,7 +52,10 @@ public class F {
         }
 
         public V get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
-            taskLock.await(timeout, unit);
+            if(!taskLock.await(timeout, unit)) {
+              throw new TimeoutException(String.format("Promise didn't redeem in %s %s", timeout, unit));
+            }
+            
             if (exception != null) {
                 // The result of the promise is an exception - throw it
                 throw new ExecutionException(exception);

--- a/samples-and-tests/just-test-cases/test/Promises.java
+++ b/samples-and-tests/just-test-cases/test/Promises.java
@@ -263,4 +263,9 @@ public class Promises extends UnitTest {
     Promise.waitAll(new DoSomething2(200).now(), new DoSomething2(200).now()).get(400, TimeUnit.MILLISECONDS);
   }
 
+  @Test(expected = TimeoutException.class)
+  public void waitForTimeout() throws InterruptedException, ExecutionException, TimeoutException {
+    new DoSomething2(200).now().get(100, TimeUnit.MILLISECONDS);
+  }
+
 }


### PR DESCRIPTION
Promise.get(timeout, unit) actually throws TimeoutExceptions if underlying CountDownLatch.await doesn't trigger within given timeout.
