### PR TITLE
create a default constructor for `play.mvc.results.Forbidden`

### DIFF
--- a/framework/src/play/mvc/results/Forbidden.java
+++ b/framework/src/play/mvc/results/Forbidden.java
@@ -7,6 +7,10 @@ import play.mvc.Http;
  */
 public class Forbidden extends Error {
 
+    public Forbidden() {
+        this("Access denied");
+    }
+
     public Forbidden(String reason) {
         super(Http.StatusCode.FORBIDDEN, reason);
     }


### PR DESCRIPTION
the default error message will be "Access denied"
It's used in Controller.forbidden(), so de-facto it's the default value in most cases