### PR TITLE
* [#2015] fix(i18n): Fix i18n tag only restore to restore all '%' characters

### DIFF
--- a/framework/templates/tags/i18n.tag
+++ b/framework/templates/tags/i18n.tag
@@ -30,7 +30,7 @@ var i18n = function(code) {
         }
     }
     // Decode encoded %% to single %
-    message = message.replace("\0%\0", "%");
+    message = message.replace(/\0%\0/g, "%");
     // Imbricated messages
     var imbricated = message.match(/&\{.*?\}/g);
     if (imbricated) {

--- a/samples-and-tests/just-test-cases/app/controllers/tagDemos/TagDemos.java
+++ b/samples-and-tests/just-test-cases/app/controllers/tagDemos/TagDemos.java
@@ -4,8 +4,12 @@ import play.mvc.Controller;
 
 public class TagDemos extends Controller {
 
-	public static void yesNo() {
-		render();
-	}
+    public static void yesNo() {
+        render();
+    }
+
+    public static void i18n() {
+        render();
+    }
 
 }

--- a/samples-and-tests/just-test-cases/app/views/main.html
+++ b/samples-and-tests/just-test-cases/app/views/main.html
@@ -9,5 +9,6 @@
     </head>
     <body>
         #{doLayout /}
+        #{get 'moreScripts' /}
     </body>
 </html>

--- a/samples-and-tests/just-test-cases/app/views/tagDemos/TagDemos/i18n.html
+++ b/samples-and-tests/just-test-cases/app/views/tagDemos/TagDemos/i18n.html
@@ -1,0 +1,17 @@
+#{extends 'main.html' /}
+#{set 'moreScripts'}
+#{get 'moreScripts'/} 
+ #{script 'jquery.js' /}
+ #{i18n keys:['script.*'] /}
+<script type="text/javascript" charset="utf-8">   
+     var text = i18n('script.tag.demos.i18n.one.percent.sign', 1);  
+     $('li').text(text); 
+     text = i18n('script.tag.demos.i18n.two.percent.sign', 1, 2); 
+     $('li:nth-child(2)').text(text); 
+</script>
+#{/set}
+<h1>i18n demo</h1>
+<ul>
+<li></li>
+<li></li>
+</ul>

--- a/samples-and-tests/just-test-cases/conf/messages
+++ b/samples-and-tests/just-test-cases/conf/messages
@@ -6,3 +6,6 @@ optimisticLocking.modelHasChanged=The object was changed. Your version is %2$s t
 @include.login=./_messages/default/login
 
 @include.other=./_messages/default/other
+
+script.tag.demos.i18n.one.percent.sign=One percent sign: %s %%
+script.tag.demos.i18n.two.percent.sign=Two percent sign: %s %% to %s %%


### PR DESCRIPTION
[lighthouse issue #2015](https://play.lighthouseapp.com/projects/57987/tickets/2015-i18n-tag-only-restore-the-first-character)