### PR TITLE
[#1881] Fix ConcurrentModificationExceptions occuring under Java 8

### DIFF
--- a/framework/src/play/mvc/ActionInvoker.java
+++ b/framework/src/play/mvc/ActionInvoker.java
@@ -177,14 +177,6 @@ public class ActionInvoker {
                             // @Catch
                             Object[] args = new Object[]{ex.getTargetException()};
                             List<Method> catches = Java.findAllAnnotatedMethods(Controller.getControllerClass(), Catch.class);
-                            Collections.sort(catches, new Comparator<Method>() {
-
-                                public int compare(Method m1, Method m2) {
-                                    Catch catch1 = m1.getAnnotation(Catch.class);
-                                    Catch catch2 = m2.getAnnotation(Catch.class);
-                                    return catch1.priority() - catch2.priority();
-                                }
-                            });
                             ControllerInstrumentation.stopActionCall();
                             for (Method mCatch : catches) {
                                 Class[] exceptions = mCatch.getAnnotation(Catch.class).value();
@@ -289,14 +281,6 @@ public class ActionInvoker {
 
     private static void handleBefores(Http.Request request) throws Exception {
         List<Method> befores = Java.findAllAnnotatedMethods(Controller.getControllerClass(), Before.class);
-        Collections.sort(befores, new Comparator<Method>() {
-
-            public int compare(Method m1, Method m2) {
-                Before before1 = m1.getAnnotation(Before.class);
-                Before before2 = m2.getAnnotation(Before.class);
-                return before1.priority() - before2.priority();
-            }
-        });
         ControllerInstrumentation.stopActionCall();
         for (Method before : befores) {
             String[] unless = before.getAnnotation(Before.class).unless();
@@ -331,14 +315,6 @@ public class ActionInvoker {
 
     private static void handleAfters(Http.Request request) throws Exception {
         List<Method> afters = Java.findAllAnnotatedMethods(Controller.getControllerClass(), After.class);
-        Collections.sort(afters, new Comparator<Method>() {
-
-            public int compare(Method m1, Method m2) {
-                After after1 = m1.getAnnotation(After.class);
-                After after2 = m2.getAnnotation(After.class);
-                return after1.priority() - after2.priority();
-            }
-        });
         ControllerInstrumentation.stopActionCall();
         for (Method after : afters) {
             String[] unless = after.getAnnotation(After.class).unless();
@@ -387,14 +363,6 @@ public class ActionInvoker {
 
         try {
             List<Method> allFinally = Java.findAllAnnotatedMethods(Controller.getControllerClass(), Finally.class);
-            Collections.sort(allFinally, new Comparator<Method>() {
-
-                public int compare(Method m1, Method m2) {
-                    Finally finally1 = m1.getAnnotation(Finally.class);
-                    Finally finally2 = m2.getAnnotation(Finally.class);
-                    return finally1.priority() - finally2.priority();
-                }
-            });
             ControllerInstrumentation.stopActionCall();
             for (Method aFinally : allFinally) {
                 String[] unless = aFinally.getAnnotation(Finally.class).unless();

--- a/framework/src/play/utils/Java.java
+++ b/framework/src/play/utils/Java.java
@@ -10,6 +10,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -31,6 +32,7 @@ import play.mvc.Before;
 import play.mvc.Finally;
 import play.mvc.With;
 import static java.util.Collections.addAll;
+import static java.util.Collections.sort;
 
 /**
  * Java utils
@@ -285,7 +287,6 @@ public class Java {
      * @return A list of method object
      */
     public static List<Method> findAllAnnotatedMethods(Class<?> clazz, Class<? extends Annotation> annotationType) {
-
         return getJavaWithCaching().findAllAnnotatedMethods(clazz, annotationType);
     }
 
@@ -498,7 +499,7 @@ class JavaWithCaching {
      * @param annotationType The annotation class
      * @return A list of method object
      */
-    public List<Method> findAllAnnotatedMethods(Class<?> clazz, Class<? extends Annotation> annotationType) {
+    public List<Method> findAllAnnotatedMethods(Class<?> clazz, final Class<? extends Annotation> annotationType) {
 
         if( clazz == null ) {
             return new ArrayList<Method>(0);
@@ -517,6 +518,7 @@ class JavaWithCaching {
             }
             // have to resolve it.
             methods = new ArrayList<Method>();
+
             // get list of all annotated methods on this class..
             for( Method method : findAllAnnotatedMethods( clazz)) {
                 if (method.isAnnotationPresent(annotationType)) {
@@ -524,10 +526,34 @@ class JavaWithCaching {
                 }
             }
 
+            sortByPriority(methods, annotationType);
+
             // store it in cache
             classAndAnnotation2Methods.put( key, methods);
 
             return methods;
+        }
+    }
+
+    private void sortByPriority(List<Method> methods, final Class<? extends Annotation> annotationType) {
+        try {
+            final Method priority = annotationType.getMethod("priority");
+            sort(methods, new Comparator<Method>() {
+                @Override public int compare(Method m1, Method m2) {
+                    try {
+                        Integer priority1 = (Integer) priority.invoke(m1.getAnnotation(annotationType));
+                        Integer priority2 = (Integer) priority.invoke(m2.getAnnotation(annotationType));
+                        return priority1.compareTo(priority2);
+                    }
+                    catch (Exception e) {
+                        // should not happen
+                        throw new RuntimeException(e);
+                    }
+                }
+            });
+        }
+        catch (NoSuchMethodException e) {
+            // no need to sort - this annotation doesn't have priority() method
         }
     }
 


### PR DESCRIPTION
This pull request caches annotated method lists already in a sorted state.

This prevents concurrent resorting of cached lists in multiple request threads, which sometimes results in ConcurrentModificationException, especially under Java 8.

We run 1.3.x branch on production on a site with >10 requests per second.
Yesterday we upgraded our production servers to Java 8.

Then, we started getting these exceptions from time to time:
java.util.ConcurrentModificationException
at java.util.ArrayList$Itr.checkForComodification(ArrayList.java:901) 
at java.util.ArrayList$Itr.next(ArrayList.java:851) 
at play.mvc.ActionInvoker.handleBefores(ActionInvoker.java:301) 
at play.mvc.ActionInvoker.invoke(ActionInvoker.java:141)

It doesn't happen with Java 7, probably because it has a more forgiving ArrayList implementation.
