### PR TITLE
Fix jobs plugin

### DIFF
--- a/framework/src/play/jobs/Job.java
+++ b/framework/src/play/jobs/Job.java
@@ -143,6 +143,7 @@ public class Job<V> extends Invoker.Invocation implements Callable<V> {
      */
     public void every(int seconds) {
         JobsPlugin.executor.scheduleWithFixedDelay(this, seconds, seconds, TimeUnit.SECONDS);
+        JobsPlugin.scheduledJobs.add(this);
     }
 
     // Customize Invocation

--- a/framework/src/play/jobs/Job.java
+++ b/framework/src/play/jobs/Job.java
@@ -190,7 +190,7 @@ public class Job<V> extends Invoker.Invocation implements Callable<V> {
                 try {
                     lastException = null;
                     lastRun = System.currentTimeMillis();
-                    monitor = MonitorFactory.start(getClass().getName()+".doJob()");
+                    monitor = MonitorFactory.start(this + ".doJob()");
                     
                     // If we have a plugin, get him to execute the job within the filter. 
                     final AtomicBoolean executed = new AtomicBoolean(false);

--- a/framework/src/play/jobs/JobsPlugin.java
+++ b/framework/src/play/jobs/JobsPlugin.java
@@ -108,7 +108,6 @@ public class JobsPlugin extends PlayPlugin {
                 jobs.add(clazz);
             }
         }
-        scheduledJobs = new ArrayList<Job>();
         for (final Class<?> clazz : jobs) {
             // @OnApplicationStart
             if (clazz.isAnnotationPresent(OnApplicationStart.class)) {
@@ -191,6 +190,7 @@ public class JobsPlugin extends PlayPlugin {
     public void onApplicationStart() {
         int core = Integer.parseInt(Play.configuration.getProperty("play.jobs.pool", "10"));
         executor = new ScheduledThreadPoolExecutor(core, new PThreadFactory("jobs"), new ThreadPoolExecutor.AbortPolicy());
+        scheduledJobs = new ArrayList<Job>();
     }
 
     public static <V> void scheduleForCRON(Job<V> job) {

--- a/framework/src/play/jobs/JobsPlugin.java
+++ b/framework/src/play/jobs/JobsPlugin.java
@@ -28,8 +28,8 @@ import play.utils.PThreadFactory;
 
 public class JobsPlugin extends PlayPlugin {
 
-    public static ScheduledThreadPoolExecutor executor = null;
-    public static List<Job> scheduledJobs = null;
+    public static ScheduledThreadPoolExecutor executor;
+    public static List<Job> scheduledJobs;
     private static ThreadLocal<List<Callable<? extends Object>>> afterInvocationActions = new ThreadLocal<List<Callable<? extends Object>>>();
 
     @Override
@@ -54,7 +54,7 @@ public class JobsPlugin extends PlayPlugin {
             out.println("Scheduled jobs (" + scheduledJobs.size() + "):");
             out.println("~~~~~~~~~~~~~~~~~~~~~~~~~~");
             for (Job job : scheduledJobs) {
-                out.print(job.getClass().getName());
+                out.print(job);
                 if (job.getClass().isAnnotationPresent(OnApplicationStart.class)
                         && !(job.getClass().isAnnotationPresent(On.class) || job.getClass().isAnnotationPresent(Every.class))) {
                     OnApplicationStart appStartAnnotation = job.getClass().getAnnotation(OnApplicationStart.class);


### PR DESCRIPTION
Currently, application status doesn't display Jobs manually shcheduled using Job.every().

Another issue is 'Scheduled jobs' and 'Waiting jobs' using different ways to display jobs: first one displays the class name directly, while the second uses toString().
Both should use the same method (toString), so that Job can override how it is displayed.

https://play.lighthouseapp.com/projects/57987-play-framework/tickets/1983-jobsplugingetstatus-doesnt-display-manually-scheduled-jobs-and-displays-some-jobs-differently