### PR TITLE
[#1112] Allow to limit the size of whole request or the size of one uploaded file in a request

### DIFF
--- a/documentation/manual/configuration.textile
+++ b/documentation/manual/configuration.textile
@@ -1165,6 +1165,21 @@ bc. upload.threshold=20480
 
 Default: @10240@
 
+h3(#upload.maxRequestSize). upload.maxRequestSize
+
+The maximum size permitted for the complete request. A value of -1 indicates no maximum.
+
+bc. upload.maxRequestSize=2048
+
+Default: @-1@
+
+h3(#upload.maxFileSize). upload.maxFileSize
+
+The maximum size permitted for a single uploaded file, as opposed to. A value of -1 indicates no maximum.
+
+bc. upload.maxFileSize=1024
+
+Default: @-1@
 
 h2(#xforwarded). Proxy forwarding
 

--- a/framework/src/play/data/parsing/ApacheMultipartParser.java
+++ b/framework/src/play/data/parsing/ApacheMultipartParser.java
@@ -610,14 +610,14 @@ public class ApacheMultipartParser extends DataParser {
     // ----------------------------------------------------------- Data members
     /**
      * The maximum size permitted for the complete request, as opposed to
-     * {@link #fileSizeMax}. A value of -1 indicates no maximum.
+     * {@link #maxFileSize}. A value of -1 indicates no maximum.
      */
-    private long sizeMax = -1;
+    private long maxRequestSize = Integer.parseInt(Play.configuration.getProperty("upload.maxRequestSize", "-1"));
     /**
      * The maximum size permitted for a single uploaded file, as opposed to
-     * {@link #sizeMax}. A value of -1 indicates no maximum.
+     * {@link #maxRequestSize}. A value of -1 indicates no maximum.
      */
-    private long fileSizeMax = -1;
+    private long maxFileSize = Integer.parseInt(Play.configuration.getProperty("upload.maxFileSize", "-1"));
 
     // ------------------------------------------------------ Protected methods
 
@@ -865,8 +865,8 @@ public class ApacheMultipartParser extends DataParser {
                 contentType = pContentType;
                 formField = pFormField;
                 InputStream istream = multi.newInputStream();
-                if (fileSizeMax != -1) {
-                    istream = new LimitedInputStream(istream, fileSizeMax) {
+                if (maxFileSize != -1) {
+                    istream = new LimitedInputStream(istream, maxFileSize) {
 
                         @Override
                         protected void raiseError(long pSizeMax, long pCount) throws IOException {
@@ -998,10 +998,10 @@ public class ApacheMultipartParser extends DataParser {
                 throw new InvalidContentTypeException("the request doesn't contain a " + MULTIPART_FORM_DATA + " or " + MULTIPART_MIXED + " stream, content type header is " + contentType);
             }
 
-            if (sizeMax >= 0) {
+            if (maxRequestSize >= 0) {
                 // TODO check size
 
-                input = new LimitedInputStream(input, sizeMax) {
+                input = new LimitedInputStream(input, maxRequestSize) {
 
                     @Override
                     protected void raiseError(long pSizeMax, long pCount) throws IOException {


### PR DESCRIPTION
…file in a request.

 The configuration parameters are: 'upload.sizeMax' and 'upload.fileSizeMax'.
 The defaults stay the same -1 which means 'unlimited'.