### PR TITLE
[#2035] Fix regression in WS.getString between 1.2.x and 1.4.x

### DIFF
--- a/framework/src/play/libs/WS.java
+++ b/framework/src/play/libs/WS.java
@@ -2,6 +2,7 @@ package play.libs;
 
 import java.io.File;
 import java.io.InputStream;
+import java.io.StringReader;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
@@ -680,7 +681,7 @@ public class WS extends PlayPlugin {
          */
         public Document getXml(String encoding) {
             try {
-                InputSource source = new InputSource(getStream());
+                InputSource source = new InputSource(new StringReader(getString()));
                 source.setEncoding(encoding);
                 DocumentBuilder builder = XML.newDocumentBuilder();
                 return builder.parse(source);
@@ -694,9 +695,7 @@ public class WS extends PlayPlugin {
          * 
          * @return the body of the http response
          */
-        public String getString() {
-            return IO.readContentAsString(getStream(), getEncoding());
-        }
+        public abstract String getString();
 
         /**
          * get the response body as a string
@@ -705,9 +704,7 @@ public class WS extends PlayPlugin {
          *            string charset encoding
          * @return the body of the http response
          */
-        public String getString(String encoding) {
-            return IO.readContentAsString(getStream(), encoding);
-        }
+        public abstract String getString(String encoding);
 
         /**
          * Parse the response string as a query string.
@@ -731,6 +728,10 @@ public class WS extends PlayPlugin {
 
         /**
          * get the response as a stream
+         * <p>
+         +     this method can only be called onced because async implementation does not allow it to be called
+         +     multiple times
+         + </p>
          * 
          * @return an inputstream
          */

--- a/framework/src/play/libs/ws/WSAsync.java
+++ b/framework/src/play/libs/ws/WSAsync.java
@@ -611,6 +611,24 @@ public class WSAsync implements WSImpl {
             return result;
         }
 
+        @Override
+        public String getString() {
+            try {
+                return response.getResponseBody();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public String getString(String encoding) {
+            try {
+                return response.getResponseBody(encoding);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
         /**
          * get the response as a stream
          * @return an inputstream

--- a/framework/src/play/libs/ws/WSUrlFetch.java
+++ b/framework/src/play/libs/ws/WSUrlFetch.java
@@ -338,6 +338,15 @@ public class WSUrlFetch implements WSImpl {
             return body;
         }
 
+        @Override
+        public String getString(String encoding) {
+            try {
+                return new String(body.getBytes(), encoding);
+            } catch (UnsupportedEncodingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
         /**
          * get the response as a stream
          * 

--- a/framework/test-src/play/libs/TestHttpResponse.java
+++ b/framework/test-src/play/libs/TestHttpResponse.java
@@ -42,6 +42,16 @@ public class TestHttpResponse extends HttpResponse {
     }
 
     @Override
+    public String getString() {
+        return this.queryContent;
+    }
+
+    @Override
+    public String getString(String encoding) {
+        return this.queryContent;
+    }
+
+    @Override
     public InputStream getStream() {
         try {
             return new ByteArrayInputStream(this.queryContent.getBytes("UTF-8"));

--- a/samples-and-tests/just-test-cases/test/WSTest.java
+++ b/samples-and-tests/just-test-cases/test/WSTest.java
@@ -19,12 +19,22 @@ import java.lang.reflect.Field;
 public class WSTest extends UnitTest {
 
     @Test
-    public void multiplePosttContentTest() {
+    public void multipleGetStreamOk() {
         String url = "http://google.com";
         HttpResponse response = WS.url(url).post();
         String resp1 = response.getString();
-        // Stream is consumed, no more content
+        // getString is repeatable
         String resp2 = response.getString();
+        assertEquals(resp1, resp2);
+    }
+
+    @Test
+    public void multipleGetStreamKo() {
+        String url = "http://google.com";
+        HttpResponse response = WS.url(url).post();
+        String resp1 = IO.readContentAsString(response.getStream(), response.getEncoding());
+        // Stream is consumed, no more content
+        String resp2 = IO.readContentAsString(response.getStream(), response.getEncoding());
         assertNotEquals(resp1, resp2);
         assertEquals("", resp2);
     }


### PR DESCRIPTION
In http-client-async getResponseBodyAsStream cannot be called multiple times. This leads to WS.getStream to also must be called once.

Here is a proposal to not use getStream in getString method so getString can be called multiple times. This was the default behaviour in play 1.2.x. The modification leads to several regressions because ofter getString is used in logs before really using the response.

With this version getString use underlying getResponseBody that can be use multiple times.