### PR TITLE
[#1876] artifacts named '*.jar' should not be treated as modules.

### DIFF
--- a/framework/src/play/deps/DependenciesManager.java
+++ b/framework/src/play/deps/DependenciesManager.java
@@ -302,7 +302,11 @@ public class DependenciesManager {
     }
 
     private boolean isPlayModule(ArtifactDownloadReport artifact) throws Exception {
-        boolean isPlayModule = artifact.getLocalFile().getName().endsWith(".zip");
+        String name = artifact.getLocalFile().getName();
+        if (name.endsWith(".jar")) {
+            return false;
+        }
+        boolean isPlayModule = name.endsWith(".zip");
         if (!isPlayModule) {
             // Check again from origin location
             if (!artifact.getArtifactOrigin().isLocal() && artifact.getArtifactOrigin().getLocation().endsWith(".zip")) {


### PR DESCRIPTION
this patch ensure local '.jar' artifacts are copied to 'lib/'
instead of extracted to 'modules/'.

see http://play.lighthouseapp.com/projects/57987-play-framework/tickets/1876
