### PR TITLE
Add support for navigating XML with namespaces.

### DIFF
--- a/framework/src/play/libs/WS.java
+++ b/framework/src/play/libs/WS.java
@@ -749,11 +749,33 @@ public class WS extends PlayPlugin {
 
         /**
          * Parse and get the response body as a {@link Document DOM document}
-         * 
+         *
          * @return a DOM document
          */
         public Document getXml() {
-            return getXml(getEncoding());
+            return getXml(false);
+        }
+
+        /**
+         * Parse and get the response body as a {@link Document DOM document}
+         *
+         * @param namespaceAware
+         *            whether to output XML namespace information in the returned document
+         * @return a DOM document
+         */
+        public Document getXml(boolean namespaceAware) {
+            return getXml(getEncoding(), namespaceAware);
+        }
+
+        /**
+         * parse and get the response body as a {@link Document DOM document}
+         *
+         * @param encoding
+         *            xml charset encoding
+         * @return a DOM document
+         */
+        public Document getXml(String encoding) {
+            return getXml(encoding, false);
         }
 
         /**
@@ -761,13 +783,15 @@ public class WS extends PlayPlugin {
          * 
          * @param encoding
          *            xml charset encoding
+         * @param namespaceAware
+         *           whether to output XML namespace information in the returned document
          * @return a DOM document
          */
-        public Document getXml(String encoding) {
+        public Document getXml(String encoding, boolean namespaceAware) {
             try {
                 InputSource source = new InputSource(new StringReader(getString()));
                 source.setEncoding(encoding);
-                DocumentBuilder builder = XML.newDocumentBuilder();
+                DocumentBuilder builder = XML.newDocumentBuilder(namespaceAware);
                 return builder.parse(source);
             } catch (Exception e) {
                 throw new RuntimeException(e);

--- a/framework/src/play/libs/XML.java
+++ b/framework/src/play/libs/XML.java
@@ -49,8 +49,13 @@ import play.Logger;
 public class XML {
 
     public static DocumentBuilderFactory newDocumentBuilderFactory() {
+        return newDocumentBuilderFactory(false);
+    }
+
+    public static DocumentBuilderFactory newDocumentBuilderFactory(boolean namespaceAware) {
         try {
             DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+            dbf.setNamespaceAware(namespaceAware);
             dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
             dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
             dbf.setFeature("http://javax.xml.XMLConstants/feature/secure-processing", true);
@@ -62,8 +67,12 @@ public class XML {
     }
 
     public static DocumentBuilder newDocumentBuilder() {
+        return newDocumentBuilder(false);
+    }
+
+    public static DocumentBuilder newDocumentBuilder(boolean namespaceAware) {
         try {
-            return newDocumentBuilderFactory().newDocumentBuilder();
+            return newDocumentBuilderFactory(namespaceAware).newDocumentBuilder();
         } catch (ParserConfigurationException e) {
             throw new RuntimeException(e);
         }
@@ -92,15 +101,30 @@ public class XML {
 
     /**
      * Parse an XML file to DOM
-     * 
+     *
      * @param file
      *            The XML file
      * @return null if an error occurs during parsing.
      *
      */
     public static Document getDocument(File file) {
+        return getDocument(file, false);
+    }
+
+    /**
+     * Parse an XML file to DOM
+     * 
+     * @param file
+     *            The XML file
+     * @param namespaceAware
+     *            whether to output XML namespace information in the returned document
+     *
+     * @return null if an error occurs during parsing.
+     *
+     */
+    public static Document getDocument(File file, boolean namespaceAware) {
         try {
-            return newDocumentBuilder().parse(file);
+            return newDocumentBuilder(namespaceAware).parse(file);
         } catch (SAXException e) {
             Logger.warn("Parsing error when building Document object from xml file '" + file + "'.", e);
         } catch (IOException e) {
@@ -111,15 +135,28 @@ public class XML {
 
     /**
      * Parse an XML string content to DOM
-     * 
+     *
      * @param xml
      *            The XML string
      * @return null if an error occurs during parsing.
      */
     public static Document getDocument(String xml) {
+        return getDocument(xml, false);
+    }
+
+    /**
+     * Parse an XML string content to DOM
+     * 
+     * @param xml
+     *            The XML string
+     * @param namespaceAware
+     *            whether to output XML namespace information in the returned document
+     * @return null if an error occurs during parsing.
+     */
+    public static Document getDocument(String xml, boolean namespaceAware) {
         InputSource source = new InputSource(new StringReader(xml));
         try {
-            return newDocumentBuilder().parse(source);
+            return newDocumentBuilder(namespaceAware).parse(source);
         } catch (SAXException e) {
             Logger.warn("Parsing error when building Document object from xml data.", e);
         } catch (IOException e) {
@@ -130,14 +167,27 @@ public class XML {
 
     /**
      * Parse an XML coming from an input stream to DOM
-     * 
+     *
      * @param stream
      *            The XML stream
      * @return null if an error occurs during parsing.
      */
     public static Document getDocument(InputStream stream) {
+        return getDocument(stream, false);
+    }
+
+    /**
+     * Parse an XML coming from an input stream to DOM
+     * 
+     * @param stream
+     *            The XML stream
+     * @param namespaceAware
+     *            whether to output XML namespace information in the returned document
+     * @return null if an error occurs during parsing.
+     */
+    public static Document getDocument(InputStream stream, boolean namespaceAware) {
         try {
-            return newDocumentBuilder().parse(stream);
+            return newDocumentBuilder(namespaceAware).parse(stream);
         } catch (SAXException e) {
             Logger.warn("Parsing error when building Document object from xml data.", e);
         } catch (IOException e) {

--- a/framework/test-src/play/libs/TestXMLHttpResponse.java
+++ b/framework/test-src/play/libs/TestXMLHttpResponse.java
@@ -1,0 +1,49 @@
+package play.libs;
+
+import play.mvc.Http;
+
+import java.io.InputStream;
+import java.util.List;
+
+public class TestXMLHttpResponse extends WS.HttpResponse {
+    private final String body;
+
+    public TestXMLHttpResponse(final String body) {
+        this.body = body;
+    }
+
+    @Override
+    public Integer getStatus() {
+        return null;
+    }
+
+    @Override
+    public String getStatusText() {
+        return null;
+    }
+
+    @Override
+    public String getHeader(String key) {
+        return null;
+    }
+
+    @Override
+    public List<Http.Header> getHeaders() {
+        return null;
+    }
+
+    @Override
+    public String getString() {
+        return body;
+    }
+
+    @Override
+    public String getString(String encoding) {
+        return body;
+    }
+
+    @Override
+    public InputStream getStream() {
+        return null;
+    }
+}

--- a/framework/test-src/play/libs/XMLTest.java
+++ b/framework/test-src/play/libs/XMLTest.java
@@ -1,10 +1,18 @@
 package play.libs;
 
-import static org.junit.Assert.assertEquals;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 /**
  * Tests for {@link XML} class.
@@ -34,5 +42,64 @@ public class XMLTest {
         assertEquals(
                 stripPreamble(ORIGINAL_DOCUMENT),
                 stripPreamble(outputDocument));
+    }
+
+    @Test
+    public void shouldFindNodesWithXpath() {
+        final Node titleNode = XPath.selectNode("/feed/title", document);
+        assertEquals("title", titleNode.getNodeName());
+    }
+
+    @Test
+    public void shouldNotFindNodesWithXPathAndNamespacesByDefault() {
+        final Map<String, String> namespaces = new HashMap<>();
+        namespaces.put("x", "http://www.w3.org/2005/Atom");
+        final Node titleNode = XPath.selectNode("/x:feed/x:title", document, namespaces);
+        assertNull(titleNode);
+    }
+
+    @Test
+    public void shouldFindNodesWithXpathAndNamespacesFromString() {
+        final Map<String, String> namespaces = new HashMap<>();
+        namespaces.put("x", "http://www.w3.org/2005/Atom");
+        final Document namespaceDocument = XML.getDocument(ORIGINAL_DOCUMENT, true);
+        final Node titleNode = XPath.selectNode("/x:feed/x:title", namespaceDocument, namespaces);
+        assertEquals("title", titleNode.getNodeName());
+    }
+
+    @Test
+    public void shouldFindNodesWithXpathAndNamespacesFromStream() {
+        final Map<String, String> namespaces = new HashMap<>();
+        namespaces.put("x", "http://www.w3.org/2005/Atom");
+        final Document namespaceDocument = XML.getDocument(
+                new ByteArrayInputStream(ORIGINAL_DOCUMENT.getBytes(StandardCharsets.UTF_8)), true);
+        final Node titleNode = XPath.selectNode("/x:feed/x:title", namespaceDocument, namespaces);
+        assertEquals("title", titleNode.getNodeName());
+    }
+
+    @Test
+    public void shouldParseAnXMLResponseBody() {
+        TestXMLHttpResponse  response = new TestXMLHttpResponse(ORIGINAL_DOCUMENT);
+        final Node titleNode = XPath.selectNode("/feed/title", response.getXml());
+        assertEquals("title", titleNode.getNodeName());
+    }
+
+    @Test
+    public void shouldNotParseAnXMLResponseBodyWithNamespaces() {
+        final Map<String, String> namespaces = new HashMap<>();
+        namespaces.put("x", "http://www.w3.org/2005/Atom");
+        TestXMLHttpResponse  response = new TestXMLHttpResponse(ORIGINAL_DOCUMENT);
+        final Node titleNode = XPath.selectNode("/x:feed/x:title", response.getXml(), namespaces);
+        assertNull(titleNode);
+    }
+
+
+    @Test
+    public void shouldParseAnXMLResponseBodyWithNamespaces() {
+        final Map<String, String> namespaces = new HashMap<>();
+        namespaces.put("x", "http://www.w3.org/2005/Atom");
+        TestXMLHttpResponse  response = new TestXMLHttpResponse(ORIGINAL_DOCUMENT);
+        final Node titleNode = XPath.selectNode("/x:feed/x:title", response.getXml(true), namespaces);
+        assertEquals("title", titleNode.getNodeName());
     }
 }


### PR DESCRIPTION
Add method overloads that let you generate documents that you can naviagate with XPath while taking XML namespaces into account.
This adds method to get namespace-aware XML documents from strings, files, input streams and request bodies.
Without this, navigating the documents with XPath always returns null if namespaces are taken into account. I’ve added a few tests to demonstrate the issue.