### PR TITLE
* [#1892] fix(IPv4AddressCheck): fix validation to avoid additional character(+, .)

### DIFF
--- a/framework/src/play/data/validation/IPv4AddressCheck.java
+++ b/framework/src/play/data/validation/IPv4AddressCheck.java
@@ -5,6 +5,8 @@ import net.sf.oval.configuration.annotation.AbstractAnnotationCheck;
 import net.sf.oval.context.OValContext;
 import net.sf.oval.exception.OValException;
 
+import org.apache.commons.lang.StringUtils;
+
 public class IPv4AddressCheck extends AbstractAnnotationCheck<IPv4Address> {
 
     final static String mes = "validation.ipv4";
@@ -14,20 +16,25 @@ public class IPv4AddressCheck extends AbstractAnnotationCheck<IPv4Address> {
         setMessage(ipv4Address.message());
     }
 
-    public boolean isSatisfied(Object validatedObject, Object value, OValContext context, Validator validator)
-    throws OValException {
+    @Override
+    public boolean isSatisfied(Object validatedObject, Object value, OValContext context, Validator validator) throws OValException {
         if (value == null || value.toString().length() == 0) {
             return true;
         }
         try {
             String[] parts = value.toString().split("[.]");
-            if (parts.length != 4) {
+            // Check that there is no trailing separator
+            if (parts.length != 4 || StringUtils.countMatches(value.toString(), ".") != 3) {
                 return false;
             }
-            
-            for(int i=0; i<parts.length; i++) {
+
+            for (int i = 0; i < parts.length; i++) {
+                // Check taht we don't have empty part or (+-) sign
+                if (parts[i].isEmpty() || !parts[i].matches("[0-9]{1,3}")) {
+                    return false;
+                }
                 int p = Integer.valueOf(parts[i]);
-                if(p < 0 || p > 255) {
+                if (p < 0 || p > 255) {
                     return false;
                 }
             }

--- a/framework/test-src/play/data/validation/IpAddressTest.java
+++ b/framework/test-src/play/data/validation/IpAddressTest.java
@@ -1,0 +1,120 @@
+package play.data.validation;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import play.data.validation.Validation.ValidationResult;
+import play.i18n.MessagesBuilder;
+
+public class IpAddressTest {
+
+    @Test
+    public void validIpV4AddressValidationTest() {
+        new MessagesBuilder().build();
+        Validation.current.set(new Validation());
+
+        assertValidIpV4Address(true, "192.168.10.2");
+        assertValidIpV4Address(true, "0.0.0.0");
+
+        assertValidIpV4Address(true, "255.255.255.255");
+        assertValidIpV4Address(true, "192.168.010.002");
+
+    }
+
+    @Test
+    public void invalidIpV4AddressValidationTest() {
+        new MessagesBuilder().build();
+        Validation.current.set(new Validation());
+
+        // With letters
+        assertValidIpV4Address(false, "192.168.o10.002");
+        assertValidIpV4Address(false, "(305) abc 09 58 ext 101");
+        assertValidIpV4Address(false, "+330147376224");
+        assertValidIpV4Address(false, "+33(0)147376224");
+
+        // with other separator
+        assertValidIpV4Address(false, "192,168.10.2");
+        assertValidIpV4Address(false, "192.168,10.2");
+        assertValidIpV4Address(false, "192.168.10,2");
+
+        assertValidIpV4Address(false, "192.168.10-2.2");
+
+        assertValidIpV4Address(false, "192-168.10.2");
+        assertValidIpV4Address(false, "192.168-10.2");
+        assertValidIpV4Address(false, "192.168.10-2");
+
+        assertValidIpV4Address(false, "192_168.10.2");
+        assertValidIpV4Address(false, "192.168_10.2");
+        assertValidIpV4Address(false, "192.168.10_2");
+
+        assertValidIpV4Address(false, "192/168.10.2");
+        assertValidIpV4Address(false, "192.168/10.2");
+        assertValidIpV4Address(false, "192.168.10/2");
+
+        assertValidIpV4Address(false, "192+168.10.2");
+        assertValidIpV4Address(false, "192.168+10.2");
+        assertValidIpV4Address(false, "192.168.10+2");
+
+        assertValidIpV4Address(false, "192*168.10.2");
+        assertValidIpV4Address(false, "192.168*10.2");
+        assertValidIpV4Address(false, "192.168.10*2");
+
+        assertValidIpV4Address(false, "+192.168.10.2");
+        assertValidIpV4Address(false, "192.+168.10.2");
+        assertValidIpV4Address(false, "192.168.+10.2");
+        assertValidIpV4Address(false, "192.168.10.+2");
+        assertValidIpV4Address(false, "192.168.10.2+");
+
+        // over 255
+        assertValidIpV4Address(false, "256.255.255.255");
+        assertValidIpV4Address(false, "255.256.255.255");
+        assertValidIpV4Address(false, "255.255.256.255");
+        assertValidIpV4Address(false, "255.255.255.256");
+        assertValidIpV4Address(false, "1192.168.10.2");
+        assertValidIpV4Address(false, "192.1168.10.2");
+        assertValidIpV4Address(false, "192.168.1110.2");
+        assertValidIpV4Address(false, "192.168.10.1112");
+
+        // With space
+        assertValidIpV4Address(false, " 192.168.10.2");
+        assertValidIpV4Address(false, "192.168.10.2 ");
+        assertValidIpV4Address(false, "192. 168.10.2");
+        assertValidIpV4Address(false, "192.168 .10.2");
+
+        // With negative number
+        assertValidIpV4Address(false, "-192.168.10.2");
+        assertValidIpV4Address(false, "-92.168.10.2");
+        assertValidIpV4Address(false, "92.168.10.-2");
+
+        // With additional character
+        assertValidIpV4Address(false, "...");
+        assertValidIpV4Address(false, "192..168.2");
+        assertValidIpV4Address(false, "192..168.10.2");
+        assertValidIpV4Address(false, "192.168..10.2");
+        assertValidIpV4Address(false, "192.168.10..2");
+
+        assertValidIpV4Address(false, "192.168.10.2.");
+        assertValidIpV4Address(false, ".192.168.10.2");
+        assertValidIpV4Address(false, "192.168.10.2+");
+        assertValidIpV4Address(false, "192.168.10.2-");
+        assertValidIpV4Address(false, "192.168.10.2/");
+        assertValidIpV4Address(false, "192.168.10.2*");
+
+        assertValidIpV4Address(false, "+192.168.10.2");
+        assertValidIpV4Address(false, "-192.168.10.2");
+        assertValidIpV4Address(false, "/192.168.10.2");
+        assertValidIpV4Address(false, "*192.168.10.2");
+
+        assertValidIpV4Address(false, ".192.168.10.2");
+        assertValidIpV4Address(false, "255.255.255.255.");
+
+    }
+
+    public void assertValidIpV4Address(Boolean valid, String ipAddress) {
+        Validation.clear();
+        ValidationResult result = Validation.ipv4Address("phone", ipAddress);
+        assertEquals("Validation ipv4Address [" + ipAddress + "] should be " + valid, valid, result.ok);
+    }
+
+}

--- a/framework/test-src/play/data/validation/PhoneTest.java
+++ b/framework/test-src/play/data/validation/PhoneTest.java
@@ -1,10 +1,11 @@
 package play.data.validation;
 
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Test;
 
 import play.data.validation.Validation.ValidationResult;
 import play.i18n.MessagesBuilder;
-import static org.junit.Assert.assertEquals;
 
 public class PhoneTest {
 
@@ -32,9 +33,9 @@ public class PhoneTest {
         // UK
         assertValidPhone(true, "(020) 1234 1234");
     }
-    
+
     @Test
-    public void invalidalidPhoneValidationTest() {
+    public void invalidPhoneValidationTest() {
         new MessagesBuilder().build();
         Validation.current.set(new Validation());
 
@@ -43,18 +44,18 @@ public class PhoneTest {
         assertValidPhone(false, "+330147376224");
         assertValidPhone(false, "+33(0)147376224");
         assertValidPhone(false, "+33  (0)1 47 37 62 24 x3");
-        
+
         // China
         assertValidPhone(false, "+86(10)69445464");
         assertValidPhone(false, "+86(0)69445464");
-        
+
         assertValidPhone(false, "+1229 343433345");
     }
-    
-    public void assertValidPhone(Boolean valid, String phone){
+
+    public void assertValidPhone(Boolean valid, String phone) {
         Validation.clear();
-        ValidationResult result = Validation.phone("phone", phone); 
+        ValidationResult result = Validation.phone("phone", phone);
         assertEquals("Validation phone [" + phone + "] should be " + valid, valid, result.ok);
     }
-    
+
 }


### PR DESCRIPTION
* Add ipv4Address validation test
* fix typo in PhoneTest method

[Lighthouse #1892](https://play.lighthouseapp.com/projects/57987/tickets/1892-ipv4addresscheck-allows-invalid-addresses)