### PR TITLE
[#2016] default value of "XForwardedOverwriteDomainAndPort" setting should be…

### DIFF
--- a/documentation/manual/configuration.textile
+++ b/documentation/manual/configuration.textile
@@ -1156,6 +1156,7 @@ For example:
 
 bc. XForwardedOverwriteDomainAndPort=true
 
+Default: @false@
 
 h2(#enhancers). Enhancers
 

--- a/framework/src/play/mvc/Http.java
+++ b/framework/src/play/mvc/Http.java
@@ -394,7 +394,7 @@ public class Http {
                 }
             }
 
-            if (Play.configuration.getProperty("XForwardedOverwriteDomainAndPort", "true").toLowerCase().equals("true") && this.host != null
+            if (Play.configuration.getProperty("XForwardedOverwriteDomainAndPort", "false").toLowerCase().equals("true") && this.host != null
                     && !this.host.equals(_host)) {
                 if (this.host.contains(":")) {
                     final String[] hosts = this.host.split(":");


### PR DESCRIPTION
… false

I believe it was initial intention of author of Pull Request #1772
See their description in https://play.lighthouseapp.com/projects/57987-play-framework/tickets/1772: "Our change has no effects to any existing Play applications"

Lighthouse issue: https://play.lighthouseapp.com/projects/57987-play-framework/tickets/2016-default-value-of-xforwardedoverwritedomainandport-setting-should-be-false