### PR TITLE
fix putting property to customer DB configuration

### DIFF
--- a/framework/src/play/db/Configuration.java
+++ b/framework/src/play/db/Configuration.java
@@ -77,9 +77,6 @@ public class Configuration {
      }
 
     String generateKey(String key) {
-        if (isDefault())
-            return key;
-        
         Pattern pattern = new Pattern("^(db|jpa|hibernate){1}(\\.?[\\da-zA-Z\\.-_]*)$");
         Matcher m = pattern.matcher(key);
         if (m.matches()) {

--- a/framework/src/play/db/Configuration.java
+++ b/framework/src/play/db/Configuration.java
@@ -2,8 +2,6 @@ package play.db;
 
 import java.util.*;
 
-import javax.sql.DataSource;
-
 import play.*;
 import jregex.Matcher;
 import jregex.Pattern;
@@ -51,18 +49,13 @@ public class Configuration {
      
      
      public String getProperty(String key, String defaultString) {
-         if(key != null){
-             String newKey = key;
-             Pattern pattern = new jregex.Pattern("^(db|jpa|hibernate){1}(\\.)*(.)*$");
-             Matcher m = pattern.matcher(key);
-             if(m.matches() && m.groupCount() > 1){
-                 newKey = m.group(1) + "." + this.configName + key.substring(m.group(1).length());
-             }
+         if (key != null) {
+             String newKey = generateKey(key);
              Object value = Play.configuration.get(newKey);
-             if(value == null && this.isDefault()){
+             if (value == null && this.isDefault()){
                  value = Play.configuration.get(key);
              }
-             if(value != null){
+             if (value != null){
                  return value.toString();
              }
          }
@@ -77,19 +70,24 @@ public class Configuration {
       * @return the previous value of the specified key in this hashtable, or null if it did not have one
       */
      public Object put(String key, String value) {
-         if(key != null){
-             String newKey = key;
-             Pattern pattern = new jregex.Pattern("^([db|jpa|hibernate]{1})(\\.[\\da-zA-Z.-_]*)$");
-             Matcher m = pattern.matcher(key);
-             if(m.matches()){
-                 newKey = m.group(0) + "." + this.configName;
-             }
-             
-             return Play.configuration.put(newKey, value);
+         if (key != null) {
+             return Play.configuration.put(generateKey(key), value);
          }
          return null;
      }
-     
+
+    String generateKey(String key) {
+        if (isDefault())
+            return key;
+        
+        Pattern pattern = new Pattern("^(db|jpa|hibernate){1}(\\.?[\\da-zA-Z\\.-_]*)$");
+        Matcher m = pattern.matcher(key);
+        if (m.matches()) {
+            return m.group(1) + "." + this.configName + m.group(2);
+        }
+        return key;
+    }
+
 
     public Map<String, String> getProperties() {
         Map<String, String> properties = new HashMap<String, String>();

--- a/framework/test-src/play/db/ConfigurationTest.java
+++ b/framework/test-src/play/db/ConfigurationTest.java
@@ -315,9 +315,9 @@ public class ConfigurationTest {
     @Test
     public void usesDefaultConfigurationPropertyNameForDefaultDatabase() {
         Configuration configuration = new Configuration("default");
-        assertEquals("db", configuration.generateKey("db"));
-        assertEquals("db.driver", configuration.generateKey("db.driver"));
-        assertEquals("db.url", configuration.generateKey("db.url"));
+        assertEquals("db.default", configuration.generateKey("db"));
+        assertEquals("db.default.driver", configuration.generateKey("db.driver"));
+        assertEquals("db.default.url", configuration.generateKey("db.url"));
         assertEquals("another-property", configuration.generateKey("another-property"));
     }
 
@@ -326,7 +326,7 @@ public class ConfigurationTest {
         Configuration configuration = new Configuration("default");
         configuration.put("db.driver", "org.h2.Driver");
         assertEquals("org.h2.Driver", configuration.getProperty("db.driver"));
-        assertEquals("org.h2.Driver", Play.configuration.getProperty("db.driver"));
+        assertEquals("org.h2.Driver", Play.configuration.getProperty("db.default.driver"));
     }
     
     @Test
@@ -351,8 +351,15 @@ public class ConfigurationTest {
         assertEquals("org.h2.Driver", configuration1.getProperty("db.driver"));
         assertEquals("com.mysql.Driver", configuration2.getProperty("db.driver"));
         
-        assertEquals("com.oracle.OracleDriver", Play.configuration.getProperty("db.driver"));
+        assertEquals("com.oracle.OracleDriver", Play.configuration.getProperty("db.default.driver"));
         assertEquals("org.h2.Driver", Play.configuration.getProperty("db.db1.driver"));
         assertEquals("com.mysql.Driver", Play.configuration.getProperty("db.db2.driver"));
+    }
+
+    @Test
+    public void getPropertyFromDefaultConfiguration() {
+        Play.configuration.setProperty("db.default.url", "jdbc:h2:mem:play;MODE=MSSQLServer;LOCK_MODE=0");
+        Configuration configuration = new Configuration("default");
+        assertEquals("jdbc:h2:mem:play;MODE=MSSQLServer;LOCK_MODE=0", configuration.getProperty("db.url"));
     }
 }

--- a/framework/test-src/play/db/ConfigurationTest.java
+++ b/framework/test-src/play/db/ConfigurationTest.java
@@ -1,9 +1,6 @@
 package play.db;
 
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
+import java.util.*;
 
 import org.junit.*;
 
@@ -13,32 +10,33 @@ import static org.junit.Assert.assertNull;
 
 public class ConfigurationTest {
 
-    @Test
-    public void dbNameResolverTest() {
+    @Before
+    public void setUp() {
         Play.configuration = new Properties();
-        Play.configuration.put("db", "mysql:user:pwd@database_name");
-        Set<String> dbNames = Configuration.getDbNames();
-        assertEquals(1, dbNames.size());
-        Iterator<String> it = dbNames.iterator();
-        assertEquals("default", it.next());
-
-        Play.configuration.put("db.test", "mysql:user:pwd@database_name2");
-        dbNames = Configuration.getDbNames();
-        assertEquals(2, dbNames.size());
-        it = dbNames.iterator();
-        assertEquals("default", it.next());
-        assertEquals("test", it.next());
-        
-        Configuration configuration = new Configuration("default");
-        assertEquals("mysql:user:pwd@database_name", configuration.getProperty("db"));
-        
-        configuration = new Configuration("test");
-        assertEquals("mysql:user:pwd@database_name2", configuration.getProperty("db"));
     }
 
     @Test
-    public void dbNameResolverMultiDbURLTest1() {
-        Play.configuration = new Properties();
+    public void dbNameResolver_singleDatabase() {
+        Play.configuration.put("db", "mysql:user:pwd@database_name");
+        Set<String> dbNames = Configuration.getDbNames();
+        assertEquals(1, dbNames.size());
+        assertEquals("default", dbNames.iterator().next());
+    }
+    
+    @Test
+    public void dbNameResolver_multipleDatabases() {
+        Play.configuration.put("db", "mysql:user:pwd@database_name");
+        Play.configuration.put("db.test", "mysql:user:pwd@database_name2");
+        List<String> dbNames = new ArrayList<String>(Configuration.getDbNames());
+        assertEquals(2, dbNames.size());
+        assertEquals("default", dbNames.get(0));
+        assertEquals("test", dbNames.get(1));
+        assertEquals("mysql:user:pwd@database_name", new Configuration("default").getProperty("db"));
+        assertEquals("mysql:user:pwd@database_name2", new Configuration("test").getProperty("db"));
+    }
+
+    @Test
+    public void dbNameResolverMultiDbURL_singleDatabase() {
         Play.configuration.put("db.url", "jdbc:postgresql://localhost/database_name");
         Play.configuration.put("db.driver", "org.postgresql.Driver");
         Play.configuration.put("db.user", "user");
@@ -46,30 +44,36 @@ public class ConfigurationTest {
 
         Set<String> dbNames = Configuration.getDbNames();
         assertEquals(1, dbNames.size());
-        Iterator<String> it = dbNames.iterator();
-        assertEquals("default", it.next());
+        assertEquals("default", dbNames.iterator().next());
+    }
 
+    @Test
+    public void dbNameResolverMultiDbURL_multipleDatabases() {
+        Play.configuration.put("db.url", "jdbc:postgresql://localhost/database_name");
+        Play.configuration.put("db.driver", "org.postgresql.Driver");
+        Play.configuration.put("db.user", "user");
+        Play.configuration.put("db.pass", "pass");
         Play.configuration.put("db.test.url", "jdbc:postgresql://localhost/database_name2");
         Play.configuration.put("db.test.driver", "org.postgresql.Driver");
         Play.configuration.put("db.test.user", "user2");
         Play.configuration.put("db.test.pass", "pass2");
-        dbNames = Configuration.getDbNames();
+        
+        List<String> dbNames = new ArrayList<String>(Configuration.getDbNames());
         assertEquals(2, dbNames.size());
-        it = dbNames.iterator();
-        assertEquals("default", it.next());
-        assertEquals("test", it.next());
+        assertEquals("default", dbNames.get(0));
+        assertEquals("test", dbNames.get(1));
         
-        Configuration configuration = new Configuration("default");
-        assertEquals("jdbc:postgresql://localhost/database_name", configuration.getProperty("db.url"));
-        assertEquals("org.postgresql.Driver", configuration.getProperty("db.driver"));
-        assertEquals("user", configuration.getProperty("db.user"));
-        assertEquals("pass", configuration.getProperty("db.pass"));
-        
-        configuration = new Configuration("test");
-        assertEquals("jdbc:postgresql://localhost/database_name2", configuration.getProperty("db.url"));
-        assertEquals("org.postgresql.Driver", configuration.getProperty("db.driver"));
-        assertEquals("user2", configuration.getProperty("db.user"));
-        assertEquals("pass2", configuration.getProperty("db.pass"));
+        Configuration configuration1 = new Configuration("default");
+        assertEquals("jdbc:postgresql://localhost/database_name", configuration1.getProperty("db.url"));
+        assertEquals("org.postgresql.Driver", configuration1.getProperty("db.driver"));
+        assertEquals("user", configuration1.getProperty("db.user"));
+        assertEquals("pass", configuration1.getProperty("db.pass"));
+
+        Configuration configuration2 = new Configuration("test");
+        assertEquals("jdbc:postgresql://localhost/database_name2", configuration2.getProperty("db.url"));
+        assertEquals("org.postgresql.Driver", configuration2.getProperty("db.driver"));
+        assertEquals("user2", configuration2.getProperty("db.user"));
+        assertEquals("pass2", configuration2.getProperty("db.pass"));
     }
 
     @Test
@@ -86,8 +90,7 @@ public class ConfigurationTest {
 
         Set<String> dbNames = Configuration.getDbNames();
         assertEquals(1, dbNames.size());
-        Iterator<String> it = dbNames.iterator();
-        assertEquals("default", it.next());
+        assertEquals("default", dbNames.iterator().next());
         
         Configuration configuration = new Configuration("default");
         assertEquals("jdbc:mysql://127.0.0.1/testPlay", configuration.getProperty("db.url"));
@@ -116,8 +119,7 @@ public class ConfigurationTest {
         Play.configuration.put("db", "mysql:user:pwd@database_name");
         Set<String> dbNames = Configuration.getDbNames();
         assertEquals(1, dbNames.size());
-        Iterator<String> it = dbNames.iterator();
-        assertEquals("default", it.next());
+        assertEquals("default", dbNames.iterator().next());
     }
 
     @Test
@@ -239,8 +241,6 @@ public class ConfigurationTest {
     
     @Test
     public void getPropertiesForDefaultTest() {
-        Play.configuration = new Properties();
-
         Play.configuration.put("db.url", "jdbc:mysql://127.0.0.1/testPlay");
         Play.configuration.put("db.driver", "com.mysql.jdbc.Driver");
         Play.configuration.put("db.user", "root");
@@ -273,8 +273,6 @@ public class ConfigurationTest {
     
     @Test
     public void getPropertiesForDBTest() {
-        Play.configuration = new Properties();
-
         Play.configuration.put("db.test.url", "jdbc:mysql://127.0.0.1/testPlay");
         Play.configuration.put("db.test.driver", "com.mysql.jdbc.Driver");
         Play.configuration.put("db.test.user", "root");
@@ -303,5 +301,58 @@ public class ConfigurationTest {
         assertEquals("postUpdate", properties.get("hibernate.ejb.event.post-update"));
         
         assertEquals(Play.configuration.size(), properties.size());
+    }
+
+    @Test
+    public void generatesConfigurationPropertyNameBasedOnDatabaseName() {
+        Configuration configuration = new Configuration("another");
+        assertEquals("db.another", configuration.generateKey("db"));
+        assertEquals("db.another.driver", configuration.generateKey("db.driver"));
+        assertEquals("db.another.url", configuration.generateKey("db.url"));
+        assertEquals("another-property", configuration.generateKey("another-property"));
+    }
+
+    @Test
+    public void usesDefaultConfigurationPropertyNameForDefaultDatabase() {
+        Configuration configuration = new Configuration("default");
+        assertEquals("db", configuration.generateKey("db"));
+        assertEquals("db.driver", configuration.generateKey("db.driver"));
+        assertEquals("db.url", configuration.generateKey("db.url"));
+        assertEquals("another-property", configuration.generateKey("another-property"));
+    }
+
+    @Test
+    public void putPropertyToDefaultConfiguration() {
+        Configuration configuration = new Configuration("default");
+        configuration.put("db.driver", "org.h2.Driver");
+        assertEquals("org.h2.Driver", configuration.getProperty("db.driver"));
+        assertEquals("org.h2.Driver", Play.configuration.getProperty("db.driver"));
+    }
+    
+    @Test
+    public void putPropertyToCustomConfiguration() {
+        Configuration configuration = new Configuration("custom");
+        
+        configuration.put("db.driver", "com.oracle.OracleDriver");
+        assertEquals("com.oracle.OracleDriver", configuration.getProperty("db.driver"));
+    }
+
+    @Test
+    public void putPropertyToMultipleCustomConfigurations() {
+        Configuration configuration = new Configuration("default");
+        Configuration configuration1 = new Configuration("db1");
+        Configuration configuration2 = new Configuration("db2");
+        
+        configuration.put("db.driver", "com.oracle.OracleDriver");
+        configuration1.put("db.driver", "org.h2.Driver");
+        configuration2.put("db.driver", "com.mysql.Driver");
+        
+        assertEquals("com.oracle.OracleDriver", configuration.getProperty("db.driver"));
+        assertEquals("org.h2.Driver", configuration1.getProperty("db.driver"));
+        assertEquals("com.mysql.Driver", configuration2.getProperty("db.driver"));
+        
+        assertEquals("com.oracle.OracleDriver", Play.configuration.getProperty("db.driver"));
+        assertEquals("org.h2.Driver", Play.configuration.getProperty("db.db1.driver"));
+        assertEquals("com.mysql.Driver", Play.configuration.getProperty("db.db2.driver"));
     }
 }


### PR DESCRIPTION
In current Play implementation, putting property to custom DB configuration uses wrong property name.

See this failing test:

```java
    @Test
    public void putPropertyToCustomConfiguration() {
        Configuration configuration = new Configuration("custom");
        
        configuration.put("db.driver", "com.oracle.OracleDriver");
        assertEquals("com.oracle.OracleDriver", configuration.getProperty("db.driver"));
    }
```

This pull request makes this test green. 

See ticket https://play.lighthouseapp.com/projects/57987-play-framework/tickets/1992-fix-putting-property-to-customer-db-configuration