### PR TITLE
[#2088] Guard against IllegalArgumentExceptions thrown by definePacka…

### DIFF
--- a/framework/src/play/classloading/ApplicationClassloader.java
+++ b/framework/src/play/classloading/ApplicationClassloader.java
@@ -150,7 +150,9 @@ public class ApplicationClassloader extends ClassLoader {
             }
 
             if (!applicationClass.isClass()) {
-                definePackage(applicationClass.getPackage(), null, null, null, null, null, null, null);
+                if(null == getPackage(applicationClass.getPackage())) {
+                    definePackage(applicationClass.getPackage(), null, null, null, null, null, null, null);
+                }
             } else {
                 loadPackage(name);
             }


### PR DESCRIPTION
…ge. This can happen when a external test harness framework (e.g. eclipse's junit test runner) has already loaded the application's packages by the time Play!'s ApplicationClassLoader runs.