### PR TITLE
add possibility to disable generating getters/setters

### DIFF
--- a/framework/src/play/classloading/enhancers/PropertiesEnhancer.java
+++ b/framework/src/play/classloading/enhancers/PropertiesEnhancer.java
@@ -55,40 +55,36 @@ public class PropertiesEnhancer extends Enhancer {
 
     private void addDefaultConstructor(CtClass ctClass) {
         try {
-            boolean hasDefaultConstructor = false;
-            for (CtConstructor constructor : ctClass.getDeclaredConstructors()) {
-                if (constructor.getParameterTypes().length == 0) {
-                    hasDefaultConstructor = true;
-                    break;
-                }
-            }
+            boolean hasDefaultConstructor = hasDefaultConstructor(ctClass);
             if (!hasDefaultConstructor && !ctClass.isInterface()) {
                 CtConstructor defaultConstructor = CtNewConstructor.make("public " + ctClass.getSimpleName() + "() {}", ctClass);
                 ctClass.addConstructor(defaultConstructor);
             }
         } catch (Exception e) {
-            Logger.error(e, "Error in PropertiesEnhancer");
-            throw new UnexpectedException("Error in PropertiesEnhancer", e);
+            Logger.error(e, "Failed to generate default constructor for " + ctClass.getName());
+            throw new UnexpectedException("Failed to generate default constructor for " + ctClass.getName(), e);
         }
     }
 
     private void addDefaultConstructor2(CtClass ctClass) {
         try {
-            boolean hasDefaultConstructor = false;
-            for (CtConstructor constructor : ctClass.getDeclaredConstructors()) {
-                if (constructor.getParameterTypes().length == 0) {
-                    hasDefaultConstructor = true;
-                    break;
-                }
-            }
-            if (!hasDefaultConstructor) {
+            if (!hasDefaultConstructor(ctClass)) {
                 CtConstructor defaultConstructor = CtNewConstructor.defaultConstructor(ctClass);
                 ctClass.addConstructor(defaultConstructor);
             }
         } catch (Exception e) {
-            Logger.error(e, "Error in PropertiesEnhancer");
-            throw new UnexpectedException("Error in PropertiesEnhancer", e);
+            Logger.error(e, "Failed to generate default constructor for " + ctClass.getName());
+            throw new UnexpectedException("Failed to generate default constructor for " + ctClass.getName(), e);
         }
+    }
+
+    private boolean hasDefaultConstructor(CtClass ctClass) throws NotFoundException {
+        for (CtConstructor constructor : ctClass.getDeclaredConstructors()) {
+            if (constructor.getParameterTypes().length == 0) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private void generateAccessors(CtClass ctClass) {
@@ -133,8 +129,9 @@ public class PropertiesEnhancer extends Enhancer {
                 }
 
             } catch (Exception e) {
-                Logger.error(e, "Error in PropertiesEnhancer");
-                throw new UnexpectedException("Error in PropertiesEnhancer", e);
+                String message = "Failed to generate default accessor for " + ctClass.getName() + "." + ctField.getName();
+                Logger.error(e, message);
+                throw new UnexpectedException(message, e);
             }
         }
     }
@@ -184,7 +181,8 @@ public class PropertiesEnhancer extends Enhancer {
                         }
 
                     } catch (Exception e) {
-                        throw new UnexpectedException("Error in PropertiesEnhancer", e);
+                        String message = "Failed to modify access to " + ctClass.getName() + "." + ctMethod.getName();
+                        throw new UnexpectedException(message, e);
                     }
                 }
             });

--- a/framework/src/play/classloading/enhancers/PropertiesEnhancer.java
+++ b/framework/src/play/classloading/enhancers/PropertiesEnhancer.java
@@ -27,10 +27,13 @@ import play.exceptions.UnexpectedException;
  */
 public class PropertiesEnhancer extends Enhancer {
 
+    private boolean enabled = Boolean.parseBoolean(Play.configuration.getProperty("play.propertiesEnhancer.enabled", "true"));
+    private boolean generateAccessors = Boolean.parseBoolean(Play.configuration.getProperty("play.propertiesEnhancer.generateAccessors", "true"));
+
     @Override
     public void enhanceThisClass(ApplicationClass applicationClass) throws Exception {
 
-        if(!Boolean.parseBoolean(Play.configuration.getProperty("play.propertiesEnhancer.enabled", "true"))) return;
+        if (!enabled) return;
 
         final CtClass ctClass = makeClass(applicationClass);
         if (ctClass.isInterface()) {
@@ -56,6 +59,12 @@ public class PropertiesEnhancer extends Enhancer {
         } catch (Exception e) {
             Logger.error(e, "Error in PropertiesEnhancer");
             throw new UnexpectedException("Error in PropertiesEnhancer", e);
+        }
+
+        if (!generateAccessors) {
+            applicationClass.enhancedByteCode = ctClass.toBytecode();
+            ctClass.defrost();
+            return;
         }
 
         if (isScala(applicationClass)) {


### PR DESCRIPTION
add possibility to disable generating getters/setters 
(via setting `play.propertiesEnhancer.generateAccessors=false`)

it's useful because generation of getters/setters and replacing all field accesses with getters/setters is the slowest part of compilation process. Many applications do not really need it.
