### PR TITLE
Security bug : leak private data of last user

### DIFF
--- a/framework/src/play/server/PlayHandler.java
+++ b/framework/src/play/server/PlayHandler.java
@@ -98,10 +98,12 @@ public class PlayHandler extends SimpleChannelUpstreamHandler {
 
             // Plain old HttpRequest
             try {
-                final Request request = parseRequest(ctx, nettyRequest, messageEvent);
-
+                //Reset request object and response object for the current thread.
+                Http.Request.current.set(new Http.Request());
                 final Response response = new Response();
                 Http.Response.current.set(response);
+
+                final Request request = parseRequest(ctx, nettyRequest, messageEvent);
 
                 // Buffered in memory output
                 response.out = new ByteArrayOutputStream();


### PR DESCRIPTION
Current thread does not clear, so the exception thrown by the parseRequest method can leak private data of last user.
Request headers with non-numeric port will cause error by the parseInt method and lead to problems.
