### PR TITLE
Fix NPE in FileArrayBinder if no files are uploaded

### DIFF
--- a/framework/src/play/data/FileUpload.java
+++ b/framework/src/play/data/FileUpload.java
@@ -1,17 +1,16 @@
 package play.data;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-
 import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.io.FilenameUtils;
-
 import play.data.parsing.TempFilePlugin;
 import play.exceptions.UnexpectedException;
 import play.libs.Files;
 import play.libs.IO;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 
 public class FileUpload implements Upload {
 
@@ -90,7 +89,7 @@ public class FileUpload implements Upload {
 
     @Override
     public Long getSize() {
-        return defaultFile.length();
+        return defaultFile == null ? null : defaultFile.length();
     }
 
     @Override

--- a/framework/src/play/data/binding/types/FileArrayBinder.java
+++ b/framework/src/play/data/binding/types/FileArrayBinder.java
@@ -28,7 +28,7 @@ public class FileArrayBinder implements TypeBinder<File[]> {
             if (uploads != null) {
                 for (Upload upload : uploads) {
                     if (upload.getFieldName().equals(value)) {
-                        if(upload.getSize() != null && upload.getSize() > 0) {
+                        if (upload.getSize() != null && upload.getSize() > 0) {
                             File file = upload.asFile();
                             if (file.length() > 0) {
                                 fileArray.add(file);

--- a/framework/test-src/play/data/FileUploadTest.java
+++ b/framework/test-src/play/data/FileUploadTest.java
@@ -1,0 +1,12 @@
+package play.data;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertNull;
+
+public class FileUploadTest {
+  @Test
+  public void sizeIsNullForMissingFile() {
+    assertNull(new FileUpload().getSize());
+  }
+}


### PR DESCRIPTION
We have a lot of optional "file upload" controls in our web application.
When submitting a form without any files uploaded, FileArrayBinder throws NullPointerException.