### PR TITLE
callback method can not be invoked in await method

### DIFF
--- a/framework/src/play/server/PlayHandler.java
+++ b/framework/src/play/server/PlayHandler.java
@@ -265,14 +265,14 @@ public class PlayHandler extends SimpleChannelUpstreamHandler {
 
         @Override
         public void execute() throws Exception {
-            if (!ctx.getChannel().isConnected()) {
-                try {
-                    ctx.getChannel().close();
-                } catch (Throwable e) {
-                    // Ignore
-                }
-                return;
-            }
+            //if (!ctx.getChannel().isConnected()) {
+            //    try {
+            //        ctx.getChannel().close();
+            //    } catch (Throwable e) {
+            //        // Ignore
+            //    }
+            //    return;
+            //}
 
             // Check the exceeded size before re rendering so we can render the error if the size is exceeded
             saveExceededSizeError(nettyRequest, request, response);


### PR DESCRIPTION
Callback method can not be invoked in await method when refreshing page after sending the request.

I don't know whether it designed for any deep reasons, but I think program should continue even if the request channel is closed when 

refreshing or closing the page.