### PR TITLE
[#1855] Fix AIOOB exception in WS.getQueryString

### DIFF
--- a/framework/src/play/libs/WS.java
+++ b/framework/src/play/libs/WS.java
@@ -636,8 +636,11 @@ public class WS extends PlayPlugin {
             Map<String, String> result = new HashMap<String, String>();
             String body = getString();
             for (String entry: body.split("&")) {
-                if (entry.indexOf("=") > 0) {
-                    result.put(entry.split("=")[0], entry.split("=")[1]);
+                int pos = entry.indexOf("=");
+                if (pos > -1) {
+                    result.put(entry.substring(0,pos), entry.substring(pos+1));
+                } else {
+                    result.put(entry, "");
                 }
             }
             return result;


### PR DESCRIPTION
A minimal fix for the exception in getQueryString without breaking any backwards compatibility. Like I mention in [lighthouse #1855](http://play.lighthouseapp.com/projects/57987-play-framework/tickets/1855-aioob-exception-in-wsgetquerystring), I think a much better solution would be to remove this method and fix OAuth2.java, but that might break outside code.
