### PR TITLE
[#1766] fix for websocket being overloaded

### DIFF
--- a/framework/src/play/mvc/Http.java
+++ b/framework/src/play/mvc/Http.java
@@ -22,6 +22,7 @@ import play.Play;
 import play.exceptions.UnexpectedException;
 import play.libs.Codec;
 import play.libs.F;
+import play.libs.F.BlockingEventStream;
 import play.libs.F.Option;
 import play.libs.F.Promise;
 import play.libs.F.EventStream;
@@ -829,7 +830,8 @@ public class Http {
         public static Inbound current() {
             return current.get();
         }
-        final EventStream<WebSocketEvent> stream = new EventStream<WebSocketEvent>();
+
+        final BlockingEventStream<WebSocketEvent> stream = new BlockingEventStream<WebSocketEvent>();
 
         public void _received(WebSocketFrame frame) {
             stream.publish(frame);


### PR DESCRIPTION
This prevents the websocket packet loss from the code doing a packet.poll()....not sure why someone decided to drop packets in the middle of a stream.  the dropped packets resulted in our client missing many messages.

Ideally, the client should be slowed down through tcp flow control(usually done by simply letting the local nic buffer fill up and not reading from the socket when overloaded which then prevents one client from overloading the system as the remote nic buffer then fills up preventing him from writing to the socket).

This fix causes tcp flow control to kick in at a cost of tying up a nio thread :( but there is no nio token to tell the nio library to stop reading from the socket until the queue empties out a little.
