### PR TITLE
Make it possible to change session store implementation

### DIFF
--- a/framework/src/play/mvc/CookieSessionStore.java
+++ b/framework/src/play/mvc/CookieSessionStore.java
@@ -1,0 +1,96 @@
+package play.mvc;
+
+import play.Play;
+import play.exceptions.UnexpectedException;
+import play.libs.Crypto;
+import play.libs.Time;
+
+import static play.mvc.Scope.*;
+import static play.mvc.Scope.Session.TS_KEY;
+
+/**
+ * Default session store implementation that stores signed data in a cookie
+ */
+public class CookieSessionStore implements SessionStore {
+
+    @Override
+    public Session restore() {
+        try {
+            Session session = new Session();
+            Http.Cookie cookie = Http.Request.current().cookies.get(COOKIE_PREFIX + "_SESSION");
+            int duration = Time.parseDuration(COOKIE_EXPIRE);
+            long expiration = (duration * 1000l);
+
+            if (cookie != null && Play.started && cookie.value != null && !cookie.value.trim().equals("")) {
+                String value = cookie.value;
+                int firstDashIndex = value.indexOf("-");
+                if (firstDashIndex > -1) {
+                    String sign = value.substring(0, firstDashIndex);
+                    String data = value.substring(firstDashIndex + 1);
+                    if (CookieDataCodec.safeEquals(sign, Crypto.sign(data, Play.secretKey.getBytes()))) {
+                        CookieDataCodec.decode(session.data, data);
+                    }
+                }
+                if (COOKIE_EXPIRE != null) {
+                    // Verify that the session contains a timestamp, and
+                    // that it's not expired
+                    if (!session.contains(TS_KEY)) {
+                        session = new Session();
+                    } else {
+                        if ((Long.parseLong(session.get(TS_KEY))) < System.currentTimeMillis()) {
+                            // Session expired
+                            session = new Session();
+                        }
+                    }
+                    session.put(TS_KEY, System.currentTimeMillis() + expiration);
+                } else {
+                    // Just restored. Nothing changed. No cookie-expire.
+                    session.changed = false;
+                }
+            } else {
+                // no previous cookie to restore; but we may have to set the
+                // timestamp in the new cookie
+                if (COOKIE_EXPIRE != null) {
+                    session.put(TS_KEY, (System.currentTimeMillis() + expiration));
+                }
+            }
+
+            return session;
+        } catch (Exception e) {
+            throw new UnexpectedException("Corrupted HTTP session from " + Http.Request.current().remoteAddress, e);
+        }
+    }
+
+    @Override
+    public void save(Session session) {
+        if (Http.Response.current() == null) {
+            // Some request like WebSocket don't have any response
+            return;
+        }
+        if (!session.changed && SESSION_SEND_ONLY_IF_CHANGED && COOKIE_EXPIRE == null) {
+            // Nothing changed and no cookie-expire, consequently send
+            // nothing back.
+            return;
+        }
+        if (session.isEmpty()) {
+            // The session is empty: delete the cookie
+            if (Http.Request.current().cookies.containsKey(COOKIE_PREFIX + "_SESSION") || !SESSION_SEND_ONLY_IF_CHANGED) {
+                Http.Response.current().setCookie(COOKIE_PREFIX + "_SESSION", "", null, "/", 0, COOKIE_SECURE, SESSION_HTTPONLY);
+            }
+            return;
+        }
+        try {
+            String sessionData = CookieDataCodec.encode(session.data);
+            String sign = Crypto.sign(sessionData, Play.secretKey.getBytes());
+            if (COOKIE_EXPIRE == null) {
+                Http.Response.current().setCookie(COOKIE_PREFIX + "_SESSION", sign + "-" + sessionData, null, "/", null, COOKIE_SECURE,
+                        SESSION_HTTPONLY);
+            } else {
+                Http.Response.current().setCookie(COOKIE_PREFIX + "_SESSION", sign + "-" + sessionData, null, "/",
+                        Time.parseDuration(COOKIE_EXPIRE), COOKIE_SECURE, SESSION_HTTPONLY);
+            }
+        } catch (Exception e) {
+            throw new UnexpectedException("Session serializationProblem", e);
+        }
+    }
+}

--- a/framework/src/play/mvc/Scope.java
+++ b/framework/src/play/mvc/Scope.java
@@ -1,13 +1,5 @@
 package play.mvc;
 
-import java.lang.annotation.Annotation;
-import java.net.URLEncoder;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.UUID;
-
 import play.Logger;
 import play.Play;
 import play.data.binding.Binder;
@@ -20,8 +12,11 @@ import play.exceptions.UnexpectedException;
 import play.i18n.Messages;
 import play.libs.Codec;
 import play.libs.Crypto;
-import play.libs.Time;
 import play.utils.Utils;
