### PR TITLE
[#2041] enable manuallyconfigured Logger with windows

### DIFF
--- a/framework/build.xml
+++ b/framework/build.xml
@@ -247,6 +247,12 @@
     <!-- Launch all *Test.java -->
 
     <target name="test" depends="clean,jar,build-test-modules" description="run tests suite">
+        <condition property="pythonExecutable" value="${basedir}/../python/python.exe">
+            <and><os family="windows"/></and>
+        </condition>
+        <condition property="pythonExecutable" value="python">
+            <and><os family="unix"/></and>
+        </condition>
         <condition property="playExtension" value=".bat">
             <and><os family="windows"/></and>
         </condition>
@@ -260,11 +266,11 @@
         
         <echo message="Testing development lifecycle (wait ...)" />
 
-        <exec executable="python" failonerror="true">
+        <exec executable="${pythonExecutable}" failonerror="true">
             <arg value="${basedir}/../samples-and-tests/i-am-a-developer/tests.py" />
         </exec>
 
-        <exec executable="python" failonerror="true">
+        <exec executable="${pythonExecutable}" failonerror="true">
             <arg value="${basedir}/../samples-and-tests/i-am-a-developer/test_jvm_version_flag.py" />
         </exec>
 

--- a/framework/src/play/Logger.java
+++ b/framework/src/play/Logger.java
@@ -3,6 +3,8 @@ package play;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.List;
@@ -70,11 +72,16 @@ public class Logger {
             PropertyConfigurator.configure(shutUp);
         } else if (Logger.log4j == null) {
 
-            if (log4jConf.getFile().indexOf(Play.applicationPath.getAbsolutePath()) == 0) {
-                // The log4j configuration file is located somewhere in the application folder,
-                // so it's probably a custom configuration file
-                configuredManually = true;
+            Path path1 = null;
+            try {
+              path1 = Paths.get(log4jConf.toURI());
+            } catch (Throwable t) {
             }
+            Path path2 = Play.applicationPath.toPath();
+            // The log4j configuration file is located somewhere in the application folder,
+            // so it's probably a custom configuration file
+            configuredManually = path1 != null ? path1.startsWith(path2) : false;
+
             if (isXMLConfig) {
                 DOMConfigurator.configure(log4jConf);
             } else {


### PR DESCRIPTION
This fix should enable you to build the Play! framework entirely with all tests on windows.
Perhaps you can use this as starter (ant, jdk ... required)

`SET "JAVA_HOME=c:\Program Files\Java\jdk1.8.0_72"`
`SET "ANT_HOME=c:\apache\ant\1.9.6"`
`SET "PLAY_HOME=c:\Users\user\git\play"`
`SET "PATH=%PATH%;c:\Users\user\git\play\python;%JAVA_HOME%\bin;%ANT_HOME%\bin;%PLAY_HOME%"`
`SET "JAVA_OPTS=-Duser.language=en -Duser.region=US"`
`CD %PLAY_HOME%`
`ant -f framework\build.xml -Dversion=1.4.2 test`
`pause`
