### PR TITLE
[#1990] extract code for detecting application.conf changes

### DIFF
--- a/framework/src/play.plugins
+++ b/framework/src/play.plugins
@@ -1,4 +1,5 @@
 0:play.CorePlugin
+1:play.ConfigurationChangeWatcherPlugin
 100:play.data.parsing.TempFilePlugin
 200:play.data.validation.ValidationPlugin
 300:play.db.DBPlugin

--- a/framework/src/play/ConfigurationChangeWatcherPlugin.java
+++ b/framework/src/play/ConfigurationChangeWatcherPlugin.java
@@ -6,8 +6,11 @@ import play.vfs.VirtualFile;
  * Plugin used for tracking for application.conf changes
  */
 public class ConfigurationChangeWatcherPlugin extends PlayPlugin {
+    protected static long configLastModified;
+    
     @Override
     public void onConfigurationRead() {
+        configLastModified = System.currentTimeMillis();
         if (Play.mode.isProd()) {
             Play.pluginCollection.disablePlugin(this);
         }
@@ -16,7 +19,8 @@ public class ConfigurationChangeWatcherPlugin extends PlayPlugin {
     @Override
     public void detectChange() {
         for (VirtualFile conf : Play.confs) {
-            if (conf.lastModified() > Play.startedAt) {
+            if (conf.lastModified() > configLastModified) {
+                configLastModified = conf.lastModified();
                 onConfigurationFileChanged(conf);
             }
         }

--- a/framework/src/play/ConfigurationChangeWatcherPlugin.java
+++ b/framework/src/play/ConfigurationChangeWatcherPlugin.java
@@ -1,0 +1,28 @@
+package play;
+
+import play.vfs.VirtualFile;
+
+/**
+ * Plugin used for tracking for application.conf changes
+ */
+public class ConfigurationChangeWatcherPlugin extends PlayPlugin {
+    @Override
+    public void onConfigurationRead() {
+        if (Play.mode.isProd()) {
+            Play.pluginCollection.disablePlugin(this);
+        }
+    }
+
+    @Override
+    public void detectChange() {
+        for (VirtualFile conf : Play.confs) {
+            if (conf.lastModified() > Play.startedAt) {
+                onConfigurationFileChanged(conf);
+            }
+        }
+    }
+
+    protected void onConfigurationFileChanged(VirtualFile conf) {
+        throw new RuntimeException("Need to restart Play because " + conf.getRealFile().getAbsolutePath() + " has been changed");
+    }
+}

--- a/framework/src/play/Play.java
+++ b/framework/src/play/Play.java
@@ -636,12 +636,6 @@ public class Play {
                 classloader.detectChanges();
             }
             Router.detectChanges(ctxPath);
-            for(VirtualFile conf : confs) {
-                if (conf.lastModified() > startedAt) {
-                    start();
-                    return;
-                }
-            }
             pluginCollection.detectChange();
             if (!Play.started) {
                 throw new RuntimeException("Not started");

--- a/framework/test-src/play/plugins/PluginCollectionTest.java
+++ b/framework/test-src/play/plugins/PluginCollectionTest.java
@@ -6,10 +6,7 @@ import java.util.Collection;
 import org.junit.Before;
 import org.junit.Test;
 
-import play.CorePlugin;
-import play.Play;
-import play.PlayBuilder;
-import play.PlayPlugin;
+import play.*;
 import play.data.parsing.TempFilePlugin;
 import play.data.validation.ValidationPlugin;
 import play.db.DBPlugin;
@@ -43,6 +40,7 @@ public class PluginCollectionTest {
         //the following plugin-list should match the list in the file 'play.plugins'
         assertThat(pc.getEnabledPlugins()).containsExactly(
                 pc.getPluginInstance(CorePlugin.class),
+                pc.getPluginInstance(ConfigurationChangeWatcherPlugin.class),
                 pc.getPluginInstance(TempFilePlugin.class),
                 pc.getPluginInstance(ValidationPlugin.class),
                 pc.getPluginInstance(DBPlugin.class),


### PR DESCRIPTION
...from Play.detectChanges() to a separate plugin.

the goal is to be able to override this behaviour: e.g. we don't want to restart play on every conf change - it slows down development process.

Ticket: https://play.lighthouseapp.com/projects/57987-play-framework/tickets/1990-extract-code-for-detecting-applicationconf-changes-from-playdetectchanges-to-a-separate-plugin