### PR TITLE
[#1849] Exceptions from controllers are not detected in FunctionalTests

### DIFF
--- a/samples-and-tests/just-test-cases/app/controllers/StatusCodes.java
+++ b/samples-and-tests/just-test-cases/app/controllers/StatusCodes.java
@@ -30,7 +30,7 @@ public class StatusCodes extends Controller {
   }
 
   public static void throwsException() throws Exception {
-    throw new Exception("Whoops");
+    throw new UnsupportedOperationException("Whoops");
   }
 
 }

--- a/samples-and-tests/just-test-cases/app/controllers/StatusCodes.java
+++ b/samples-and-tests/just-test-cases/app/controllers/StatusCodes.java
@@ -1,0 +1,36 @@
+package controllers;
+
+import play.jobs.Job;
+import play.mvc.Controller;
+import play.mvc.Http.Response;
+
+public class StatusCodes extends Controller {
+
+  public static void justOkay() {
+    renderText("Okay");
+  }
+
+  public static void rendersNotFound() {
+    notFound();
+  }
+
+  public static void rendersUnauthorized() {
+    unauthorized();
+  }
+
+  public static void usesContinuation() {
+    final String text = await(new Job<String>() {
+      @Override
+      public String doJobWithResult() throws Exception {
+        return "Job completed successfully";
+      }
+    }.now());
+    Response.current().status = Integer.valueOf(201);
+    renderText(text);
+  }
+
+  public static void throwsException() throws Exception {
+    throw new Exception("Whoops");
+  }
+
+}

--- a/samples-and-tests/just-test-cases/app/controllers/WithContinuations.java
+++ b/samples-and-tests/just-test-cases/app/controllers/WithContinuations.java
@@ -163,14 +163,14 @@ public class WithContinuations extends Controller {
     
     public static void streamedResult() {
         response.contentType = "text/html";
-        response.writeChunk("<h1>This page should load progressively in about 3 second</h1>");
+        response.writeChunk("<h1>This page should load progressively in about a few seconds</h1>");
         long s = System.currentTimeMillis();
         for(int i=0; i<100; i++) {
             await(10);
             response.writeChunk("<h2>Hello " + i + "</h2>");
         }
         long t = System.currentTimeMillis() - s;
-        response.writeChunk("Time: " + t + ", isOk->" + (t > 1000 && t < 10000));
+        response.writeChunk("Time: " + t + ", isOk->" + (t > 1000 && t < 25000));
     }
     
     public static void loopWithCallback() {
@@ -206,7 +206,7 @@ public class WithContinuations extends Controller {
                     await(10, this);
                 } else {
                     long t = System.currentTimeMillis() - s.get();
-                    response.writeChunk("Time: " + t + ", isOk->" + (t > 1000 && t < 10000));
+                    response.writeChunk("Time: " + t + ", isOk->" + (t > 1000 && t < 25000));
                 }                
             }
         };

--- a/samples-and-tests/just-test-cases/conf/routes
+++ b/samples-and-tests/just-test-cases/conf/routes
@@ -78,3 +78,9 @@ GET     /databinding/changeLanguage/{lang}/?                DataBinding.changeLa
 
 
 GET		/useAwaitViaOtherClass				WithContinuations.ControllerWithoutContinuations.useAwaitViaOtherClass
+
+GET   /status/ok/             StatusCodes.justOkay
+GET   /status/not-found/      StatusCodes.rendersNotFound
+GET   /status/unauthorized/   StatusCodes.rendersUnauthorized
+POST  /status/job/            StatusCodes.usesContinuation
+GET   /status/failure/        StatusCodes.throwsException

--- a/samples-and-tests/just-test-cases/test/BinaryTest.java
+++ b/samples-and-tests/just-test-cases/test/BinaryTest.java
@@ -28,7 +28,7 @@ public class BinaryTest extends FunctionalTest {
         Response deletedResponse = GET(deleteURL);
         assertStatus(200, deletedResponse);
     }
