### PR TITLE
[#1947] [#1948] Fix PlayPlugin filter stacking.

### DIFF
--- a/framework/src/play/Invoker.java
+++ b/framework/src/play/Invoker.java
@@ -265,11 +265,11 @@ public class Invoker {
             InvocationContext.current.remove();
         }
 
-        private void withinFilter(play.libs.F.Function0<Void> fct) throws Throwable {
-          for( PlayPlugin plugin :  Play.pluginCollection.getEnabledPlugins() ) {
-               if (plugin.getFilter() != null)
-                plugin.getFilter().withinFilter(fct);
-           }
+        private void withinFilter(final play.libs.F.Function0<Void> fct) throws Throwable {
+          final F.Option<PlayPlugin.Filter<Void>> filters = Play.pluginCollection.composeFilters();
+          if (filters.isDefined()) {
+            filters.get().withinFilter(fct);
+          }
         }
 
         /**

--- a/framework/src/play/jobs/Job.java
+++ b/framework/src/play/jobs/Job.java
@@ -5,7 +5,6 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-
 import play.Invoker;
 import play.Invoker.InvocationContext;
 import play.Logger;
@@ -13,6 +12,7 @@ import play.Play;
 import play.exceptions.JavaExecutionException;
 import play.exceptions.PlayException;
 import play.exceptions.UnexpectedException;
+import play.libs.F;
 import play.libs.F.Promise;
 import play.libs.Time;
 import play.mvc.Http;
@@ -170,14 +170,19 @@ public class Job<V> extends Invoker.Invocation implements Callable<V> {
         call();
     }
 
-    private V withinFilter(play.libs.F.Function0<V> fct) throws Throwable {
-        for (PlayPlugin plugin :  Play.pluginCollection.getEnabledPlugins() ){
-           if (plugin.getFilter() != null) {
-              return (V)plugin.getFilter().withinFilter(fct);
-           }
-        }
-        return null;
+
+
+
+
+
+  private V withinFilter(final play.libs.F.Function0<V> fct) throws Throwable {
+    final F.Option<PlayPlugin.Filter<V>> filters = Play.pluginCollection.composeFilters();
+    if (!filters.isDefined()) {
+      return null;
+    } else {
+      return filters.get().withinFilter(fct);
     }
+  }
 
     public V call() {
         Monitor monitor = null;

--- a/framework/src/play/plugins/PluginCollection.java
+++ b/framework/src/play/plugins/PluginCollection.java
@@ -8,6 +8,7 @@ import play.classloading.ApplicationClassloader;
 import play.data.binding.RootParamNode;
 import play.db.Model;
 import play.exceptions.UnexpectedException;
+import play.libs.F;
 import play.mvc.Http;
 import play.mvc.Router;
 import play.mvc.results.Result;
@@ -76,6 +77,18 @@ public class PluginCollection {
      * Using this cached copy so we don't have to create it all the time
      */
     protected List<PlayPlugin> enabledPlugins_readOnlyCopy = createReadonlyCopy(enabledPlugins);
+
+
+    /**
+     * List of all enabled plugins with filters
+     */
+    protected List<PlayPlugin> enabledPluginsWithFilters = new ArrayList<PlayPlugin>();
+
+    /**
+     * Readonly copy of enabledPluginsWithFilters - updated each time enabledPluginsWithFilters is updated.
+     * Using this cached copy so we don't have to create it all the time
+     */
+    protected List<PlayPlugin> enabledPluginsWithFilters_readOnlyCopy = createReadonlyCopy(enabledPluginsWithFilters);
 
 
     /**
@@ -285,7 +298,13 @@ public class PluginCollection {
             if (enabledPlugins.remove( oldPlugin)) {
                 enabledPlugins.add(newPlugin);
                 Collections.sort( enabledPlugins);
-                enabledPlugins_readOnlyCopy = createReadonlyCopy( enabledPlugins);
+                enabledPlugins_readOnlyCopy = createReadonlyCopy( enabledPlugins );
+
+                if (enabledPluginsWithFilters.remove ( oldPlugin ) && newPlugin.hasFilter()) {
+                    enabledPluginsWithFilters.add( newPlugin );
+                    Collections.sort( enabledPluginsWithFilters );
+                    enabledPluginsWithFilters_readOnlyCopy = createReadonlyCopy( enabledPluginsWithFilters );
+                }
             }
 
         
@@ -305,6 +324,13 @@ public class PluginCollection {
                     enabledPlugins.add( plugin );
                     Collections.sort( enabledPlugins);
                     enabledPlugins_readOnlyCopy = createReadonlyCopy( enabledPlugins);
+
+                    if ( plugin.hasFilter()) {
+                        enabledPluginsWithFilters.add(plugin);
+                        Collections.sort(enabledPluginsWithFilters);
+                        enabledPluginsWithFilters_readOnlyCopy = createReadonlyCopy(enabledPluginsWithFilters);
+                    }
+
                     updatePlayPluginsList();
                     Logger.trace("Plugin " + plugin + " enabled");
                     return true;
@@ -348,6 +374,11 @@ public class PluginCollection {
         if (enabledPlugins.remove(plugin)) {
             //plugin was removed
             enabledPlugins_readOnlyCopy = createReadonlyCopy( enabledPlugins);
+
+            if (enabledPluginsWithFilters.remove(plugin)) {
+                enabledPluginsWithFilters_readOnlyCopy = createReadonlyCopy(enabledPluginsWithFilters);
+            }
+
             updatePlayPluginsList();
             Logger.trace("Plugin " + plugin + " disabled");
             return true;
@@ -380,6 +411,35 @@ public class PluginCollection {
     public List<PlayPlugin> getEnabledPlugins() {
         return enabledPlugins_readOnlyCopy;
     }
+
+    /**
+     * Returns new readonly list of all enabled plugins that define filters.
+     * @return List of plugins
+     */
+    public List<PlayPlugin> getEnabledPluginsWithFilters() {
+        return enabledPluginsWithFilters_readOnlyCopy;
+    }
+
+    @SuppressWarnings("unchecked")
+    public<T> F.Option<PlayPlugin.Filter<T>> composeFilters()
+    {
+      //Copy list of plugins here in case the list changes in the midst of doing composition...
+      //(Is it really necessary to do this?)
+      final List<PlayPlugin> pluginsWithFilters = new ArrayList<PlayPlugin>(this.getEnabledPluginsWithFilters());
+
+      if (pluginsWithFilters.isEmpty()) {
+        return F.Option.None();
+      } else {
+        final Iterator<PlayPlugin> itr = getEnabledPluginsWithFilters().iterator();
+        PlayPlugin.Filter<T> ret = itr.next().getFilter();
+        while (itr.hasNext()) {
+          ret = ret.<T>decorate(itr.next().getFilter());
+        }
+        return F.Option.Some(ret);
+      }
+    }
+
+
     
     /**
      * Returns readonly view of all enabled plugins in reversed order


### PR DESCRIPTION
In 1.3.1, Plugin filters do not behave the way documentation suggests they should.  (For example, see javadoc for PlayPlugin::Filter.)    

Everything works normally as long as only one filter is defined (typically the one for JPAPlugin), but as soon as a second enters the picture everything goes off the rails. In Job, only the filter belonging to the highest priority plugin is executed.  In Invoker, actions are executed once per filter.  This does not seem like the intended behavior.

This patch makes plugins stack in the way documentation suggests they should.