### PR TITLE
[#1212] Fix non-Latin characters decode in UrlEncodedParser

### DIFF
--- a/framework/src/play/data/parsing/UrlEncodedParser.java
+++ b/framework/src/play/data/parsing/UrlEncodedParser.java
@@ -4,6 +4,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -15,7 +16,6 @@ import play.mvc.Http;
 import play.mvc.results.Status;
 import play.utils.Utils;
 
-import org.apache.commons.codec.net.URLCodec;
 
 /**
  * Parse url-encoded requests.
@@ -119,17 +119,17 @@ public class UrlEncodedParser extends DataParser {
 
             // We're ready to decode the params
             Map<String, String[]> decodedParams = new LinkedHashMap<>(params.size());
-            URLCodec codec = new URLCodec();
             for (Map.Entry<String, String[]> e : params.entrySet()) {
                 String key = e.getKey();
                 try {
-                    key = codec.decode(e.getKey(), charset);
+                    key = URLDecoder.decode(e.getKey(), charset);
                 } catch (Throwable z) {
                     // Nothing we can do about, ignore
                 }
                 for (String value : e.getValue()) {
                     try {
-                        Utils.Maps.mergeValueInMap(decodedParams, key, (value == null ? null : codec.decode(value, charset)));
+                        String decodedValue = value == null ? null : URLDecoder.decode(value, charset);
+                        Utils.Maps.mergeValueInMap(decodedParams, key, decodedValue);
                     } catch (Throwable z) {
                         // Nothing we can do about, lets fill in with the non decoded value
                         Utils.Maps.mergeValueInMap(decodedParams, key, value);

--- a/framework/test-src/play/data/parsing/UrlEncodedParserTest.java
+++ b/framework/test-src/play/data/parsing/UrlEncodedParserTest.java
@@ -1,0 +1,49 @@
+package play.data.parsing;
+
+import org.junit.Test;
+import play.mvc.Http;
+import play.test.FunctionalTest;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+public class UrlEncodedParserTest {
+
+    @Test
+    public void parseTest() {
+
+        Map<String, String[]> params = new HashMap<>();
+
+        params.put("english", new String[] {"Hello"});
+        params.put("russian", new String[] {"Привет"});
+        params.put("chinese", new String[] {"嗨"});
+
+        String queryString = params.entrySet()
+                                   .stream()
+                                   .map(entry -> entry.getKey() + "=" + entry.getValue()[0])
+                                   .collect(Collectors.joining("&"));
+
+        params.put("body", new String[] {queryString});
+
+        Http.Request req = FunctionalTest.newRequest();
+        Http.Request.current.set(req);
+
+        Map<String, String[]> parse = UrlEncodedParser.parse(queryString);
+
+        assertThat(parse.size(), is(params.size()));
+        assertThat(transform(parse), is(transform(params)));
+    }
+
+
+    private Map<String, String> transform(Map<String, String[]> map) {
+        // arrays in map values fail during asserting
+        return map.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue()[0]));
+    }
+}


### PR DESCRIPTION
This PR fixes the decoding of a query string from requests with content-type "application/x-www-form-urlencoded". Error detected in org.apache.common.codec.net.URLCodec so it is replaced by java.net.URLDecoder.