### PR TITLE
[#1827] Fix Play 1.3 starting in precompiled mode

### DIFF
--- a/framework/src/play/db/jpa/JPAPlugin.java
+++ b/framework/src/play/db/jpa/JPAPlugin.java
@@ -161,8 +161,6 @@ public class JPAPlugin extends PlayPlugin {
             cfg.configure(Configuration.addHibernateProperties(properties, dbName));
             cfg.setDataSource(DB.getDataSource(dbName));
           
-            JPA.emfs.put(dbName, cfg.buildEntityManagerFactory());
-            
             try {
                 Field field = cfg.getClass().getDeclaredField("overridenClassLoader");
                 field.setAccessible(true);
@@ -172,6 +170,8 @@ public class JPAPlugin extends PlayPlugin {
             }
             
             cfg.setInterceptor(new HibernateInterceptor());
+
+            JPA.emfs.put(dbName, cfg.buildEntityManagerFactory());
         }
         JPQL.instance = new JPQL();
     }


### PR DESCRIPTION
The problem is with Hibernate - it seems not to use Play's classloader and fails with ClassNotFoundException for entity classes.

For some reason, it works in non-precompiled mode (maybe it sets Thread.contextClassloader then?)

Anyway, the fix is simple - just call buildEntityManagerFactory() after we have redefined Hibernate's classloader.
