### PR TITLE
[#1772] Fix redirect to wrong domain and port behind apache

### DIFF
--- a/framework/src/play/mvc/Http.java
+++ b/framework/src/play/mvc/Http.java
@@ -369,6 +369,17 @@ public class Http {
 
             newRequest.parseXForwarded();
 
+            if (Play.configuration.containsKey("XForwardedOverwriteDomainAndPort") && newRequest.host != null && !newRequest.host.equals(_host)) {
+                if (newRequest.host.contains(":")) {
+                    final String[] hosts = newRequest.host.split(":");
+                    newRequest.port = Integer.parseInt(hosts[1]);
+                    newRequest.domain = hosts[0];
+                } else {
+                    newRequest.port = 80;
+                    newRequest.domain = newRequest.host;
+                }
+            }
+
             newRequest.resolveFormat();
 
             newRequest.authorizationInit();


### PR DESCRIPTION
We have a issue that play.mvc.Controller.redirect("url") doesn't redirect users correctly without ProxyPreserveHost directive setting.

Even if "XForwardedSupport=all" is set in the Play configuration, play.mvc.Controller.redirect("/index") redirects browsers to not "example.com/index" but "server1:9000/index" when mod_proxy's ProxyPreserveHost directive is absent.
In most every case, work around is setting ProxyPreserveHost. But we cannot set ProxyPreserveHost directive because other applications are also running in the same Apache vertual host.
We're not sure that this behavior is intentional, so our team forked Play 1.3.x and fixed the issue by adding new option named "XForwardedOverwriteDomainAndPort" and modifying play.mvc.Http.java.