### PR TITLE
play 1.3.x is broken: fix typo in XML parser feature uri

### DIFF
--- a/framework/src/play/libs/XML.java
+++ b/framework/src/play/libs/XML.java
@@ -48,7 +48,7 @@ public class XML {
         try {
             DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
             dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
-            dbf.setFeature("http://xml.org/sax/features/external-paramater-entities", false);
+            dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
             return dbf;
         } catch (ParserConfigurationException e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
XML class is totally broken after yesterday's XXE improvement
