### PR TITLE
[#2066] avoid NPE in regex matcher

### DIFF
--- a/framework/src/play/vfs/VirtualFile.java
+++ b/framework/src/play/vfs/VirtualFile.java
@@ -230,6 +230,9 @@ public class VirtualFile {
     }
 
     public static VirtualFile fromRelativePath(String relativePath) {
+        if (relativePath == null) { // avoid NPE in pattern.matcher(relativePath)
+            return null;
+        }
         Pattern pattern = Pattern.compile("^(\\{(.+?)\\})?(.*)$");
         Matcher matcher = pattern.matcher(relativePath);
 


### PR DESCRIPTION
I think it is enough to check only once for `null` before calling the regex matcher.

This fix is needed if you really use "open file from errors pages" (a Play! developer feature):
```
# Open file from errors pages
# ~~~~~
# If your text editor supports opening files by URL, Play! will
# dynamically link error pages to files 
#
# Example, for textmate:
# play.editor=txmt://open?url=file://%s&line=%s
```

Here is a nice summary how to use it with several os: [How open files in ide from debugger](https://pla.nette.org/en/how-open-files-in-ide-from-debugger)
