### PR TITLE
[#1230] fix(image): Close the OutputStream in image.crop

### DIFF
--- a/framework/src/play/libs/Images.java
+++ b/framework/src/play/libs/Images.java
@@ -186,9 +186,16 @@ public class Images {
             graphics.drawImage(croppedImage, 0, 0, null);
             ImageWriter writer = ImageIO.getImageWritersByMIMEType(mimeType).next();
             ImageWriteParam params = writer.getDefaultWriteParam();
-            writer.setOutput(new FileImageOutputStream(to));
-            IIOImage image = new IIOImage(dest, null, null);
-            writer.write(null, image, params);
+
+            FileImageOutputStream toFs = new FileImageOutputStream(to);
+            try {
+                writer.setOutput(toFs);
+                IIOImage image = new IIOImage(dest, null, null);
+                writer.write(null, image, params);
+                toFs.flush();
+            } finally {
+                toFs.close();
+            }
             writer.dispose();
         } catch (Exception e) {
             throw new RuntimeException(e);
@@ -205,8 +212,7 @@ public class Images {
      * @throws java.io.IOException
      */
     public static String toBase64(File image) throws IOException {
-        return "data:" + MimeTypes.getMimeType(image.getName()) + ";base64,"
-                + Codec.encodeBASE64(IO.readContent(image));
+        return "data:" + MimeTypes.getMimeType(image.getName()) + ";base64," + Codec.encodeBASE64(IO.readContent(image));
     }
 
     /**


### PR DESCRIPTION
[Lighthouse #1230](https://play.lighthouseapp.com/projects/57987/tickets/1230-playlibsimagecrop-dont-close-the-outputstream)