### PR TITLE
ticket #2072: add method Binder.unregister()

### DIFF
--- a/framework/src/play/data/binding/Binder.java
+++ b/framework/src/play/data/binding/Binder.java
@@ -43,9 +43,25 @@ public abstract class Binder {
         supportedTypes.put(byte[][].class, new ByteArrayArrayBinder());
     }
 
-
+    /**
+     * Add custom binder for any given class
+     * 
+     * E.g. @{code Binder.register(BigDecimal.class, new MyBigDecimalBinder());}
+     * 
+     * NB! Do not forget to UNREGISTER your custom binder when applications is reloaded (most probably in method onApplicationStop()).
+     * Otherwise you will have a memory leak.
+     * 
+     * @see #unregister(java.lang.Class)
+     */
     public static <T> void register(Class<T> clazz, TypeBinder<T> typeBinder) {
         supportedTypes.put(clazz, typeBinder);
+    }
+
+    /**
+     * Remove custom binder that was add with method #register(java.lang.Class, play.data.binding.TypeBinder)
+     */
+    public static <T> void unregister(Class<T> clazz) {
+        supportedTypes.remove(clazz);
     }
 
     static Map<Class<?>, BeanWrapper> beanwrappers = new HashMap<>();

--- a/framework/test-src/play/data/binding/BinderTest.java
+++ b/framework/test-src/play/data/binding/BinderTest.java
@@ -7,9 +7,14 @@ import play.data.validation.Validation;
 import play.data.validation.ValidationPlugin;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.math.BigDecimal;
 import java.util.*;
 
+import static java.math.BigDecimal.TEN;
 import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 
 public class BinderTest {
@@ -311,6 +316,21 @@ public class BinderTest {
         return r2;
     }
 
+    @Test
+    public void applicationCanRegisterAndUnregisterCustomBinders() {
+        Binder.register(BigDecimal.class, new MyBigDecimalBinder());
+        assertNotNull(Binder.supportedTypes.get(BigDecimal.class));
+
+        Binder.unregister(BigDecimal.class);
+        assertNull(Binder.supportedTypes.get(BigDecimal.class));
+    }
+
+    private static class MyBigDecimalBinder implements TypeBinder<BigDecimal> {
+        @Override
+        public Object bind(String name, Annotation[] annotations, String value, Class actualClass, Type genericType) throws Exception {
+            return new BigDecimal(value).add(TEN);
+        }
+    }
 }
 
 


### PR DESCRIPTION
... to avoid holding custom binders in static list forever, holding reference to the initial ApplicationClassloader