### PR TITLE
[#1884] Skip static fields when building properties list

### DIFF
--- a/framework/src/play/db/jpa/JPAPlugin.java
+++ b/framework/src/play/db/jpa/JPAPlugin.java
@@ -513,7 +513,8 @@ public class JPAPlugin extends PlayPlugin {
                 tclazz = tclazz.getSuperclass();
             }
             for (Field f : fields) {
-                if (Modifier.isTransient(f.getModifiers())) {
+                int mod = f.getModifiers();
+                if (Modifier.isTransient(mod) || Modifier.isStatic(mod)) {
                     continue;
                 }
                 if (f.isAnnotationPresent(Transient.class)) {
@@ -585,7 +586,8 @@ public class JPAPlugin extends PlayPlugin {
                 properties = new HashMap<String, Model.Property>();
                 Set<Field> fields = getModelFields(clazz);
                 for (Field f : fields) {
-                    if (Modifier.isTransient(f.getModifiers())) {
+                    int mod = f.getModifiers();
+                    if (Modifier.isTransient(mod) || Modifier.isStatic(mod)) {
                         continue;
                     }
                     if (f.isAnnotationPresent(Transient.class)) {
@@ -880,7 +882,7 @@ public class JPAPlugin extends PlayPlugin {
 				} else {
 					return ((JPABase) o).willBeSaved;
 				}
-                   } 
+                   }
 			} else {
            		System.out.println("HOO: Case not handled !!!");
         	}
@@ -905,17 +907,17 @@ public class JPAPlugin extends PlayPlugin {
 		}
 
 		protected ThreadLocal<Object> entities = new ThreadLocal<Object>();
-		
+
 		@Override
 	 	public boolean onSave(Object entity, Serializable id, Object[] state, String[] propertyNames, Type[] types)  {
 			entities.set(entity);
 			return super.onSave(entity, id, state, propertyNames, types);
 		}
-				
+
 		@Override
 		public void afterTransactionCompletion(org.hibernate.Transaction tx) {
 			entities.remove();
 		}
-    
+
     }
 }


### PR DESCRIPTION
There's a static field in my entity class, which caused the following exception when loading data using `play.test.Fixtures.loadModels`:

> java.lang.ClassCastException: sun.reflect.generics.reflectiveObjects.WildcardTypeImpl cannot be cast to java.lang.Class
>         at play.db.jpa.JPAPlugin$JPAModelLoader.buildProperty(JPAPlugin.java:794)
>         at play.db.jpa.JPAPlugin$JPAModelLoader.listProperties(JPAPlugin.java:543)
>         at play.test.Fixtures.resolveDependencies(Fixtures.java:440)
>         at play.test.Fixtures.loadModels(Fixtures.java:206)

Though adding `transient` modifier or the `@Transient` annotation both can avoid the error, I think `static` itself should be sufficient to get the field skipped.

Here is a related discussion: https://forum.hibernate.org/viewtopic.php?f=9&t=938860&start=0
