### PR TITLE
[#2019] Make method Cache.clear() null-safe

### DIFF
--- a/framework/src/play/cache/Cache.java
+++ b/framework/src/play/cache/Cache.java
@@ -205,7 +205,9 @@ public abstract class Cache {
      * Clear all data from cache.
      */
     public static void clear() {
-        cacheImpl.clear();
+        if (cacheImpl != null) {
+            cacheImpl.clear();
+        }
     }
 
     /**

--- a/framework/test-src/play/cache/CacheTest.java
+++ b/framework/test-src/play/cache/CacheTest.java
@@ -1,0 +1,21 @@
+package play.cache;
+
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class CacheTest {
+    @Test
+    public void clearCallsImplClear() {
+        Cache.cacheImpl = mock(CacheImpl.class);
+        Cache.clear();
+        verify(Cache.cacheImpl).clear();
+    }
+
+    @Test
+    public void clearIsNullSafe_ifImplIsNotInitializedYet() {
+        Cache.cacheImpl = null;
+        Cache.clear();
+    }
+}


### PR DESCRIPTION
it's often called during Play! restart, when cache is not initialized yet

Lighthouse ticket: https://play.lighthouseapp.com/projects/57987-play-framework/tickets/2019-make-method-cacheclear-null-safe