### PR TITLE
ticket #2072: create c3p0 data source with "library" classloader, not…

### DIFF
--- a/framework/src/play/db/DBPlugin.java
+++ b/framework/src/play/db/DBPlugin.java
@@ -161,6 +161,8 @@ public class DBPlugin extends PlayPlugin {
                         ds.setNumHelperThreads(Integer.parseInt(dbConfig.getProperty("db.pool.numHelperThreads", "3")));
                         ds.setUnreturnedConnectionTimeout(Integer.parseInt(dbConfig.getProperty("db.pool.unreturnedConnectionTimeout", "0")));
                         ds.setDebugUnreturnedConnectionStackTraces(Boolean.parseBoolean(dbConfig.getProperty("db.pool.debugUnreturnedConnectionStackTraces", "false")));
+                        ds.setContextClassLoaderSource("library");
+                        ds.setPrivilegeSpawnedThreads(true);
 
                         if (dbConfig.getProperty("db.testquery") != null) {
                             ds.setPreferredTestQuery(dbConfig.getProperty("db.testquery"));


### PR DESCRIPTION
… the current `ApplicationClassloader`

... to avoid holding the first `ApplicationClassloader` in memory forever

Lighthouse ticket: https://play.lighthouseapp.com/projects/57987-play-framework/tickets/2072-play-has-memory-leaks