### PR TITLE
Avoid casting when calling getPluginInstance()

### DIFF
--- a/framework/src/play/Play.java
+++ b/framework/src/play/Play.java
@@ -677,8 +677,8 @@ public class Play {
     }
 
     @SuppressWarnings("unchecked")
-    public static <T> T plugin(Class<T> clazz) {
-        return (T) pluginCollection.getPluginInstance((Class<? extends PlayPlugin>) clazz);
+    public static <T extends PlayPlugin> T plugin(Class<T> clazz) {
+        return pluginCollection.getPluginInstance(clazz);
     }
 
     /**

--- a/framework/src/play/plugins/PluginCollection.java
+++ b/framework/src/play/plugins/PluginCollection.java
@@ -399,10 +399,10 @@ public class PluginCollection {
      *            The plugin class
      * @return PlayPlugin
      */
-    public synchronized PlayPlugin getPluginInstance(Class<? extends PlayPlugin> pluginClazz) {
+    public synchronized <T extends PlayPlugin> T getPluginInstance(Class<T> pluginClazz) {
         for (PlayPlugin p : getAllPlugins()) {
             if (pluginClazz.isInstance(p)) {
-                return p;
+                return (T) p;
             }
         }
         return null;

--- a/framework/test-src/play/plugins/ConfigurablePluginDisablingPluginTest.java
+++ b/framework/test-src/play/plugins/ConfigurablePluginDisablingPluginTest.java
@@ -140,8 +140,7 @@ public class ConfigurablePluginDisablingPluginTest {
 
         new PlayBuilder().build();
         pc.loadPlugins();
-        PlayPlugin pi = pc.getPluginInstance(ConfigurablePluginDisablingPlugin.class);
-        assertThat(pi).isInstanceOf(ConfigurablePluginDisablingPlugin.class);
+        ConfigurablePluginDisablingPlugin pi = pc.getPluginInstance(ConfigurablePluginDisablingPlugin.class);
         assertThat(pc.getEnabledPlugins()).contains( pi );
     }
 

--- a/framework/test-src/play/plugins/PluginCollectionTest.java
+++ b/framework/test-src/play/plugins/PluginCollectionTest.java
@@ -67,8 +67,8 @@ public class PluginCollectionTest {
 
         pc.loadPlugins();
 
-        PlayPlugin corePlugin_first_instance = pc.getPluginInstance(CorePlugin.class);
-        PlayPlugin testPlugin_first_instance = pc.getPluginInstance(TestPlugin.class);
+        CorePlugin corePlugin_first_instance = pc.getPluginInstance(CorePlugin.class);
+        TestPlugin testPlugin_first_instance = pc.getPluginInstance(TestPlugin.class);
 
         assertThat(pc.getAllPlugins()).containsExactly(
                 corePlugin_first_instance,
@@ -91,8 +91,8 @@ public class PluginCollectionTest {
 
         pc.loadPlugins();
 
-        PlayPlugin corePlugin_first_instance = pc.getPluginInstance(CorePlugin.class);
-        PlayPlugin testPlugin_first_instance = pc.getPluginInstance(TestPlugin.class);
+        CorePlugin corePlugin_first_instance = pc.getPluginInstance(CorePlugin.class);
+        TestPlugin testPlugin_first_instance = pc.getPluginInstance(TestPlugin.class);
 
         //the following plugin-list should match the list in the file 'play.plugins'
         assertThat(pc.getEnabledPlugins()).containsExactly(
@@ -104,7 +104,7 @@ public class PluginCollectionTest {
 
         pc.reloadApplicationPlugins();
 
-        PlayPlugin testPlugin_second_instance = pc.getPluginInstance(TestPlugin.class);
+        TestPlugin testPlugin_second_instance = pc.getPluginInstance(TestPlugin.class);
 
         assertThat(pc.getPluginInstance(CorePlugin.class)).isEqualTo( corePlugin_first_instance);
         assertThat(testPlugin_second_instance).isNotEqualTo( testPlugin_first_instance);


### PR DESCRIPTION
make getPluginInstance() return the plugin of specific type