### PR TITLE
Add return type for Play.fatalServerError

### DIFF
--- a/framework/src/play/Play.java
+++ b/framework/src/play/Play.java
@@ -245,7 +245,7 @@ public class Play {
             mode = Mode.valueOf(configuration.getProperty("application.mode", "DEV").toUpperCase());
         } catch (IllegalArgumentException e) {
             Logger.error("Illegal mode '%s', use either prod or dev", configuration.getProperty("application.mode"));
-            fatalServerErrorOccurred();
+            throw Play.<Error>fatalServerError();
         }
 	
         // Force the Production mode if forceProd or precompile is activate
@@ -378,7 +378,7 @@ public class Play {
         } catch (RuntimeException e) {
             if (e.getCause() instanceof IOException) {
                 Logger.fatal("Cannot read "+filename);
-                fatalServerErrorOccurred();
+                return fatalServerError();
             }
         }
         confs.add(conf);
@@ -593,8 +593,7 @@ public class Play {
                 return true;
             }
             Logger.error("Precompiled classes are missing!!");
-            fatalServerErrorOccurred();
-            return false;
+            return fatalServerError();
         }
         try {
             Logger.info("Precompiling ...");
@@ -617,8 +616,7 @@ public class Play {
             return true;
         } catch (Throwable e) {
             Logger.error(e, "Cannot start in PROD mode with errors");
-            fatalServerErrorOccurred();
-            return false;
+            return fatalServerError();
         }
     }
 
@@ -842,11 +840,18 @@ public class Play {
 
     /**
      * Call this method when there has been a fatal error that Play cannot recover from
+     * @deprecated use {@link #fatalServerError()} instead.
      */
+    @Deprecated
     public static void fatalServerErrorOccurred() {
+        fatalServerError();
+    }
+
+    public static <T> T fatalServerError() {
         if (standalonePlayServer) {
             // Just quit the process
             System.exit(-1);
+            return null;
         } else {
             // Cannot quit the process while running inside an applicationServer
             String msg = "A fatal server error occurred";

--- a/framework/src/play/server/Server.java
+++ b/framework/src/play/server/Server.java
@@ -37,7 +37,7 @@ public class Server {
 
         if (httpPort == httpsPort) {
             Logger.error("Could not bind on https and http on the same port " + httpPort);
-            Play.fatalServerErrorOccurred();
+            throw Play.<Error>fatalServerError();
         }
 
         InetAddress address = null;
@@ -51,7 +51,7 @@ public class Server {
 
         } catch (Exception e) {
             Logger.error(e, "Could not understand http.address");
-            Play.fatalServerErrorOccurred();
+            throw Play.<Error>fatalServerError();
         }
         try {
             if (p.getProperty("https.address") != null) {
@@ -61,7 +61,7 @@ public class Server {
             }
         } catch (Exception e) {
             Logger.error(e, "Could not understand https.address");
-            Play.fatalServerErrorOccurred();
+            throw Play.<Error>fatalServerError();
         }
         ServerBootstrap bootstrap = new ServerBootstrap(new NioServerSocketChannelFactory(
                 Executors.newCachedThreadPool(), Executors.newCachedThreadPool())
@@ -91,7 +91,7 @@ public class Server {
 
         } catch (ChannelException e) {
             Logger.error("Could not bind on port " + httpPort, e);
-            Play.fatalServerErrorOccurred();
+            throw Play.<Error>fatalServerError();
         }
 
         bootstrap = new ServerBootstrap(new NioServerSocketChannelFactory(
@@ -122,7 +122,7 @@ public class Server {
 
         } catch (ChannelException e) {
             Logger.error("Could not bind on port " + httpsPort, e);
-            Play.fatalServerErrorOccurred();
+            throw Play.<Error>fatalServerError();
         }
         if (Play.mode == Mode.DEV || Play.runningInTestMode()) {
            // print this line to STDOUT - not using logger, so auto test runner will not block if logger is misconfigured (see #1222)     


### PR DESCRIPTION
This allows reasoning about code path, and eliminates false positives with code analysis tools.
