### PR TITLE
[#2011] "double semicolon" as escape in evolutions scripts

### DIFF
--- a/framework/src/play/db/SQLSplitter.java
+++ b/framework/src/play/db/SQLSplitter.java
@@ -193,14 +193,19 @@ public class SQLSplitter implements Iterable<CharSequence> {
 				while ( i < sql.length() ) {
 					if ( sql.charAt(i) == ';' ) {
 						++i;
-						CharSequence ret = sql.subSequence(prev, i);
-						prev = i;
-						return ret;
+						// check "double semicolon" -> used to escape a semicolon and avoid splitting
+						if ((i < sql.length() && sql.charAt(i) == ';')) {
+							++i;
+						} else {
+							CharSequence ret = sql.subSequence(prev, i).toString().replace(";;", ";");
+							prev = i;
+							return ret;
+						}
 					}
 					i = nextChar(sql, i);
 				}
 				if ( prev != i ) {
-					CharSequence ret = sql.subSequence(prev, i);
+					CharSequence ret = sql.subSequence(prev, i).toString().replace(";;", ";");
 					prev = i;
 					return ret;
 				}

--- a/framework/test-src/play/db/SQLSplitterTest.java
+++ b/framework/test-src/play/db/SQLSplitterTest.java
@@ -88,6 +88,12 @@ public class SQLSplitterTest {
 		assertEquals(3, SQLSplitter.consumeParentheses("(()", 0));
 	}
 
+	@Test
+	public void verifyDoubleSemicolonHandling() {
+		assertEquals(2, SQLSplitter.splitSQL("a;\nb;;\nc;").size());
+		assertEquals(3, SQLSplitter.splitSQL("a;\nb;\nc;").size());
+	}
+
 	String readFile(final String filename) throws Exception {
 		final File src = new File(getClass().getResource(filename).toURI());
 		final byte [] srcbytes = new byte[(int)src.length()];


### PR DESCRIPTION
"double semicolon" used to escape a semicolon and avoid splitting the same way Play 2.x supports escaping the single semicolon.

Useful to handle trigger or function declarations in evolutions scripts for SQL dialects that don't support dollar comments/delimiters (i.e. MySQL).

See [Lighthouse 2011](https://play.lighthouseapp.com/projects/57987-play-framework/tickets/2011-support-double-semicolon-escaping-in-evolution-scripts)