### PR TITLE
fix KeyError: 'disable_random_jpda' in application.check_jpda

### DIFF
--- a/framework/pym/play/application.py
+++ b/framework/pym/play/application.py
@@ -224,7 +224,7 @@ class PlayApplication(object):
             s.bind(('', int(self.jpda_port)))
             s.close()
         except socket.error, e:
-            if self.play_env["disable_random_jpda"]:
+            if "disable_random_jpda" in self.play_env and self.play_env["disable_random_jpda"]:
                 print 'JPDA port %s is already used, and command line option "-f" was specified. Cannot start server\n' % self.jpda_port
                 sys.exit(-1)
             else:


### PR DESCRIPTION
Otherwise some tests fail sometimes, when variable `disable_random_jpda` is not defined in `self.play_env`. See stacktrace of failing test:

```python
 [exec] ======================================================================
     [exec] ERROR: testWithoutFlag (__main__.JvmVersionFlag)
     [exec] ----------------------------------------------------------------------
     [exec] Traceback (most recent call last):
     [exec]   File "/home/jenkins/workspace/play/samples-and-tests/i-am-a-developer/mock.py", line 1201, in patched
     [exec]     return func(*args, **keywargs)
     [exec]   File "/home/jenkins/workspace/play/framework/../samples-and-tests/i-am-a-developer/test_jvm_version_flag.py", line 43, in testWithoutFlag
     [exec]     play_app.java_cmd([])
     [exec]   File "/home/jenkins/workspace/play/framework/../samples-and-tests/i-am-a-developer/../../framework/pym/play/application.py", line 306, in java_cmd
     [exec]     self.check_jpda()
     [exec]   File "/home/jenkins/workspace/play/framework/../samples-and-tests/i-am-a-developer/../../framework/pym/play/application.py", line 227, in check_jpda
     [exec]     if self.play_env["disable_random_jpda"]:
     [exec] KeyError: 'disable_random_jpda'
```