### PR TITLE
[#1857] Automatically convert existing sessions

### DIFF
--- a/framework/src/play/mvc/CookieDataCodec.java
+++ b/framework/src/play/mvc/CookieDataCodec.java
@@ -4,17 +4,33 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Provides operations around the encoding and decoding of Cookie data.
  */
 public class CookieDataCodec {
+
+    static Pattern sessionParser = Pattern.compile("\u0000([^:]*):([^\u0000]*)\u0000");
+
     /**
      * @param map  the map to decode data into.
      * @param data the data to decode.
      * @throws UnsupportedEncodingException
      */
     public static void decode(Map<String, String> map, String data) throws UnsupportedEncodingException {
+        // support old Play 1.2.5 session data encoding so that the cookie data doesn't become invalid when
+        // applications are upgraded to a newer version of Play
+        if (data.startsWith("%00") && data.contains("%3A") && data.endsWith("%00")) {
+            String sessionData = URLDecoder.decode(data, "utf-8");
+            Matcher matcher = sessionParser.matcher(sessionData);
+            while (matcher.find()) {
+                map.put(matcher.group(1), matcher.group(2));
+            }
+            return;
+        }
+
         String[] keyValues = data.split("&");
         for (String keyValue : keyValues) {
             String[] splitted = keyValue.split("=", 2);


### PR DESCRIPTION
We've upgraded from Play 1.2.5 on one of our products, but due to the new session cookie format, this instantly logs out all the users that upgrade. We wanted this process to be friction-free for our users.

This patch automatically converts existing sessions the first time they connect to our app with v1.3 of Play, from then onwards the new cookie format will be used.

I'm not sure if this is something that you'd want in the mainline, if you do, here's the pull request.
