### PR TITLE
[#1759] http 500 comes back but no exception existed in logs

### DIFF
--- a/framework/src/play/server/PlayHandler.java
+++ b/framework/src/play/server/PlayHandler.java
@@ -129,6 +129,7 @@ public class PlayHandler extends SimpleChannelUpstreamHandler {
                 }
 
             } catch (Exception ex) {
+            	Logger.warn(ex, "Exception on request. serving 500 back");
                 serve500(ex, ctx, nettyRequest);
             }
         }


### PR DESCRIPTION
This ensures we log the exception that occurred that causes the 500 to come back which just said Internal Error (See logs) but there were no logs.  Now there will be a log of the exception.
