### PR TITLE
fix: allow zero-length blobs

### DIFF
--- a/framework/src/play/data/binding/types/BinaryBinder.java
+++ b/framework/src/play/data/binding/types/BinaryBinder.java
@@ -25,7 +25,7 @@ public class BinaryBinder implements TypeBinder<Model.BinaryField> {
                 List<Upload> uploads = (List<Upload>) req.args.get("__UPLOADS");
                 if(uploads != null){
                     for (Upload upload : uploads) {
-                        if (upload.getFieldName().equals(value) && upload.getSize() > 0) {
+                        if (upload.getFieldName().equals(value) && upload.getFileName().trim().length() > 0) {
                             b.set(upload.asStream(), upload.getContentType());
                             return b;
                         }


### PR DESCRIPTION
the fix for [#1564] breaks Blob binding, this fix resolves this by checking for an empty file name instead of a 0-size (which has resulted in a NPE)