### PR TITLE
[#1825] NPE is thrown when initializing some exception classes in precompiled mode

### DIFF
--- a/framework/src/play/exceptions/CacheException.java
+++ b/framework/src/play/exceptions/CacheException.java
@@ -1,30 +1,12 @@
 package play.exceptions;
 
-import java.util.Arrays;
-import java.util.List;
-import play.classloading.ApplicationClasses.ApplicationClass;
-import play.Play;
-
 /**
  * Cache related exception
  */
-public class CacheException extends PlayException {
+public class CacheException extends PlayExceptionWithJavaSource {
     
-    String sourceFile;
-    List<String> source;
-    Integer line;    
-
     public CacheException(String message, Throwable cause) {
         super(message, cause);
-        StackTraceElement element = getInterestingStrackTraceElement(cause);
-        if(element != null) {
-            ApplicationClass applicationClass = Play.classes.getApplicationClass(element.getClassName());
-            if (applicationClass.javaFile != null)
-                sourceFile = applicationClass.javaFile.relativePath();
-            if (applicationClass.javaSource != null)
-                source = Arrays.asList(applicationClass.javaSource.split("\n"));
-            line = element.getLineNumber();
-        }
     }
 
     @Override
@@ -35,22 +17,5 @@ public class CacheException extends PlayException {
     @Override
     public String getErrorDescription() {
         return getMessage();
-    }
-    
-    public String getSourceFile() {
-        return sourceFile;
-    }
-
-    public List<String> getSource() {
-        return source;
-    }
-
-    public Integer getLineNumber() {
-        return line;
-    }
-
-    @Override
-    public boolean isSourceAvailable() {
-        return sourceFile != null;
     }
 }

--- a/framework/src/play/exceptions/DatabaseException.java
+++ b/framework/src/play/exceptions/DatabaseException.java
@@ -1,33 +1,17 @@
 
 package play.exceptions;
 
-import java.util.Arrays;
-import java.util.List;
-import play.Play;
-import play.classloading.ApplicationClasses.ApplicationClass;
-
 /**
  * Database error
  */
-public class DatabaseException extends PlayException implements SourceAttachment {
-    
-    String sourceFile;
-    List<String> source;
-    Integer line;    
+public class DatabaseException extends PlayExceptionWithJavaSource {
     
     public DatabaseException(String message) {
-        super(message, null);
+        super(message);
     }
     
     public DatabaseException(String message, Throwable cause) {
         super(message, cause);
-        StackTraceElement element = getInterestingStrackTraceElement(cause);
-        if(element != null) {
-            ApplicationClass applicationClass = Play.classes.getApplicationClass(element.getClassName());
-            sourceFile = applicationClass.javaFile.relativePath();
-            source = Arrays.asList(applicationClass.javaSource.split("\n"));
-            line = element.getLineNumber();
-        }
     }
 
     @Override
@@ -39,22 +23,4 @@ public class DatabaseException extends PlayException implements SourceAttachment
     public String getErrorDescription() {
         return String.format("A database error occured : <strong>%s</strong>", getMessage());
     }
-
-    public String getSourceFile() {
-        return sourceFile;
-    }
-
-    public List<String> getSource() {
-        return source;
-    }
-
-    public Integer getLineNumber() {
-        return line;
-    }
-
-    @Override
-    public boolean isSourceAvailable() {
-        return sourceFile != null;
-    }
-
 }

--- a/framework/src/play/exceptions/JavaException.java
+++ b/framework/src/play/exceptions/JavaException.java
@@ -1,43 +1,22 @@
 package play.exceptions;
 
-import java.util.Arrays;
-import java.util.List;
 import play.classloading.ApplicationClasses.ApplicationClass;
 
 /**
  * A Java exception
  */
-public abstract class JavaException extends PlayException implements SourceAttachment {
+public abstract class JavaException extends PlayExceptionWithJavaSource {
 
-    private ApplicationClass applicationClass;
-    private Integer lineNumber;
-
-    public JavaException(ApplicationClass applicationClass, Integer lineNumber, String message) {
-        super(message);
-        this.applicationClass = applicationClass;
-        this.lineNumber = lineNumber;
+    public JavaException(ApplicationClass applicationClass, Integer line, String message) {
+        super(message, null, applicationClass, line);
     }
 
-    public JavaException(ApplicationClass applicationClass, Integer lineNumber, String message, Throwable cause) {
-        super(message, cause);
-        this.applicationClass = applicationClass;
-        this.lineNumber = lineNumber;
-    }
-
-    public Integer getLineNumber() {
-        return lineNumber;
-    }
-
-    public List<String> getSource() {
-        return Arrays.asList(applicationClass.javaSource.split("\n"));
-    }
-
-    public String getSourceFile() {
-        return applicationClass.javaFile.relativePath();
+    public JavaException(ApplicationClass applicationClass, Integer line, String message, Throwable cause) {
+        super(message, cause, applicationClass, line);
     }
 
     @Override
     public boolean isSourceAvailable() {
-        return applicationClass != null && applicationClass.javaFile != null && lineNumber != null;
+        return super.isSourceAvailable() && line != null;
     }
 }

--- a/framework/src/play/exceptions/MailException.java
+++ b/framework/src/play/exceptions/MailException.java
@@ -1,33 +1,17 @@
 
 package play.exceptions;
 
-import java.util.Arrays;
-import java.util.List;
-import play.Play;
-import play.classloading.ApplicationClasses.ApplicationClass;
-
 /**
  * Error while sending an email
  */
-public class MailException extends PlayException implements SourceAttachment {
-    
-    String sourceFile;
-    List<String> source;
-    Integer line;    
+public class MailException extends PlayExceptionWithJavaSource {
     
     public MailException(String message) {
-        super(message, null);
+        super(message);
     }
     
     public MailException(String message, Throwable cause) {
         super(message, cause);
-        StackTraceElement element = getInterestingStrackTraceElement(cause);
-        if(element != null) {
-            ApplicationClass applicationClass = Play.classes.getApplicationClass(element.getClassName());
-            sourceFile = applicationClass.javaFile.relativePath();
-            source = Arrays.asList(applicationClass.javaSource.split("\n"));
-            line = element.getLineNumber();
-        }
     }
 
     @Override
@@ -39,22 +23,4 @@ public class MailException extends PlayException implements SourceAttachment {
     public String getErrorDescription() {
         return String.format("A mail error occured : <strong>%s</strong>", getMessage());
     }
-
-    public String getSourceFile() {
-        return sourceFile;
-    }
-
-    public List<String> getSource() {
-        return source;
-    }
-
-    public Integer getLineNumber() {
-        return line;
-    }
-
-    @Override
-    public boolean isSourceAvailable() {
-        return sourceFile != null;
-    }
-
 }

--- a/framework/src/play/exceptions/PlayException.java
+++ b/framework/src/play/exceptions/PlayException.java
@@ -12,7 +12,6 @@ public abstract class PlayException extends RuntimeException {
     String id;
 
     public PlayException() {
-        super();
         setId();
     }
 

--- a/framework/src/play/exceptions/PlayExceptionWithJavaSource.java
+++ b/framework/src/play/exceptions/PlayExceptionWithJavaSource.java
@@ -1,0 +1,57 @@
+package play.exceptions;
+
+import play.Play;
+
+import java.util.Collections;
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static play.classloading.ApplicationClasses.ApplicationClass;
+
+public abstract class PlayExceptionWithJavaSource extends PlayException implements SourceAttachment {
+    ApplicationClass applicationClass;
+    Integer line;
+
+    protected PlayExceptionWithJavaSource() {
+    }
+
+    protected PlayExceptionWithJavaSource(String message) {
+        super(message);
+    }
+
+    protected PlayExceptionWithJavaSource(String message, Throwable cause, ApplicationClass applicationClass, Integer line) {
+        super(message, cause);
+        this.applicationClass = applicationClass;
+        this.line = line;
+    }
+
+    protected PlayExceptionWithJavaSource(String message, Throwable cause) {
+        super(message, cause);
+
+        StackTraceElement element = getInterestingStrackTraceElement(cause);
+        if (element != null) {
+            applicationClass = Play.classes.getApplicationClass(element.getClassName());
+            line = element.getLineNumber();
+        }
+    }
+
+    @Override
+    public String getSourceFile() {
+        return isSourceAvailable() && applicationClass.javaFile != null ? applicationClass.javaFile.relativePath() : null;
+    }
+
+    @Override
+    public List<String> getSource() {
+        return isSourceAvailable() ? asList(applicationClass.javaSource.split("\n")) : Collections.<String>emptyList();
+    }
+
+    @Override
+    public Integer getLineNumber() {
+        return line;
+    }
+
+    @Override
+    public boolean isSourceAvailable() {
+        return applicationClass != null && applicationClass.javaSource != null;
+    }
+}


### PR DESCRIPTION
We deploy our app to production in precompiled mode without including the source files.
This works nicely until some specific exceptions are thrown that try to access non-existent source files (eg. MailException).

The outcome is that we get NPE instead, which occurs in the constructor of MailException and therefore the original cause is lost.

There are several more exceptions like this. In the past I have already fixed CacheException, which made it to Play 1.2.7. Now we need to fix the rest.

The fix introduces base class for all exceptions trying to access Java source files - PlayExceptionWithJavaSource that fixes this issue for all exceptions that now extend it.
