### PR TITLE
Form tag url support

### DIFF
--- a/framework/src/play/cache/MemcachedImpl.java
+++ b/framework/src/play/cache/MemcachedImpl.java
@@ -1,18 +1,5 @@
 package play.cache;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
-import java.io.ObjectStreamClass;
-import java.net.InetSocketAddress;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-
 import net.spy.memcached.AddrUtil;
 import net.spy.memcached.ConnectionFactory;
 import net.spy.memcached.ConnectionFactoryBuilder;
@@ -23,6 +10,14 @@ import net.spy.memcached.transcoders.SerializingTranscoder;
 import play.Logger;
 import play.Play;
 import play.exceptions.ConfigurationException;
+
+import java.io.*;
+import java.net.InetSocketAddress;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Memcached implementation (using http://code.google.com/p/spymemcached/)
@@ -69,7 +64,9 @@ public class MemcachedImpl implements CacheImpl {
                         }
                     }.readObject();
                 } catch (Exception e) {
-                    Logger.error(e, "Could not deserialize");
+                    if (!Cache.isPlayRecentlyStarted()) {
+                        Logger.error(e, "Could not deserialize");
+                    }
                 }
                 return null;
             }

--- a/framework/src/play/classloading/ApplicationClassloader.java
+++ b/framework/src/play/classloading/ApplicationClassloader.java
@@ -2,10 +2,8 @@ package play.classloading;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
-
 import play.Logger;
 import play.Play;
-import play.cache.Cache;
 import play.classloading.ApplicationClasses.ApplicationClass;
 import play.classloading.hash.ClassStateHashCreator;
 import play.exceptions.RestartNeededException;
