### PR TITLE
[#2029] upgrade to groovy-all 2.4.6

### DIFF
--- a/framework/dependencies.yml
+++ b/framework/dependencies.yml
@@ -44,7 +44,7 @@ require:    &allDependencies
     - org.apache.geronimo.specs -> geronimo-servlet_2.5_spec 1.2
     - org.apache.ivy -> ivy 2.4.0
     - org.bouncycastle -> bcprov-jdk15 1.45
-    - org.codehaus.groovy -> groovy-all 2.4.5
+    - org.codehaus.groovy -> groovy-all 2.4.6
     - org.eclipse.jdt.core 3.10.0.v20140604-1726
     - org.hibernate -> hibernate-core 4.2.19.Final
     - org.hibernate -> hibernate-commons-annotations 4.0.2.Final


### PR DESCRIPTION
groovy 2.4.6 has been released today.

It has quite a comprehensive changelog:
http://groovy-lang.org/changelogs/changelog-2.4.6.html

lighthouse ticket: https://play.lighthouseapp.com/projects/57987-play-framework/tickets/2029-upgrade-to-groovy-246