### PR TITLE
[#1924] Sane c3p0 logging

### DIFF
--- a/framework/src/log4j.properties
+++ b/framework/src/log4j.properties
@@ -7,6 +7,7 @@ log4j.logger.DataNucleus=WARN
 log4j.logger.org.apache.commons.httpclient=ERROR
 log4j.logger.net.sf.oval.internal=ERROR
 log4j.logger.org.springframework=WARN
+log4j.logger.com.mchange=WARN
 
 # Console
 log4j.appender.Console=org.apache.log4j.ConsoleAppender

--- a/framework/src/play/Logger.java
+++ b/framework/src/play/Logger.java
@@ -50,6 +50,8 @@ public class Logger {
      */
     public static boolean configuredManually = false;
 
+    public static boolean usesJuli() { return forceJuli || log4j == null; }
+
     /**
      * Try to init stuff.
      */

--- a/framework/src/play/db/DBPlugin.java
+++ b/framework/src/play/db/DBPlugin.java
@@ -57,8 +57,11 @@ public class DBPlugin extends PlayPlugin {
 
     @Override
     public void onApplicationStart() {
-        System.setProperty("com.mchange.v2.log.MLog", "com.mchange.v2.log.FallbackMLog");
-        System.setProperty("com.mchange.v2.log.FallbackMLog.DEFAULT_CUTOFF_LEVEL", "OFF");
+	if ( play.Logger.usesJuli() ) {
+	    System.setProperty("com.mchange.v2.log.MLog", "jul");
+	} else {
+	    System.setProperty("com.mchange.v2.log.MLog", "log4j");
+	}
 
         List<String> dbConfigNames = new ArrayList<String>(1);
 


### PR DESCRIPTION
play1 simultaneously uses c3p0 as its default Connection pool but sends all c3p0 logging to `/dev/null` (metaphorically speaking). That renders applications which experience database problems very difficult to debug.

c3p0's logging is unreasonably verbose at DEBUG/FINE/TRACE levels, but is reasonably quiet at INFO and very quiet at WARN or above, unless something really breaks. The library is intended to be logged at INFO. But it does emit an full configuration dump on pool initialization at INFO.

Presumably someone got annoyed by c3p0's logging and (insanely) just swept it away all at once.

This pull request restores c3p0 logging at WARN level. From the perspective of a guy who often gets c3p0 support requests, I'd prefer logging at INFO, so users can view and report their pool configurations. But given the extreme prejudice with which c3p0 logging was eliminated, I figure I should be grateful to even get logging at WARN. (I'd be glad to update this with a commit that logs at INFO instead, if you are amenable!)