@@ -330,7 +328,6 @@ public class ApplicationClassloader extends ClassLoader {
         }
         
         if (!newDefinitions.isEmpty()) {
-            Cache.clear();
             if (HotswapAgent.enabled) {
                 try {
                     HotswapAgent.reload(newDefinitions.toArray(new ClassDefinition[newDefinitions.size()]));

--- a/framework/src/play/templates/FastTags.java
+++ b/framework/src/play/templates/FastTags.java
@@ -127,7 +127,16 @@ public class FastTags {
      *            template line number where the tag is defined
      */
     public static void _form(Map<?, ?> args, Closure body, PrintWriter out, ExecutableTemplate template, int fromLine) {
-        ActionDefinition actionDef = (ActionDefinition) args.get("arg");
+        ActionDefinition actionDef = null;
+        Object arg = args.get("arg");
+        if (arg instanceof ActionDefinition) {
+            actionDef = (ActionDefinition) arg;
+        }
+        else if (arg != null) {
+            actionDef = new ActionDefinition();
+            actionDef.url = arg.toString();
+            actionDef.method = "POST";
+        }
         if (actionDef == null) {
             actionDef = (ActionDefinition) args.get("action");
         }
@@ -151,7 +160,7 @@ public class FastTags {
             actionDef.method = "POST";
         }
         String encoding = Http.Response.current().encoding;
-        out.print("<form action=\"" + actionDef.url + "\" method=\"" + actionDef.method.toLowerCase() + "\" accept-charset=\"" + encoding
+        out.println("<form action=\"" + actionDef.url + "\" method=\"" + actionDef.method.toLowerCase() + "\" accept-charset=\"" + encoding
                 + "\" enctype=\"" + enctype + "\" " + serialize(args, "name", "action", "method", "accept-charset", "enctype")
                 + (name != null ? "name=\"" + name + "\"" : "") + ">");
         if (!("GET".equals(actionDef.method))) {

--- a/framework/test-src/play/cache/CacheTest.java
+++ b/framework/test-src/play/cache/CacheTest.java
@@ -1,11 +1,23 @@
 package play.cache;
 
+import org.junit.Before;
 import org.junit.Test;
+import play.Play;
 
+import java.util.Properties;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 public class CacheTest {
+    @Before
+    public void setUp() {
+        Play.configuration = new Properties();
+        Play.configuration.setProperty("play.cache.warmupPeriodMs", "1000");
+    }
+
     @Test
     public void clearCallsImplClear() {
         Cache.cacheImpl = mock(CacheImpl.class);
@@ -17,5 +29,17 @@ public class CacheTest {
     public void clearIsNullSafe_ifImplIsNotInitializedYet() {
         Cache.cacheImpl = null;
         Cache.clear();
+    }
+
+    @Test
+    public void detectsIfPlayHasRecentlyRestarted() {
+        Play.startedAt = System.currentTimeMillis() - 100;
+        assertTrue(Cache.isPlayRecentlyStarted());
+    }
+
+    @Test
+    public void playIsRestartedMoreThanNMillisecondsAgo() {
+        Play.startedAt = System.currentTimeMillis() - 1001;
+        assertFalse(Cache.isPlayRecentlyStarted());
     }
 }

--- a/framework/test-src/play/templates/FastTagsTest.java
+++ b/framework/test-src/play/templates/FastTagsTest.java
@@ -1,0 +1,196 @@
+package play.templates;
+
+import groovy.lang.Closure;
+import org.junit.Before;
+import org.junit.Test;
+import play.mvc.Http;
+import play.mvc.Router;
+import play.mvc.Scope;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+public class FastTagsTest {
+
+    private StringWriter out = new StringWriter();
+
+    @Before
+    public void setUp() throws Exception {
+        Http.Response.current.set(new Http.Response());
+        Http.Response.current().encoding = "UTF-8";
+
+        Scope.Session.current.set(new Scope.Session());
+        Scope.Session.current().put("___AT", "1234");
+    }
+
+    @Test
+    public void _form_simple() throws Exception {
+        Router.ActionDefinition actionDefinition = new Router.ActionDefinition();
+        actionDefinition.url = "/foo/bar";
+        actionDefinition.method = "GET";
+
+        Map<String, ?> args = new HashMap<String, Object>() {{
+            put("arg", actionDefinition);
+        }};
+
+        FastTags._form(args, mock(Closure.class), new PrintWriter(out), null, 0);
+
+        assertEquals(
+                "<form action=\"/foo/bar\" method=\"get\" accept-charset=\"UTF-8\" enctype=\"application/x-www-form-urlencoded\" >\n" +
+                "\n" +
+                "</form>", out.toString());
+    }
+
+    @Test
+    public void _form_withName() throws Exception {
+        Router.ActionDefinition actionDefinition = new Router.ActionDefinition();
+        actionDefinition.url = "/foo/bar";
+        actionDefinition.method = "GET";
+
+        Map<String, ?> args = new HashMap<String, Object>() {{
+            put("arg", actionDefinition);
+            put("name", "my-form");
+        }};
+
+        FastTags._form(args, mock(Closure.class), new PrintWriter(out), null, 0);
+
+        assertEquals(
+                "<form action=\"/foo/bar\" method=\"get\" accept-charset=\"UTF-8\" enctype=\"application/x-www-form-urlencoded\" name=\"my-form\">\n" +
+                "\n" +
+                "</form>", out.toString());
+    }
+
+    @Test
+    public void _form_post() throws Exception {
+        Router.ActionDefinition actionDefinition = new Router.ActionDefinition();
+        actionDefinition.url = "/foo/bar";
+        actionDefinition.method = "POST";
+
+        Map<String, ?> args = new HashMap<String, Object>() {{
+            put("arg", actionDefinition);
+        }};
+
+        FastTags._form(args, mock(Closure.class), new PrintWriter(out), null, 0);
+
+        assertEquals(
+                "<form action=\"/foo/bar\" method=\"post\" accept-charset=\"UTF-8\" enctype=\"application/x-www-form-urlencoded\" >\n" +
+                "<input type=\"hidden\" name=\"authenticityToken\" value=\"1234\"/>\n" +
+                "\n" +
+                "</form>", out.toString());
+    }
+
+    @Test
+    public void _form_starIsPost() throws Exception {
+        Router.ActionDefinition actionDefinition = new Router.ActionDefinition();
+        actionDefinition.url = "/foo/bar";
+        actionDefinition.star = true;
+
+        Map<String, ?> args = new HashMap<String, Object>() {{
+            put("arg", actionDefinition);
+        }};
+
+        FastTags._form(args, mock(Closure.class), new PrintWriter(out), null, 0);
+
+        assertEquals(
+                "<form action=\"/foo/bar\" method=\"post\" accept-charset=\"UTF-8\" enctype=\"application/x-www-form-urlencoded\" >\n" +
+                "<input type=\"hidden\" name=\"authenticityToken\" value=\"1234\"/>\n" +
+                "\n" +
+                "</form>", out.toString());
+    }
+
+    @Test
+    public void _form_argMethodOverridesActionDefinitionMethod() throws Exception {
+        Router.ActionDefinition actionDefinition = new Router.ActionDefinition();
+        actionDefinition.url = "/foo/bar";
+        actionDefinition.method = "GET";
+
+        Map<String, ?> args = new HashMap<String, Object>() {{
+            put("arg", actionDefinition);
+            put("method", "POST");
+        }};
+
+        FastTags._form(args, mock(Closure.class), new PrintWriter(out), null, 0);
+
+        assertEquals(
+                "<form action=\"/foo/bar\" method=\"post\" accept-charset=\"UTF-8\" enctype=\"application/x-www-form-urlencoded\" >\n" +
+                "<input type=\"hidden\" name=\"authenticityToken\" value=\"1234\"/>\n" +
+                "\n" +
+                "</form>", out.toString());
+    }
+
+    @Test
+    public void _form_customArgs() throws Exception {
+        Router.ActionDefinition actionDefinition = new Router.ActionDefinition();
+        actionDefinition.url = "/foo/bar";
+        actionDefinition.method = "GET";
+
+        Map<String, ?> args = new HashMap<String, Object>() {{
+            put("arg", actionDefinition);
+            put("data-customer", "12");
+        }};
+
+        FastTags._form(args, mock(Closure.class), new PrintWriter(out), null, 0);
+
+        assertEquals(
+                "<form action=\"/foo/bar\" method=\"get\" accept-charset=\"UTF-8\" enctype=\"application/x-www-form-urlencoded\" data-customer=\"12\" >\n" +
+                "\n" +
+                "</form>", out.toString());
+    }
+
+    @Test
+    public void _form_actionAsActionArg() throws Exception {
+        Router.ActionDefinition actionDefinition = new Router.ActionDefinition();
+        actionDefinition.url = "/foo/bar";
+        actionDefinition.method = "GET";
+
+        Map<String, ?> args = new HashMap<String, Object>() {{
+            put("action", actionDefinition);
+        }};
+
+        FastTags._form(args, mock(Closure.class), new PrintWriter(out), null, 0);
+
+        assertEquals(
+                "<form action=\"/foo/bar\" method=\"get\" accept-charset=\"UTF-8\" enctype=\"application/x-www-form-urlencoded\" >\n" +
+                "\n" +
+                "</form>", out.toString());
+    }
+
+    @Test
+    public void _form_customEnctype() throws Exception {
+        Router.ActionDefinition actionDefinition = new Router.ActionDefinition();
+        actionDefinition.url = "/foo/bar";
+        actionDefinition.method = "GET";
+
+        Map<String, ?> args = new HashMap<String, Object>() {{
+            put("arg", actionDefinition);
+            put("enctype", "xyz");
+        }};
+
+        FastTags._form(args, mock(Closure.class), new PrintWriter(out), null, 0);
+
+        assertEquals(
+                "<form action=\"/foo/bar\" method=\"get\" accept-charset=\"UTF-8\" enctype=\"xyz\" >\n" +
+                "\n" +
+                "</form>", out.toString());
+    }
+
+    @Test
+    public void _form_argAsUrlInsteadOfActionDefinition() throws Exception {
+        Map<String, ?> args = new HashMap<String, Object>() {{
+            put("arg", "/foo/bar");
+        }};
+
+        FastTags._form(args, mock(Closure.class), new PrintWriter(out), null, 0);
+
+        assertEquals(
+                "<form action=\"/foo/bar\" method=\"post\" accept-charset=\"UTF-8\" enctype=\"application/x-www-form-urlencoded\" >\n" +
+                        "<input type=\"hidden\" name=\"authenticityToken\" value=\"1234\"/>\n" +
+                        "\n" +
+                        "</form>", out.toString());
+    }
+}


### PR DESCRIPTION
This commit enhances the `#{form}` tag. It allows to specify the form action as a URL instead of a `ActionDefinition`. E.g. instead of `#{form @User.settings() ...` you could write `#{form '/user/settings' ...`. 

This is useful if you want to keep your URLs stable with a good `routes` file without wildcards and possibility to move your controllers/actions around without hunting through templates to find usages.

As a side effect - before adding the new feature, I added some tests for existing `#{form}` tag functionality. It had none up to this point.