### PR TITLE
[#2120] Add support for (special) hibernate properties through applic…

### DIFF
--- a/framework/test-src/play/db/ConfigurationTest.java
+++ b/framework/test-src/play/db/ConfigurationTest.java
@@ -241,6 +241,7 @@ public class ConfigurationTest {
     
     @Test
     public void getPropertiesForDefaultTest() {
+        //db
         Play.configuration.put("db.url", "jdbc:mysql://127.0.0.1/testPlay");
         Play.configuration.put("db.driver", "com.mysql.jdbc.Driver");
         Play.configuration.put("db.user", "root");
@@ -249,13 +250,23 @@ public class ConfigurationTest {
         Play.configuration.put("db.pool.maxSize", "20");
         Play.configuration.put("db.pool.minSize", "1");
         Play.configuration.put("db.pool.maxIdleTimeExcessConnections", "60");
-        
+        //javax.persistence
+        Play.configuration.put("javax.persistence.lock.scope", "EXTENDED");
+        Play.configuration.put("javax.persistence.lock.timeout", "1000");
+        //jpa
+        Play.configuration.put("jpa.dialect", "org.hibernate.dialect.PostgreSQLDialect");
+        Play.configuration.put("jpa.ddl", "update");
+        Play.configuration.put("jpa.debugSQL", "true");
+        //hibernate
         Play.configuration.put("hibernate.ejb.event.post-insert", "postInsert");
         Play.configuration.put("hibernate.ejb.event.post-update", "postUpdate");
+        //org.hibernate
+        Play.configuration.put("org.hibernate.flushMode", "AUTO");
 
         Configuration dbConfig = new Configuration("default");
         Map<String, String> properties = dbConfig.getProperties();
-        
+
+        //db
         assertEquals("jdbc:mysql://127.0.0.1/testPlay", properties.get("db.url"));
         assertEquals("com.mysql.jdbc.Driver", properties.get("db.driver"));
         assertEquals("root",properties.get("db.user"));
@@ -264,15 +275,25 @@ public class ConfigurationTest {
         assertEquals("20", properties.get("db.pool.maxSize"));
         assertEquals("1", properties.get("db.pool.minSize"));
         assertEquals("60", properties.get("db.pool.maxIdleTimeExcessConnections"));
-        
+        //javax.persistence
+        assertEquals("EXTENDED", properties.get("javax.persistence.lock.scope"));
+        assertEquals("1000", properties.get("javax.persistence.lock.timeout"));
+        //jpa
+        assertEquals("org.hibernate.dialect.PostgreSQLDialect", properties.get("jpa.dialect"));
+        assertEquals("update", properties.get("jpa.ddl"));
+        assertEquals("true", properties.get("jpa.debugSQL"));
+        //hibernate
         assertEquals("postInsert", properties.get("hibernate.ejb.event.post-insert"));
         assertEquals("postUpdate", properties.get("hibernate.ejb.event.post-update"));
-        
+        //org.hibernate
+        assertEquals("AUTO", properties.get("org.hibernate.flushMode"));
+
         assertEquals(Play.configuration.size(), properties.size());
     }
     
     @Test
     public void getPropertiesForDBTest() {
+        //db
         Play.configuration.put("db.test.url", "jdbc:mysql://127.0.0.1/testPlay");
         Play.configuration.put("db.test.driver", "com.mysql.jdbc.Driver");
         Play.configuration.put("db.test.user", "root");
@@ -281,13 +302,23 @@ public class ConfigurationTest {
         Play.configuration.put("db.test.pool.maxSize", "20");
         Play.configuration.put("db.test.pool.minSize", "1");
         Play.configuration.put("db.test.pool.maxIdleTimeExcessConnections", "60");
-        
+        //javax.persistence
+        Play.configuration.put("javax.persistence.test.lock.scope", "EXTENDED");
+        Play.configuration.put("javax.persistence.test.lock.timeout", "1000");
+        //jpa
+        Play.configuration.put("jpa.test.dialect", "org.hibernate.dialect.PostgreSQLDialect");
+        Play.configuration.put("jpa.test.ddl", "update");
+        Play.configuration.put("jpa.test.debugSQL", "true");
+        //hibernate
         Play.configuration.put("hibernate.test.ejb.event.post-insert", "postInsert");
         Play.configuration.put("hibernate.test.ejb.event.post-update", "postUpdate");
+        //org.hibernate
+        Play.configuration.put("org.hibernate.test.flushMode", "AUTO");
 
         Configuration dbConfig = new Configuration("test");
         Map<String, String> properties = dbConfig.getProperties();
-        
+
+        //db
         assertEquals("jdbc:mysql://127.0.0.1/testPlay", properties.get("db.url"));
         assertEquals("com.mysql.jdbc.Driver", properties.get("db.driver"));
         assertEquals("root",properties.get("db.user"));
@@ -296,10 +327,19 @@ public class ConfigurationTest {
         assertEquals("20", properties.get("db.pool.maxSize"));
         assertEquals("1", properties.get("db.pool.minSize"));
         assertEquals("60", properties.get("db.pool.maxIdleTimeExcessConnections"));
-        
+        //javax.persistence
+        assertEquals("EXTENDED", properties.get("javax.persistence.lock.scope"));
+        assertEquals("1000", properties.get("javax.persistence.lock.timeout"));
+        //jpa
+        assertEquals("org.hibernate.dialect.PostgreSQLDialect", properties.get("jpa.dialect"));
+        assertEquals("update", properties.get("jpa.ddl"));
+        assertEquals("true", properties.get("jpa.debugSQL"));
+        //hibernate
         assertEquals("postInsert", properties.get("hibernate.ejb.event.post-insert"));
         assertEquals("postUpdate", properties.get("hibernate.ejb.event.post-update"));
-        
+        //org.hibernate
+        assertEquals("AUTO", properties.get("org.hibernate.flushMode"));
+
         assertEquals(Play.configuration.size(), properties.size());
     }
 

--- a/resources/application-skel/conf/application.conf
+++ b/resources/application-skel/conf/application.conf
@@ -109,6 +109,13 @@ date.format=yyyy-MM-dd
 # generic "destroy" method :
 # db.default.destroyMethod=close
 
+# # database isolation configuration
+# # Valid values are NONE, READ_UNCOMMITTED, READ_COMMITTED, REPEATABLE_READ, SERIALIZABLE,
+# # or an integer value to be passed to java.sql.Connection.setTransactionIsolation().
+# # Note that not all databases support all transaction isolation levels.
+# # Default: database dependent, usually READ_COMMITTED
+# db.default.isolation=SERIALIZABLE
+
 # JPA Configuration (Hibernate)
 # ~~~~~
 #
@@ -123,9 +130,12 @@ date.format=yyyy-MM-dd
 # jpa.default.debugSQL=true
 #
 # You can even specify additional hibernate properties here:
-# default.hibernate.use_sql_comments=true
+# hibernate.default.use_sql_comments=true
 # ...
+# org.hibernate.default.flushMode
+# javax.persistence.default.flushMode
 #
+
 # Store path for Blob content
 attachments.path=data/attachments
 


### PR DESCRIPTION
Actually only key with regex "^(db|jpa|hibernate){1}(\.?[\da-zA-Z\.-_]*)$" are recognized as properties for db, jpa and hibernate setup.

Hence special keys for hibernate like 'org.hibernate.flushMode' cannot be changed through application.conf.

Especially the flushMode of hibernate should be editable like 'db.isolation'.


This pull request fixes this