### PR TITLE
[#2036] Force secure reverse routes config

### DIFF
--- a/documentation/manual/configuration.textile
+++ b/documentation/manual/configuration.textile
@@ -29,6 +29,15 @@ bc. application.defaultCookieDomain=.example.com
 Default: a cookie is only valid for a specific domain.
 
 
+h3(#application.forceSecureReverseRoutes). application.forceSecureReverseRoutes
+
+Forces all reverse routes and controller action redirection to be secure (https). This is useful for SSL-enabled apps to prevent insecure (http) url generation when redirecting to another action from inside your controllers, or when using the <code>@{..}</code> template syntax. For example:
+
+bc. application.forceSecureReverseRoutes=true
+
+Default: @false@
+
+
 h3(#application.lang.cookie). application.lang.cookie
 
 The name of the cookie that is used to store the current language, set by @play.i18n.Lang.change(String locale)@, which you can change if you want separate language settings for separate Play applications. For example:

--- a/framework/src/play/mvc/Router.java
+++ b/framework/src/play/mvc/Router.java
@@ -576,6 +576,9 @@ public class Router {
                 actionDefinition.action = action;
                 actionDefinition.args = argsbackup;
                 actionDefinition.host = host;
+                if (Boolean.parseBoolean(Play.configuration.getProperty("application.forceSecureReverseRoutes", "false"))) {
+                    actionDefinition.secure();
+                }
                 return actionDefinition;
             }
         }


### PR DESCRIPTION
For SSL-enabled application that have early SSL-termination (meaning the application code sees it as a non-https request but with the `X-Forwarded-Proto` header set), using reverse routing out of the box can be somewhat of a pain, since it blindly uses the host request header (which is non-https) for the redirect url. This results in multiple redirects for applications that already have custom code to redirect non-secure requests in a `@Before` filter (as mine does). As a result, flash parameters are dropped due to the multiple redirection.

This PR adds a configuration setting that will force the Router's `reverse` method to use a secure url (https://) for the `actionDefinition`'s `host`.

This new configuration is of course **opt-in**, disabled by default. For what it's worth, I'm currently using this in a production app of mine on Heroku by pointing a custom buildpack to this build and it works like a charm! :smile: