### PR TITLE
Updata Controller javadoc to inform that stream content may be fully loa...

### DIFF
--- a/framework/src/play/mvc/Controller.java
+++ b/framework/src/play/mvc/Controller.java
@@ -211,7 +211,8 @@ public class Controller implements ControllerSupport {
     }
 
     /**
-     * Return a 200 OK application/binary response
+     * Return a 200 OK application/binary response.
+     * Content is fully loaded in memory, so it should not be used with large data.
      * @param is The stream to copy
      */
     protected static void renderBinary(InputStream is) {
@@ -230,6 +231,7 @@ public class Controller implements ControllerSupport {
 
     /**
      * Return a 200 OK application/binary response with content-disposition attachment.
+     * Content is fully loaded in memory, so it should not be used with large data.
      *
      * @param is The stream to copy
      * @param name Name of file user is downloading.
@@ -251,6 +253,7 @@ public class Controller implements ControllerSupport {
 
     /**
      * Return a 200 OK application/binary response with content-disposition attachment.
+     * Content is fully loaded in memory, so it should not be used with large data.
      *
      * @param is The stream to copy
      * @param name Name of file user is downloading.
@@ -273,7 +276,9 @@ public class Controller implements ControllerSupport {
     }
 
     /**
-     * Return a 200 OK application/binary response with content-disposition attachment
+     * Return a 200 OK application/binary response with content-disposition attachment.
+     * Content is fully loaded in memory, so it should not be used with large data.
+     * 
      * @param is The stream to copy
      * @param name The attachment name
      * @param contentType The content type of the attachment


### PR DESCRIPTION
...ded in memory

Added the following comment on all renderBinary methods that accept an InputStream but no length parameter:
"Content is fully loaded in memory, so it should not be used with large data."

See the RenderBinary class: all data is copied into a ByteArrayInputStream (response.out). This can lead to OutOfMemoryErrors, so I think should be documented.
