### PR TITLE
delete tmp file

### DIFF
--- a/framework/src/play/server/StreamChunkAggregator.java
+++ b/framework/src/play/server/StreamChunkAggregator.java
@@ -74,6 +74,7 @@ public class StreamChunkAggregator extends SimpleChannelUpstreamHandler {
                     currentMessage.setContent(new FileChannelBuffer(localFile));
                     this.out = null;
                     this.currentMessage = null;
+                    this.file.delete();
                     this.file = null;
                     Channels.fireMessageReceived(ctx, currentMessage, e.getRemoteAddress());
                 }


### PR DESCRIPTION
1.3.x branch already has "this.file.delete()". This will delete tmp file when uploading. See also: https://github.com/playframework/play1/commit/4601b0d688124aaa82f7ee2260a27fa8f7c32833
