### PR TITLE
[#1995] make DB properties configurable

### DIFF
--- a/documentation/manual/configuration.textile
+++ b/documentation/manual/configuration.textile
@@ -327,6 +327,73 @@ Database connection password, used with "db.url":#db.url.
 
 Default: no value, or an empty string when "db":#db is set to @mem@ or @fs@. 
 
+h3(#db.pool.acquireIncrement). db.pool.acquireIncrement
+
+Determines how many connections at a time c3p0 will try to acquire when the pool is exhausted.
+
+Default: @3@ 
+
+h3(#db.pool.acquireRetryAttempts). db.pool.acquireRetryAttempts
+
+Defines how many times c3p0 will try to acquire a new Connection from the database before giving up. If this value is less than or equal to zero, c3p0 will keep trying to fetch a Connection indefinitely.
+
+Default: @10@
+
+h3(#db.pool.acquireRetryDelay). db.pool.acquireRetryDelay
+
+Milliseconds, time c3p0 will wait between acquire attempts. 
+
+Default: @1000@
+
+h3(#db.pool.breakAfterAcquireFailure). db.pool.breakAfterAcquireFailure
+
+If true, a pooled DataSource will declare itself broken and be permanently closed if a Connection cannot be obtained from the database after making acquireRetryAttempts to acquire one. If false, failure to obtain a Connection will cause all Threads waiting for the pool to acquire a Connection to throw an Exception, but the DataSource will remain valid, and will attempt to acquire again following a call to getConnection(). 
+
+Default: @false@
+
+h3(#db.pool.unreturnedConnectionTimeout). db.pool.unreturnedConnectionTimeout
+
+Seconds. If set, if an application checks out but then fails to check-in [i.e. close()] a Connection within the specified period of time, the pool will unceremoniously destroy() the Connection. This permits applications with occasional Connection leaks to survive, rather than eventually exhausting the Connection pool. And that's a shame. Zero means no timeout, applications are expected to close() their own Connections. Obviously, if a non-zero value is set, it should be to a value longer than any Connection should reasonably be checked-out. Otherwise, the pool will occasionally kill Connections in active use, which is bad.
+ 
+Use this temporarily in combination with debugUnreturnedConnectionStackTraces to figure out where Connections are being checked-out that don't make it back into the pool!
+
+Default: @0@
+
+h3(#db.pool.debugUnreturnedConnectionStackTraces). db.pool.debugUnreturnedConnectionStackTraces
+
+f true, and if unreturnedConnectionTimeout is set to a positive value, then the pool will capture the stack trace (via an Exception) of all Connection checkouts, and the stack traces will be printed when unreturned checked-out Connections timeout. This is intended to debug applications with Connection leaks, that is applications that occasionally fail to return Connections, leading to pool growth, and eventually exhaustion (when the pool hits maxPoolSize with all Connections checked-out and lost). This parameter should only be set while debugging, as capturing the stack trace will slow down every Connection check-out. 
+
+Default: @false@
+
+h3(#db.pool.testConnectionOnCheckout). db.pool.testConnectionOnCheckout
+
+If true, an operation will be performed at every connection checkout to verify that the connection is valid. Be sure to set an efficient preferredTestQuery or automaticTestTable if you set this to true. Performing the (expensive) default Connection test on every client checkout will harm client performance. Testing Connections in checkout is the simplest and most reliable form of Connection testing, but for better performance, consider verifying connections periodically using idleConnectionTestPeriod. 
+
+Default: @false@
+
+h3(#db.pool.testConnectionOnCheckin). db.pool.testConnectionOnCheckin
+
+If true, an operation will be performed asynchronously at every connection checkin to verify that the connection is valid. Use in combination with idleConnectionTestPeriod for quite reliable, always asynchronous Connection testing. Also, setting an automaticTestTable or preferredTestQuery will usually speed up all connection tests. 
+
+Default: @true@
+
+h3(#db.pool.maxConnectionAge). db.pool.maxConnectionAge
+
+Seconds, effectively a time to live. A Connection older than maxConnectionAge will be destroyed and purged from the pool. This differs from maxIdleTime in that it refers to absolute age. Even a Connection which has not been much idle will be purged from the pool if it exceeds maxConnectionAge. Zero means no maximum absolute age is enforced.
+     
+Default: @0@
+
+h3(#db.pool.maxIdleTime). db.pool.maxIdleTime
+
+Seconds a Connection can remain pooled but unused before being discarded. Zero means idle connections never expire.
+
+Default: @0@
+
+h3(#db.pool.idleConnectionTestPeriod). db.pool.idleConnectionTestPeriod
+
+If this is a number greater than 0, c3p0 will test all idle, pooled but unchecked-out connections, every this number of seconds.
+
+Default: @10@
 
 h3(#db.pool.maxIdleTimeExcessConnections). db.pool.maxIdleTimeExcessConnections
 
@@ -352,6 +419,14 @@ bc. db.pool.minSize=10
 
 Default: @1@
 
+h3(#db.pool.initialSize). db.pool.initialSize
+
+Number of Connections a pool will try to acquire upon startup. Should be between minPoolSize and maxPoolSize. See the "c3p0 documentation":http://www.mchange.com/projects/c3p0/#initialPoolSize. For example:
+
+bc. db.pool.initialSize=5
+
+Default: @1@
+
 
 h3(#db.pool.timeout). db.pool.timeout
 
@@ -360,6 +435,24 @@ Connection pool time-out in milliseconds. See the "c3p0 documentation":http://ww
 bc. db.pool.timeout=10000
 
 Default: @5000@
+
+h3(#db.pool.loginTimeout). db.pool.loginTimeout
+
+Sets the maximum time in seconds that this data source will wait while attempting to connect to a database.
+     
+Default: @0@
+
+h3(#db.pool.maxStatements). db.pool.maxStatements
+
+The size of c3p0's global PreparedStatement cache. If both maxStatements and maxStatementsPerConnection are zero, statement caching will not be enabled.
+     
+Default: @0@
+
+h3(#db.pool.maxStatementsPerConnection). db.pool.maxStatementsPerConnection
+
+The number of PreparedStatements c3p0 will cache for a single pooled Connection. If both maxStatements and maxStatementsPerConnection are zero, statement caching will not be enabled.
+     
+Default: @0@
 
 
 h3(#db.url). db.url
@@ -383,6 +476,18 @@ Override query to use when keepalive connection polling is being performed. The 
 
 Default: null  
 Default on MySQL: /* ping */ SELECT 1
+
+h3(#db.pool.maxAdministrativeTaskTime). db.pool.maxAdministrativeTaskTime
+
+Seconds before c3p0's thread pool will try to interrupt an apparently hung task. Rarely useful.  
+
+Default: @0@
+
+h3(#db.pool.numHelperThreads). db.pool.numHelperThreads
+
+c3p0 is very asynchronous. Slow JDBC operations are generally performed by helper threads that don't hold contended locks. Spreading these operations over multiple threads can significantly improve performance by allowing multiple operations to be performed simultaneously.  
+
+Default: @3@
 
 
 h2(#evolutions). Database evolutions

--- a/framework/src/play/db/DBPlugin.java
+++ b/framework/src/play/db/DBPlugin.java
@@ -142,14 +142,27 @@ public class DBPlugin extends PlayPlugin {
                         ds.setJdbcUrl(dbConfig.getProperty("db.url"));
                         ds.setUser(dbConfig.getProperty("db.user"));
                         ds.setPassword(dbConfig.getProperty("db.pass"));
-                        ds.setAcquireRetryAttempts(10);
+                        ds.setAcquireIncrement(Integer.parseInt(dbConfig.getProperty("db.pool.acquireIncrement", "3")));
+                        ds.setAcquireRetryAttempts(Integer.parseInt(dbConfig.getProperty("db.pool.acquireRetryAttempts", "10")));
+                        ds.setAcquireRetryDelay(Integer.parseInt(dbConfig.getProperty("db.pool.acquireRetryDelay", "1000")));
                         ds.setCheckoutTimeout(Integer.parseInt(dbConfig.getProperty("db.pool.timeout", "5000")));
-                        ds.setBreakAfterAcquireFailure(false);
+                        ds.setBreakAfterAcquireFailure(Boolean.parseBoolean(dbConfig.getProperty("db.pool.breakAfterAcquireFailure", "false")));
                         ds.setMaxPoolSize(Integer.parseInt(dbConfig.getProperty("db.pool.maxSize", "30")));
                         ds.setMinPoolSize(Integer.parseInt(dbConfig.getProperty("db.pool.minSize", "1")));
+                        ds.setInitialPoolSize(Integer.parseInt(dbConfig.getProperty("db.pool.initialSize", "1")));
                         ds.setMaxIdleTimeExcessConnections(Integer.parseInt(dbConfig.getProperty("db.pool.maxIdleTimeExcessConnections", "0")));
-                        ds.setIdleConnectionTestPeriod(10);
-                        ds.setTestConnectionOnCheckin(true);
+                        ds.setIdleConnectionTestPeriod(Integer.parseInt(dbConfig.getProperty("db.pool.maxIdleConnectionTestPeriod", "10")));
+                        ds.setMaxIdleTime(Integer.parseInt(dbConfig.getProperty("db.pool.maxIdleTime", "0")));
+                        ds.setTestConnectionOnCheckin(Boolean.parseBoolean(dbConfig.getProperty("db.pool.testConnectionOnCheckin", "true")));
+                        ds.setTestConnectionOnCheckout(Boolean.parseBoolean(dbConfig.getProperty("db.pool.testConnectionOnCheckout", "false")));
+                        ds.setDebugUnreturnedConnectionStackTraces(Boolean.parseBoolean(dbConfig.getProperty("db.pool.debugUnreturnedConnectionStackTraces", "false")));
+                        ds.setLoginTimeout(Integer.parseInt(dbConfig.getProperty("db.pool.loginTimeout", "0")));
+                        ds.setMaxAdministrativeTaskTime(Integer.parseInt(dbConfig.getProperty("db.pool.maxAdministrativeTaskTime", "0")));
+                        ds.setMaxConnectionAge(Integer.parseInt(dbConfig.getProperty("db.pool.maxConnectionAge", "0")));
+                        ds.setMaxStatements(Integer.parseInt(dbConfig.getProperty("db.pool.maxStatements", "0")));
+                        ds.setMaxStatementsPerConnection(Integer.parseInt(dbConfig.getProperty("db.pool.maxStatementsPerConnection", "0")));
+                        ds.setNumHelperThreads(Integer.parseInt(dbConfig.getProperty("db.pool.numHelperThreads", "3")));
+                        ds.setUnreturnedConnectionTimeout(Integer.parseInt(dbConfig.getProperty("db.pool.unreturnedConnectionTimeout", "0")));
 
                         if (dbConfig.getProperty("db.testquery") != null) {
                             ds.setPreferredTestQuery(dbConfig.getProperty("db.testquery"));

--- a/framework/src/play/db/DBPlugin.java
+++ b/framework/src/play/db/DBPlugin.java
@@ -151,11 +151,10 @@ public class DBPlugin extends PlayPlugin {
                         ds.setMinPoolSize(Integer.parseInt(dbConfig.getProperty("db.pool.minSize", "1")));
                         ds.setInitialPoolSize(Integer.parseInt(dbConfig.getProperty("db.pool.initialSize", "1")));
                         ds.setMaxIdleTimeExcessConnections(Integer.parseInt(dbConfig.getProperty("db.pool.maxIdleTimeExcessConnections", "0")));
-                        ds.setIdleConnectionTestPeriod(Integer.parseInt(dbConfig.getProperty("db.pool.maxIdleConnectionTestPeriod", "10")));
+                        ds.setIdleConnectionTestPeriod(Integer.parseInt(dbConfig.getProperty("db.pool.idleConnectionTestPeriod", "10")));
                         ds.setMaxIdleTime(Integer.parseInt(dbConfig.getProperty("db.pool.maxIdleTime", "0")));
                         ds.setTestConnectionOnCheckin(Boolean.parseBoolean(dbConfig.getProperty("db.pool.testConnectionOnCheckin", "true")));
                         ds.setTestConnectionOnCheckout(Boolean.parseBoolean(dbConfig.getProperty("db.pool.testConnectionOnCheckout", "false")));
-                        ds.setDebugUnreturnedConnectionStackTraces(Boolean.parseBoolean(dbConfig.getProperty("db.pool.debugUnreturnedConnectionStackTraces", "false")));
                         ds.setLoginTimeout(Integer.parseInt(dbConfig.getProperty("db.pool.loginTimeout", "0")));
                         ds.setMaxAdministrativeTaskTime(Integer.parseInt(dbConfig.getProperty("db.pool.maxAdministrativeTaskTime", "0")));
                         ds.setMaxConnectionAge(Integer.parseInt(dbConfig.getProperty("db.pool.maxConnectionAge", "0")));
@@ -163,6 +162,7 @@ public class DBPlugin extends PlayPlugin {
                         ds.setMaxStatementsPerConnection(Integer.parseInt(dbConfig.getProperty("db.pool.maxStatementsPerConnection", "0")));
                         ds.setNumHelperThreads(Integer.parseInt(dbConfig.getProperty("db.pool.numHelperThreads", "3")));
                         ds.setUnreturnedConnectionTimeout(Integer.parseInt(dbConfig.getProperty("db.pool.unreturnedConnectionTimeout", "0")));
+                        ds.setDebugUnreturnedConnectionStackTraces(Boolean.parseBoolean(dbConfig.getProperty("db.pool.debugUnreturnedConnectionStackTraces", "false")));
 
                         if (dbConfig.getProperty("db.testquery") != null) {
                             ds.setPreferredTestQuery(dbConfig.getProperty("db.testquery"));


### PR DESCRIPTION
* add more configurable c3p0 properties (e.g. maxIdleTime)
* remove hardcoded settings acquireRetryAttempts=10, idleConnectionTestPeriod=10, testConnectionOnCheckin=true

Ticket: https://play.lighthouseapp.com/projects/57987-play-framework/tickets/1995-make-db-properties-configurable