### PR TITLE
Remove a rogue square bracket in cmd-start.txt

### DIFF
--- a/documentation/commands/cmd-start.txt
+++ b/documentation/commands/cmd-start.txt
@@ -4,7 +4,7 @@
 ~ 
 ~ Synopsis:
 ~ ~~~~~~~~~
-~ play start [app_path] ] [-f] [--deps] [--%fwk_id]  [--http[s].port=<value>] [--jpda.port=<value>] [--pid_file=<file>] [--java_options]
+~ play start [app_path] [-f] [--deps] [--%fwk_id] [--http[s].port=<value>] [--jpda.port=<value>] [--pid_file=<file>] [--java_options]
 ~
 ~ Description:
 ~ ~~~~~~~~~~~~


### PR DESCRIPTION
Seems something was removed once but one ] stayed behind
