### PR TITLE
Detect changed for JNDI datasource which using jndi: prefix

### DIFF
--- a/framework/src/play/db/DBPlugin.java
+++ b/framework/src/play/db/DBPlugin.java
@@ -286,7 +286,7 @@ public class DBPlugin extends PlayPlugin {
             String datasourceName = dbConfig.getProperty("db", "");
             DataSource ds = DB.getDataSource(dbName);
                      
-            if ((datasourceName.startsWith("java:")) && dbConfig.getProperty("db.url") == null) {
+            if ((datasourceName.startsWith("java:") || datasourceName.startsWith("jndi:")) && dbConfig.getProperty("db.url") == null) {
                 if (ds == null) {
                     return true;
                 }


### PR DESCRIPTION
The jndi: prefix was added at https://github.com/playframework/play1/pull/441.
But the `changed()` might not be detected when calling `onApplicationStart` in DBPlugin.java (it will return `false` if db.url and db.driver is not configured). And the datasource with `jndi:` prefix will not be initialized and not been added to DB.datasources.