-    
+
     @Test
     public void testUploadSomething() {
         URL imageURL = reverse(); {
@@ -170,11 +170,13 @@ public class BinaryTest extends FunctionalTest {
         assertTrue(Binary.emptyInputStreamClosed);
     }
 
-    @Test
+    @Test(expected = Exception.class)
     public void testGetErrorBinary() {
-        Response response = GET("/binary/getErrorBinary");
-        // This does not work. See Lighthouse ticket #1637.
-        // assertStatus(500, response);
-        assertTrue(Binary.errorInputStreamClosed);
+        try {
+            GET("/binary/getErrorBinary");
+        }
+        finally {
+            assertTrue(Binary.errorInputStreamClosed);
+        }
     }
 }

--- a/samples-and-tests/just-test-cases/test/FunctionalTestTest.java
+++ b/samples-and-tests/just-test-cases/test/FunctionalTestTest.java
@@ -2,6 +2,7 @@ import org.junit.*;
 
 import play.test.*;
 import play.mvc.Http.*;
+import play.mvc.results.*;
 import models.*;
 
 import java.util.HashMap;
@@ -133,7 +134,7 @@ public class FunctionalTestTest extends FunctionalTest {
     /**
      * When a route is called that is not even defined, an exception is expected.
      */
-    @Test(expected = Exception.class)
+    @Test(expected = NotFound.class)
     public void testNoRoute() {
         GET("/status/route-not-defined/");
     }
@@ -152,7 +153,7 @@ public class FunctionalTestTest extends FunctionalTest {
      * When a controller throws a normal exception, an exception is expected in
      * the test method as well.
      */
-    @Test(expected = Exception.class)
+    @Test(expected = UnsupportedOperationException.class)
     public void testFailure() {
       GET("/status/failure/");
     }

--- a/samples-and-tests/just-test-cases/test/FunctionalTestTest.java
+++ b/samples-and-tests/just-test-cases/test/FunctionalTestTest.java
@@ -1,4 +1,5 @@
 import org.junit.*;
+
 import play.test.*;
 import play.mvc.Http.*;
 import models.*;
@@ -118,5 +119,72 @@ public class FunctionalTestTest extends FunctionalTest {
         User u = (User) renderArgs("u");
         assertEquals("Guillaume", u.name);
     }
-}
 
+    /**
+     * A simple call that should always work.
+     */
+    @Test
+    public void testOk() {
+        final Response response = GET("/status/ok/");
+        assertStatus(200, response);
+        assertContentEquals("Okay", response);
+    }
+
+    /**
+     * When a route is called that is not even defined, an exception is expected.
+     */
+    @Test(expected = Exception.class)
+    public void testNoRoute() {
+        GET("/status/route-not-defined/");
+    }
+
+    /**
+     * When a defined route is called but the controller decides to render a 404,
+     * the test code is expected to pass and we can assert on the status.
+     */
+    @Test
+    public void testNotFound() {
+      final Response response = GET("/status/not-found/");
+      assertStatus(404, response);
+    }
+
+    /**
+     * When a controller throws a normal exception, an exception is expected in
+     * the test method as well.
+     */
+    @Test(expected = Exception.class)
+    public void testFailure() {
+      GET("/status/failure/");
+    }
+
+    /**
+     * When a controller renders a non-standard result code (which is, actually, implemented
+     * through exception), the call is expected to pass and we can assert on the status.
+     */
+    @Test
+    public void testUnauthorized() {
+      final Response response = GET("/status/unauthorized/");
+      assertStatus(401, response);
+    }
+
+    /**
+     * Even when a controller makes use of continuations, e.g. by calling and waiting for a
+     * job, it is expected that we can assert on the status code.
+     */
+    @Test
+    public void testContinuationCustomStatus() {
+      final Response response = POST("/status/job/");
+      assertStatus(201, response);
+    }
+
+    /**
+     * Even when a controller makes use of continuations, e.g. by calling and waiting for a
+     * job, it is expected that we can assert on the content.
+     */
+    @Test
+    public void testContinuationContent() {
+      final Response response = POST("/status/job/");
+      assertContentEquals("Job completed successfully", response);
+    }
+
+}


### PR DESCRIPTION
- Fix for #1849
- Includes test cases that pass only with the fix, and fail without
- Made one test more robust with respect to timing
- Tests "continuations", "Promises", and "CRUD" are still unreliable, but hopefully not related to this change