### PR TITLE
ticket #2072: set system classloader to shutdown hook

### DIFF
--- a/framework/src/play/Play.java
+++ b/framework/src/play/Play.java
@@ -466,12 +466,14 @@ public class Play {
                     //registers shutdown hook - Now there's a good chance that we can notify
                     //our plugins that we're going down when some calls ctrl+c or just kills our process..
                     shutdownHookEnabled = true;
-                    Runtime.getRuntime().addShutdownHook(new Thread() {
+                    Thread hook = new Thread() {
                         @Override
                         public void run() {
                             Play.stop();
                         }
-                    });
+                    };
+                    hook.setContextClassLoader(ClassLoader.getSystemClassLoader());
+                    Runtime.getRuntime().addShutdownHook(hook);
                 }
             }
 


### PR DESCRIPTION
otherwise the shutdown hook will keep the current `ApplicationClassloader` forever

Lighthouse ticket: https://play.lighthouseapp.com/projects/57987-play-framework/tickets/2072-play-has-memory-leaks