### PR TITLE
[#1814] Preserve order of HTTP GET/POST parameters

### DIFF
--- a/framework/src/play/data/parsing/UrlEncodedParser.java
+++ b/framework/src/play/data/parsing/UrlEncodedParser.java
@@ -5,6 +5,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import play.Logger;
@@ -46,7 +47,7 @@ public class UrlEncodedParser extends DataParser {
         // Encoding is either retrieved from contentType or it is the default encoding
         final String encoding = Http.Request.current().encoding;
         try {
-            Map<String, String[]> params = new HashMap<String, String[]>();
+            Map<String, String[]> params = new LinkedHashMap<String, String[]>();
             ByteArrayOutputStream os = new ByteArrayOutputStream();
             byte[] buffer = new byte[1024];
             int bytesRead;
@@ -117,7 +118,7 @@ public class UrlEncodedParser extends DataParser {
             }
 
             // We're ready to decode the params
-            Map<String, String[]> decodedParams = new HashMap<String, String[]>(params.size());
+            Map<String, String[]> decodedParams = new LinkedHashMap<String, String[]>(params.size());
             URLCodec codec = new URLCodec();
             for (Map.Entry<String, String[]> e : params.entrySet()) {
                 String key = e.getKey();

--- a/framework/src/play/mvc/Scope.java
+++ b/framework/src/play/mvc/Scope.java
@@ -3,6 +3,7 @@ package play.mvc;
 import java.lang.annotation.Annotation;
 import java.net.URLEncoder;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.UUID;
 
@@ -334,7 +335,7 @@ public class Scope {
             return current.get();
         }
         boolean requestIsParsed;
-        public Map<String, String[]> data = new HashMap<String, String[]>();
+        public Map<String, String[]> data = new LinkedHashMap<String, String[]>();
 
         boolean rootParamsNodeIsGenerated = false;
         private RootParamNode rootParamNode = null;


### PR DESCRIPTION
The fix is simple - just use LinkedHashMap instead of HashMap for parameter storage.

Rebasing to 1.3.x as requested, thus a new pull-request.
