### PR TITLE
Add getters to Result classes

### DIFF
--- a/framework/src/play/mvc/results/Error.java
+++ b/framework/src/play/mvc/results/Error.java
@@ -17,7 +17,7 @@ import play.templates.TemplateLoader;
  */
 public class Error extends Result {
 
-    protected int status;
+    private final int status;
 
     public Error(String reason) {
         super(reason);
@@ -56,5 +56,9 @@ public class Error extends Result {
         } catch (Exception e) {
             throw new UnexpectedException(e);
         }
+    }
+
+    public int getStatus() {
+        return status;
     }
 }

--- a/framework/src/play/mvc/results/NotModified.java
+++ b/framework/src/play/mvc/results/NotModified.java
@@ -9,7 +9,7 @@ import play.mvc.Http.Response;
  */
 public class NotModified extends Result {
 
-    String etag;
+    private String etag;
 
     public NotModified() {
         super("NotModified");
@@ -25,5 +25,9 @@ public class NotModified extends Result {
         if (etag != null) {
             response.setHeader("Etag", etag);
         }
+    }
+
+    public String getEtag() {
+        return etag;
     }
 }

--- a/framework/src/play/mvc/results/Redirect.java
+++ b/framework/src/play/mvc/results/Redirect.java
@@ -19,29 +19,29 @@ public class Redirect extends Result {
     public Redirect(String url) {
         this.url = url;
     }
-    
-	/**
-	 * Redirects to a given URL with the parameters specified in a {@link Map}
-	 * 
-	 * @param url
-	 *            The URL to redirect to as a {@link String}
-	 * @param parameters
-	 *            Parameters to be included at the end of the URL as a HTTP GET. This is a map whose entries are written out as key1=value1&amp;key2=value2 etc..
-	 */
-	public Redirect(String url, Map<String, String> parameters) {
-    StringBuilder urlSb = new StringBuilder(url);
 
-		if (parameters != null && !parameters.isEmpty()) {
-      char prepend = '?';
+    /**
+     * Redirects to a given URL with the parameters specified in a {@link Map}
+     *
+     * @param url
+     *            The URL to redirect to as a {@link String}
+     * @param parameters
+     *            Parameters to be included at the end of the URL as a HTTP GET. This is a map whose entries are written out as key1=value1&amp;key2=value2 etc..
+     */
+    public Redirect(String url, Map<String, String> parameters) {
+        StringBuilder urlSb = new StringBuilder(url);
 
-			for (Entry<String, String> parameter : parameters.entrySet()) {
-				urlSb.append(prepend).append(parameter.getKey()).append('=').append(parameter.getValue());
-				prepend = '&';
-			}
-		}
+        if (parameters != null && !parameters.isEmpty()) {
+            char prepend = '?';
 
-		this.url = urlSb.toString();
-	}
+            for (Entry<String, String> parameter : parameters.entrySet()) {
+                urlSb.append(prepend).append(parameter.getKey()).append('=').append(parameter.getValue());
+                prepend = '&';
+            }
+        }
+
+        this.url = urlSb.toString();
+    }
 
     public Redirect(String url,boolean permanent) {
         this.url = url;

--- a/framework/src/play/mvc/results/RedirectToStatic.java
+++ b/framework/src/play/mvc/results/RedirectToStatic.java
@@ -10,7 +10,7 @@ import play.mvc.Http.Response;
  */
 public class RedirectToStatic extends Result {
 
-    String file;
+    private final String file;
     
     public RedirectToStatic(String file) {
         this.file = file;
@@ -24,5 +24,9 @@ public class RedirectToStatic extends Result {
         } catch (Exception e) {
             throw new UnexpectedException(e);
         }
+    }
+
+    public String getFile() {
+        return file;
     }
 }

--- a/framework/src/play/mvc/results/RenderBinary.java
+++ b/framework/src/play/mvc/results/RenderBinary.java
@@ -22,13 +22,13 @@ public class RenderBinary extends Result {
     private static final String INLINE_DISPOSITION_TYPE = "inline";
     private static final String ATTACHMENT_DISPOSITION_TYPE = "attachment";
 
-    private static URLCodec encoder = new URLCodec();
-    boolean inline = false;
-    long length = 0;
-    File file;
-    InputStream is;
-    String name;
-    String contentType;
+    private static final URLCodec encoder = new URLCodec();
+    private final boolean inline;
+    private long length = 0;
+    private File file;
+    private InputStream is;
+    private final String name;
+    private String contentType;
 
     /**
      * send a binary stream as the response
@@ -182,5 +182,25 @@ public class RenderBinary extends Result {
     private boolean canAsciiEncode(String string) {
         CharsetEncoder asciiEncoder = Charset.forName("US-ASCII").newEncoder();
         return asciiEncoder.canEncode(string);
+    }
+
+    public boolean isInline() {
+        return inline;
+    }
+
+    public long getLength() {
+        return length;
+    }
+
+    public File getFile() {
+        return file;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getContentType() {
+        return contentType;
     }
 }

--- a/framework/src/play/mvc/results/RenderHtml.java
+++ b/framework/src/play/mvc/results/RenderHtml.java
@@ -9,20 +9,23 @@ import play.mvc.Http.Response;
  */
 public class RenderHtml extends Result {
     
-    String text;
+    private final String html;
     
-    public RenderHtml(CharSequence text) {
-        this.text = text.toString();
+    public RenderHtml(CharSequence html) {
+        this.html = html.toString();
     }
 
     @Override
     public void apply(Request request, Response response) {
         try {
             setContentTypeIfNotSet(response, "text/html");
-            response.out.write(text.getBytes(getEncoding()));
+            response.out.write(html.getBytes(getEncoding()));
         } catch(Exception e) {
             throw new UnexpectedException(e);
         }
     }
 
+    public String getHtml() {
+        return html;
+    }
 }

--- a/framework/src/play/mvc/results/RenderJson.java
+++ b/framework/src/play/mvc/results/RenderJson.java
@@ -15,7 +15,7 @@ import play.mvc.Http.Response;
  */
 public class RenderJson extends Result {
 
-    String json;
+    private final String json;
 
     public RenderJson(Object o) {
         json = new Gson().toJson(o);
@@ -70,4 +70,7 @@ public class RenderJson extends Result {
         return bestMatch;
     }
 
+    public String getJson() {
+        return json;
+    }
 }

--- a/framework/src/play/mvc/results/RenderTemplate.java
+++ b/framework/src/play/mvc/results/RenderTemplate.java
@@ -13,15 +13,17 @@ import java.util.Map;
  */
 public class RenderTemplate extends Result {
 
-    private String name;
-    private String content;
-    private long renderTime;
+    private final String name;
+    private final Map<String, Object> args;
+    private final String content;
+    private final long renderTime;
 
     public RenderTemplate(Template template, Map<String, Object> args) {
-        this.name = template.name;
         if (args.containsKey("out")) {
             throw new RuntimeException("Assertion failed! args shouldn't contain out");
         }
+        this.name = template.name;
+        this.args = args;
         long start = System.currentTimeMillis();
         this.content = template.render(args);
         this.renderTime = System.currentTimeMillis() - start;
@@ -36,6 +38,14 @@ public class RenderTemplate extends Result {
         } catch (Exception e) {
             throw new UnexpectedException(e);
         }
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Map<String, Object> getArguments() {
+        return args;
     }
 
     public String getContent() {

--- a/framework/src/play/mvc/results/RenderText.java
+++ b/framework/src/play/mvc/results/RenderText.java
@@ -10,7 +10,7 @@ import play.mvc.Http.Response;
  */
 public class RenderText extends Result {
     
-    String text;
+    private final String text;
     
     public RenderText(CharSequence text) {
         this.text = text.toString();
@@ -26,4 +26,7 @@ public class RenderText extends Result {
         }
     }
 
+    public String getText() {
+        return text;
+    }
 }

--- a/framework/src/play/mvc/results/RenderXml.java
+++ b/framework/src/play/mvc/results/RenderXml.java
@@ -14,7 +14,7 @@ import com.thoughtworks.xstream.XStream;
  */
 public class RenderXml extends Result {
 
-    String xml;
+    private final String xml;
 
     public RenderXml(CharSequence xml) {
         this.xml = xml.toString();
@@ -42,4 +42,7 @@ public class RenderXml extends Result {
         }
     }
 
+    public String getXml() {
+        return xml;
+    }
 }

--- a/framework/src/play/mvc/results/Status.java
+++ b/framework/src/play/mvc/results/Status.java
@@ -5,7 +5,7 @@ import play.mvc.Http.Response;
 
 public class Status extends Result {
 
-    int code;
+    private final int code;
 
     public Status(int code) {
         super(code+"");
@@ -15,5 +15,9 @@ public class Status extends Result {
     @Override
     public void apply(Request request, Response response) {
         response.status = code;
+    }
+
+    public int getCode() {
+        return code;
     }
 }

--- a/framework/src/play/mvc/results/Unauthorized.java
+++ b/framework/src/play/mvc/results/Unauthorized.java
@@ -9,7 +9,7 @@ import play.mvc.Http.Response;
  */
 public class Unauthorized extends Result {
     
-    String realm;
+    private final String realm;
     
     public Unauthorized(String realm) {
         super(realm);
@@ -20,5 +20,9 @@ public class Unauthorized extends Result {
     public void apply(Request request, Response response) {
         response.status = Http.StatusCode.UNAUTHORIZED;
         response.setHeader("WWW-Authenticate", "Basic realm=\"" + realm + "\"");
+    }
+
+    public String getRealm() {
+        return realm;
     }
 }


### PR DESCRIPTION
We want to add public getters to all `Result` subclasses (first of all, `RenderTemplate`).

So we can catch them in unit-tests and verify all parameters