+
+import java.lang.annotation.Annotation;
+import java.net.URLEncoder;
+import java.util.*;
 
 /**
  * All application Scopes
@@ -157,56 +152,14 @@ public class Scope {
      * Session scope
      */
     public static class Session {
+        public static SessionStore store = new CookieSessionStore();
 
         static final String AT_KEY = "___AT";
         static final String ID_KEY = "___ID";
         static final String TS_KEY = "___TS";
 
         public static Session restore() {
-            try {
-                Session session = new Session();
-                Http.Cookie cookie = Http.Request.current().cookies.get(COOKIE_PREFIX + "_SESSION");
-                int duration = Time.parseDuration(COOKIE_EXPIRE);
-                long expiration = (duration * 1000l);
-
-                if (cookie != null && Play.started && cookie.value != null && !cookie.value.trim().equals("")) {
-                    String value = cookie.value;
-                    int firstDashIndex = value.indexOf("-");
-                    if (firstDashIndex > -1) {
-                        String sign = value.substring(0, firstDashIndex);
-                        String data = value.substring(firstDashIndex + 1);
-                        if (CookieDataCodec.safeEquals(sign, Crypto.sign(data, Play.secretKey.getBytes()))) {
-                            CookieDataCodec.decode(session.data, data);
-                        }
-                    }
-                    if (COOKIE_EXPIRE != null) {
-                        // Verify that the session contains a timestamp, and
-                        // that it's not expired
-                        if (!session.contains(TS_KEY)) {
-                            session = new Session();
-                        } else {
-                            if ((Long.parseLong(session.get(TS_KEY))) < System.currentTimeMillis()) {
-                                // Session expired
-                                session = new Session();
-                            }
-                        }
-                        session.put(TS_KEY, System.currentTimeMillis() + expiration);
-                    } else {
-                        // Just restored. Nothing changed. No cookie-expire.
-                        session.changed = false;
-                    }
-                } else {
-                    // no previous cookie to restore; but we may have to set the
-                    // timestamp in the new cookie
-                    if (COOKIE_EXPIRE != null) {
-                        session.put(TS_KEY, (System.currentTimeMillis() + expiration));
-                    }
-                }
-
-                return session;
-            } catch (Exception e) {
-                throw new UnexpectedException("Corrupted HTTP session from " + Http.Request.current().remoteAddress, e);
-            }
+            return store.restore();
         }
 
         Map<String, String> data = new HashMap<>(); // ThreadLocal access
@@ -241,35 +194,7 @@ public class Scope {
         }
 
         void save() {
-            if (Http.Response.current() == null) {
-                // Some request like WebSocket don't have any response
-                return;
-            }
-            if (!changed && SESSION_SEND_ONLY_IF_CHANGED && COOKIE_EXPIRE == null) {
-                // Nothing changed and no cookie-expire, consequently send
-                // nothing back.
-                return;
-            }
-            if (isEmpty()) {
-                // The session is empty: delete the cookie
-                if (Http.Request.current().cookies.containsKey(COOKIE_PREFIX + "_SESSION") || !SESSION_SEND_ONLY_IF_CHANGED) {
-                    Http.Response.current().setCookie(COOKIE_PREFIX + "_SESSION", "", null, "/", 0, COOKIE_SECURE, SESSION_HTTPONLY);
-                }
-                return;
-            }
-            try {
-                String sessionData = CookieDataCodec.encode(data);
-                String sign = Crypto.sign(sessionData, Play.secretKey.getBytes());
-                if (COOKIE_EXPIRE == null) {
-                    Http.Response.current().setCookie(COOKIE_PREFIX + "_SESSION", sign + "-" + sessionData, null, "/", null, COOKIE_SECURE,
-                            SESSION_HTTPONLY);
-                } else {
-                    Http.Response.current().setCookie(COOKIE_PREFIX + "_SESSION", sign + "-" + sessionData, null, "/",
-                            Time.parseDuration(COOKIE_EXPIRE), COOKIE_SECURE, SESSION_HTTPONLY);
-                }
-            } catch (Exception e) {
-                throw new UnexpectedException("Session serializationProblem", e);
-            }
+            store.save(this);
         }
 
         public void put(String key, String value) {

--- a/framework/src/play/mvc/Scope.java
+++ b/framework/src/play/mvc/Scope.java
@@ -18,8 +18,6 @@ import java.lang.annotation.Annotation;
 import java.net.URLEncoder;
 import java.util.*;
 
-import static play.templates.JavaExtensions.capitalizeWords;
-
 /**
  * All application Scopes
  */
@@ -37,9 +35,10 @@ public class Scope {
     public static SessionStore sessionStore = createSessionStore();
 
     private static SessionStore createSessionStore() {
-        String sessionStoreParameter = Play.configuration.getProperty("application.session.store", "cookie");
-        String sessionStoreClass = "play.mvc." + capitalizeWords(sessionStoreParameter) + "SessionStore";
+        String sessionStoreClass = Play.configuration.getProperty("application.session.storeClass");
+        if (sessionStoreClass == null) return new CookieSessionStore();
         try {
+            Logger.info("Storing sessions using " + sessionStoreClass);
             return (SessionStore) Class.forName(sessionStoreClass).newInstance();
         }
         catch (Exception e) {

--- a/framework/src/play/mvc/Scope.java
+++ b/framework/src/play/mvc/Scope.java
@@ -184,7 +184,7 @@ public class Scope {
 
         public String getAuthenticityToken() {
             if (!data.containsKey(AT_KEY)) {
-                this.put(AT_KEY, Crypto.sign(UUID.randomUUID().toString()));
+                this.put(AT_KEY, Crypto.sign(Codec.UUID()));
             }
             return data.get(AT_KEY);
         }

--- a/framework/src/play/mvc/SessionStore.java
+++ b/framework/src/play/mvc/SessionStore.java
@@ -1,0 +1,9 @@
+package play.mvc;
+
+/**
+ * Implementations of session storage mechanisms.
+ */
+public interface SessionStore {
+    void save(Scope.Session session);
+    Scope.Session restore();
+}


### PR DESCRIPTION
There are some problems with the default cookie-based sessions, including:
* It is very easy to overwrite changed session in concurrent AJAX request with unpredictable result
* Session replay attacks are possible by sending previous version of the session until it expires

This PR makes it possible to implement other backends for session storage, e.g. cache or database.
This is similar to CacheImpl, where new caching implementaions can be created.

The default implementation is CookieSessionStore that extracted as-is from Scope.Session class. All Scope.Session API is left 100% unchanged, so no breaking changes.

No new implementations are provided as of now, but we can create a separate PR with cache-based implementation.
