### PR TITLE
[#1757] log statement not logging exception

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ framework/docs
 samples-and-tests/*/test-result/
 
 # IDE and editors
+/bin
 *~
 .idea
 nbproject

--- a/framework/src/play/db/jpa/JPA.java
+++ b/framework/src/play/db/jpa/JPA.java
@@ -76,7 +76,7 @@ public class JPA {
             try {
                 jpaConfig.close();
             } catch (Exception e) {
-                Logger.error("Error closing JPA config "+jpaConfig.getConfigName(), e);
+                Logger.error(e, "Error closing JPA config "+jpaConfig.getConfigName());
             }
         }
         jpaConfigs.clear();
@@ -95,7 +95,7 @@ public class JPA {
                 try {
                     jpaConfig.getJPAContext().closeTx(rollback);
                 } catch (Exception e) {
-                    Logger.error("Error closing transaction "+jpaConfig.getConfigName(), e);
+                    Logger.error(e, "Error closing transaction "+jpaConfig.getConfigName());
                     error=true;
                 }
             }


### PR DESCRIPTION
someone passed in exception variable "e" at the end of a logging method 

public static void error(String message, Object... args) {

when they should be calling the other one so the stack trace is shown(ie. "e" should be before the message).

 public static void error(Throwable e, String message, Object... args) {
