### PR TITLE
[#1803] Added support for IPv6 IP address for the server

### DIFF
--- a/framework/src/play/server/PlayHandler.java
+++ b/framework/src/play/server/PlayHandler.java
@@ -559,15 +559,31 @@ public class PlayHandler extends SimpleChannelUpstreamHandler {
             host = "";
             port = 80;
             domain = "";
-        } else {
-            if (host.contains(":")) {
-                final String[] hosts = host.split(":");
-                port = Integer.parseInt(hosts[1]);
-                domain = hosts[0];
-            } else {
-                port = 80;
+        }
+        // Check for IPv6 address
+        else if (host.startsWith("[")) {
+            // There is no port
+            if (host.endsWith("]")) {
                 domain = host;
+                port = 80;
             }
+            else {
+                // There is a port so take from the last colon
+                int portStart = host.lastIndexOf(':');
+                if (portStart > 0 && (portStart + 1) < host.length()) {
+                    domain = host.substring(0, portStart);
+                    port = Integer.parseInt(host.substring(portStart + 1));
+                }
+            }
+        }
+        // Non IPv6 but has port
+        else if (host.contains(":")) {
+            final String[] hosts = host.split(":");
+            port = Integer.parseInt(hosts[1]);
+            domain = hosts[0];
+        } else {
+            port = 80;
+            domain = host;
         }
 
         boolean secure = false;


### PR DESCRIPTION
In Play Framework 1.2.x if you tried to use an IPv6 address for the server, you would end up with the following error:
2014-04-10 12:35:36,823 ERROR ~ 
java.lang.NullPointerException
at play.server.PlayHandler.serve500(PlayHandler.java:743)
at Invocation.Message Received(Play!)

For example, try localhost for a local server running with http://[::1]:8000

What happens is it sees the colon in the IPv6 address and attempts to parse the part of the address as the port. This fix allows parsing the host/port property when using IPv6 IP addresses.
