### PR TITLE
[#1767] avoid a nullpointer bug when the stack is null

### DIFF
--- a/framework/src/play/classloading/enhancers/LVEnhancer.java
+++ b/framework/src/play/classloading/enhancers/LVEnhancer.java
@@ -230,11 +230,17 @@ public class LVEnhancer extends Enhancer {
         }
 
         public static void exitMethod(String clazz, String method, String signature) {
-            getCurrentMethodParams().pop();
+        	Stack<MethodExecution> stack = getCurrentMethodParams();
+        	if(stack.isEmpty())
+        		return;
+            stack.pop();
         }
 
         public static void initMethodCall(String method, int nbParams, String subject, String[] paramNames) {
-            getCurrentMethodParams().peek().currentNestedMethodCall = new MethodExecution(subject, paramNames, nbParams);
+        	Stack<MethodExecution> stack = getCurrentMethodParams();
+        	if(stack.isEmpty())
+        		return;
+        	stack.peek().currentNestedMethodCall = new MethodExecution(subject, paramNames, nbParams);
         }
         
         /**


### PR DESCRIPTION
This is a simple fix to avoid a nullpointer that had occurred in some 1.7 jdk bytecode situation.  There is obviously a bug in the bytecodeparser lib as well where enterMethod is not called but exitMethod is called.  I am not sure how to fix that bug, but we can avoid it easily enough so we can at least get basic play apps working.....in our case the below was throwing a nullpointer when calling the first method in a catch block for some reason.
