### PR TITLE
ticket #2072: reset context classloader from all invoker threads befo…

### DIFF
--- a/framework/src/play/Invoker.java
+++ b/framework/src/play/Invoker.java
@@ -14,6 +14,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import play.Play.Mode;
+import play.classloading.ApplicationClassloader;
 import play.classloading.enhancers.LocalvariablesNamesEnhancer.LocalVariablesNamesTracer;
 import play.exceptions.PlayException;
 import play.exceptions.UnexpectedException;
@@ -81,6 +82,15 @@ public class Invoker {
                 }
                 retry = true;
             }
+        }
+    }
+
+    static void resetClassloaders() {
+        Thread[] executorThreads = new Thread[executor.getPoolSize()];
+        Thread.enumerate(executorThreads);
+        for (Thread thread : executorThreads) {
+            if (thread != null && thread.getContextClassLoader() instanceof ApplicationClassloader)
+                thread.setContextClassLoader(ClassLoader.getSystemClassLoader());
         }
     }
 

--- a/framework/src/play/Play.java
+++ b/framework/src/play/Play.java
@@ -582,6 +582,7 @@ public class Play {
             started = false;
             Cache.stop();
             Router.lastLoading = 0L;
+            Invoker.resetClassloaders();
         }
     }
 


### PR DESCRIPTION
…re reloading play

otherwise onvoker threads will will keep reference the first ApplicationClassloader forever

Lighthouse ticket: https://play.lighthouseapp.com/projects/57987-play-framework/tickets/2072-play-has-memory-leaks