### PR TITLE
[1871] Refactor getJavaVersion

### DIFF
--- a/framework/pym/play/utils.py
+++ b/framework/pym/play/utils.py
@@ -242,15 +242,5 @@ def isTestFrameworkId( framework_id ):
     return (framework_id == 'test' or (framework_id.startswith('test-') and framework_id.__len__() >= 6 ))
 
 def getJavaVersion():
-    sp = subprocess.Popen(["java", "-version"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    javaVersion = sp.communicate()
-    javaVersion =  str( javaVersion)
-    
-    if re.compile('1.5').search(javaVersion) is not None:
-        return "1.5"  
-    elif re.compile('1.6').search(javaVersion) is not None:
-        return "1.6" 
-    elif re.compile('1.7').search(javaVersion) is not None:
-        return "1.7" 
-    else:
-        return "1.8"
+    javaVersion = subprocess.check_output(["java", "-version"], stderr=subprocess.STDOUT)
+    return re.search('java version "([0-9]\.[0-9])', javaVersion).group(1)


### PR DESCRIPTION
Changed the way this function operates. It now directly returns the version found in the `java -version` string instead of going to a bunch of if statements. It also makes the whole string retrieving part more compact.
This also fixes a bug in the old method, where it would match any character between the two numbers instead of a dot, as well as looking through the whole string (instead of just the simple version string).
