### PR TITLE
[#1902] Use JAVA_HOME in getJavaVersion

### DIFF
--- a/framework/pym/play/application.py
+++ b/framework/pym/play/application.py
@@ -201,13 +201,6 @@ class PlayApplication(object):
             cp_args = ';'.join(classpath)
         return cp_args
 
-
-    def java_path(self):
-        if not os.environ.has_key('JAVA_HOME'):
-            return "java"
-        else:
-            return os.path.normpath("%s/bin/java" % os.environ['JAVA_HOME'])
-
     def pid_path(self):
         if self.play_env.has_key('pid_file'):
             return os.path.join(self.path, self.play_env['pid_file'])
@@ -313,7 +306,7 @@ class PlayApplication(object):
             java_args.append('-Xrunjdwp:transport=dt_socket,address=%s,server=y,suspend=n' % self.jpda_port)
             java_args.append('-Dplay.debug=yes')
         
-        java_cmd = [self.java_path(), '-javaagent:%s' % self.agent_path()] + java_args + ['-classpath', cp_args, '-Dapplication.path=%s' % self.path, '-Dplay.id=%s' % self.play_env["id"], className] + args
+        java_cmd = [java_path(), '-javaagent:%s' % self.agent_path()] + java_args + ['-classpath', cp_args, '-Dapplication.path=%s' % self.path, '-Dplay.id=%s' % self.play_env["id"], className] + args
         return java_cmd
 
     # ~~~~~~~~~~~~~~~~~~~~~~ MISC

--- a/framework/pym/play/commands/base.py
+++ b/framework/pym/play/commands/base.py
@@ -273,7 +273,7 @@ def autotest(app, args):
     cp_args = ':'.join(fpcp)
     if os.name == 'nt':
         cp_args = ';'.join(fpcp)    
-    java_cmd = [app.java_path(), '-classpath', cp_args, '-Dapplication.url=%s://localhost:%s' % (protocol, http_port), '-DheadlessBrowser=%s' % (headless_browser), 'play.modules.testrunner.FirePhoque']
+    java_cmd = [java_path(), '-classpath', cp_args, '-Dapplication.url=%s://localhost:%s' % (protocol, http_port), '-DheadlessBrowser=%s' % (headless_browser), 'play.modules.testrunner.FirePhoque']
     if protocol == 'https':
         java_cmd.insert(-1, '-Djavax.net.ssl.trustStore=' + app.readConf('keystore.file'))
     try:

--- a/framework/pym/play/commands/deps.py
+++ b/framework/pym/play/commands/deps.py
@@ -57,7 +57,7 @@ def execute(**kargs):
         elif not arg.startswith('-Xm'):
             print "~ WARNING: " + arg + " argument will be skipped"    
 
-    java_cmd = [app.java_path()] + add_options + args_memory + ['-classpath', app.fw_cp_args(), 'play.deps.DependenciesManager']
+    java_cmd = [java_path()] + add_options + args_memory + ['-classpath', app.fw_cp_args(), 'play.deps.DependenciesManager']
     try:
         return_code = subprocess.call(java_cmd, env=os.environ)
         if 0 != return_code:

--- a/framework/pym/play/commands/evolutions.py
+++ b/framework/pym/play/commands/evolutions.py
@@ -46,7 +46,7 @@ def execute(**kargs):
         if arg in add_options:
             add_options.remove(arg)
 
-    java_cmd = [app.java_path()] + add_options + args_memory + ['-classpath', app.cp_args(), 'play.db.Evolutions']
+    java_cmd = [java_path()] + add_options + args_memory + ['-classpath', app.cp_args(), 'play.db.Evolutions']
     try:
         return_code = subprocess.call(java_cmd, env=os.environ)
         if 0 != return_code:

--- a/framework/pym/play/utils.py
+++ b/framework/pym/play/utils.py
@@ -241,8 +241,14 @@ def copy_directory(source, target, exclude = None):
 def isTestFrameworkId( framework_id ):
     return (framework_id == 'test' or (framework_id.startswith('test-') and framework_id.__len__() >= 6 ))
 
+def java_path():
+    if not os.environ.has_key('JAVA_HOME'):
+        return "java"
+    else:
+        return os.path.normpath("%s/bin/java" % os.environ['JAVA_HOME'])
+
 def getJavaVersion():
-    sp = subprocess.Popen(["java", "-version"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    sp = subprocess.Popen([java_path(), "-version"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     javaVersion = sp.communicate()
     javaVersion = str(javaVersion)
     


### PR DESCRIPTION
Moving `java_path()` out of application into utils so `getJavaVersion()` can use it too