### PR TITLE
[#1919] fixes Building modules with a space in path under windows fails

### DIFF
--- a/framework/pym/play/commands/modulesrepo.py
+++ b/framework/pym/play/commands/modulesrepo.py
@@ -326,7 +326,7 @@ def build(app, args, env):
         print "~"
         print "~ Building..."
         print "~"
-        status = subprocess.call('ant -f %s -Dplay.path=%s' % (build_file, ftb), shell=True)
+        status = subprocess.call('ant -f "%s" -Dplay.path="%s"' % (build_file, ftb), shell=True)
         print "~"
         if status:
             sys.exit(status)


### PR DESCRIPTION
https://play.lighthouseapp.com/projects/57987-play-framework/tickets/1919-building-modules-with-a-space-in-path-under-windows-fails