### PR TITLE
[#1090] Fix performance issue in classloader

### DIFF
--- a/framework/src/play/classloading/ApplicationClassloader.java
+++ b/framework/src/play/classloading/ApplicationClassloader.java
@@ -561,9 +561,4 @@ public class ApplicationClassloader extends ClassLoader {
             }
         }
     }
-
-    @Override
-    public String toString() {
-        return "(play) " + (allClasses == null ? "" : allClasses.toString());
-    }
 }


### PR DESCRIPTION
remove method ApplicationClassloader.toString()

it can cause performance issues: some libraries (e.g. xalan) log ClassLoader.toString() many times