### PR TITLE
Make play.libs.WS.getString() and play.libs.WS.getQueryString() returnin...

### DIFF
--- a/framework/src/play/libs/WS.java
+++ b/framework/src/play/libs/WS.java
@@ -527,7 +527,8 @@ public class WS extends PlayPlugin {
     public static abstract class HttpResponse {
 
         private String _encoding = null;
-
+        private String _getString = null;
+        private Map<String, String> _getQueryString = null;
         /**
          * the HTTP status code
          * @return the status code of the http response
@@ -610,7 +611,9 @@ public class WS extends PlayPlugin {
          * @return the body of the http response
          */
         public String getString() {
-            return IO.readContentAsString(getStream(), getEncoding());
+            if (_getString == null)
+                _getString = IO.readContentAsString(getStream(), getEncoding());
+            return _getString;
         }
 
         /**
@@ -629,17 +632,19 @@ public class WS extends PlayPlugin {
          * is not formed as a query string.
          */
         public Map<String, String> getQueryString() {
-            Map<String, String> result = new HashMap<String, String>();
-            String body = getString();
-            for (String entry: body.split("&")) {
-                int pos = entry.indexOf("=");
-                if (pos > -1) {
-                    result.put(entry.substring(0,pos), entry.substring(pos+1));
-                } else {
-                    result.put(entry, "");
+            if (_getQueryString == null) {
+                Map<String, String> result = _getQueryString = new HashMap<String, String>();
+                String body = getString();
+                for (String entry : body.split("&")) {
+                    int pos = entry.indexOf("=");
+                    if (pos > -1) {
+                        result.put(entry.substring(0, pos), entry.substring(pos + 1));
+                    } else {
+                        result.put(entry, "");
+                    }
                 }
             }
-            return result;
+            return _getQueryString;
         }
 
         /**


### PR DESCRIPTION
...g same result on every call, by saving proper result in the private variable.

Story:

While switching from Play 1.2.7 to 1.3.0 found that secureSocial module fails to login thru Google OAuth2.  

Code study shown that play.libs.OAuth2 codes calls multiple times play.libs.WS. getQueryString() and play.libs.WS.getString(), but getString() is able to return response body string only once.  

In Play 1.2, for some unfound reаsons WS.getString() was returning a result only on a second call, and that is why whole thing was working.  But in Play 1.3 this behavior was somehow fixed, and getString() started to return the body string on a first call, as it suppose to be. And this made play.libs.OAuth2.Response not working, since this code was build around this bug.

As a fix, I suggest make getString() function to return the response body-string in any call, but saving the string in the private variable.
