### PR TITLE
Do not clear cache on reload

### DIFF
--- a/framework/src/play/cache/MemcachedImpl.java
+++ b/framework/src/play/cache/MemcachedImpl.java
@@ -1,18 +1,5 @@
 package play.cache;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
-import java.io.ObjectStreamClass;
-import java.net.InetSocketAddress;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-
 import net.spy.memcached.AddrUtil;
 import net.spy.memcached.ConnectionFactory;
 import net.spy.memcached.ConnectionFactoryBuilder;
@@ -23,6 +10,14 @@ import net.spy.memcached.transcoders.SerializingTranscoder;
 import play.Logger;
 import play.Play;
 import play.exceptions.ConfigurationException;
+
+import java.io.*;
+import java.net.InetSocketAddress;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Memcached implementation (using http://code.google.com/p/spymemcached/)
@@ -69,7 +64,9 @@ public class MemcachedImpl implements CacheImpl {
                         }
                     }.readObject();
                 } catch (Exception e) {
-                    Logger.error(e, "Could not deserialize");
+                    if (!Cache.isPlayRecentlyStarted()) {
+                        Logger.error(e, "Could not deserialize");
+                    }
                 }
                 return null;
             }

--- a/framework/src/play/classloading/ApplicationClassloader.java
+++ b/framework/src/play/classloading/ApplicationClassloader.java
@@ -2,10 +2,8 @@ package play.classloading;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
-
 import play.Logger;
 import play.Play;
-import play.cache.Cache;
 import play.classloading.ApplicationClasses.ApplicationClass;
 import play.classloading.hash.ClassStateHashCreator;
 import play.exceptions.RestartNeededException;
@@ -330,7 +328,6 @@ public class ApplicationClassloader extends ClassLoader {
         }
         
         if (!newDefinitions.isEmpty()) {
-            Cache.clear();
             if (HotswapAgent.enabled) {
                 try {
                     HotswapAgent.reload(newDefinitions.toArray(new ClassDefinition[newDefinitions.size()]));

--- a/framework/test-src/play/cache/CacheTest.java
+++ b/framework/test-src/play/cache/CacheTest.java
@@ -1,11 +1,23 @@
 package play.cache;
 
+import org.junit.Before;
 import org.junit.Test;
+import play.Play;
 
+import java.util.Properties;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 public class CacheTest {
+    @Before
+    public void setUp() {
+        Play.configuration = new Properties();
+        Play.configuration.setProperty("play.cache.warmupPeriodMs", "1000");
+    }
+
     @Test
     public void clearCallsImplClear() {
         Cache.cacheImpl = mock(CacheImpl.class);
@@ -17,5 +29,17 @@ public class CacheTest {
     public void clearIsNullSafe_ifImplIsNotInitializedYet() {
         Cache.cacheImpl = null;
         Cache.clear();
+    }
+
+    @Test
+    public void detectsIfPlayHasRecentlyRestarted() {
+        Play.startedAt = System.currentTimeMillis() - 100;
+        assertTrue(Cache.isPlayRecentlyStarted());
+    }
+
+    @Test
+    public void playIsRestartedMoreThanNMillisecondsAgo() {
+        Play.startedAt = System.currentTimeMillis() - 1001;
+        assertFalse(Cache.isPlayRecentlyStarted());
     }
 }


### PR DESCRIPTION
This pull request fixes the issue #985 

Proposal is simple: Play does not clear cache on reload, but ignores all deserialization errors during 1 minute after restart. This period is configurable via `play.cache.warmupPeriodMs` property (default value is 60000).