### PR TITLE
fix(tests): issue #1200, added testing compatibility for jdk9+

### DIFF
--- a/framework/src/play/mvc/Controller.java
+++ b/framework/src/play/mvc/Controller.java
@@ -1234,7 +1234,7 @@ public class Controller implements PlayController, ControllerSupport, LocalVaria
                 }
 
                 if (haveSeenFirstApplicationClass) {
-                    if (className.startsWith("sun.") || className.startsWith("play.")) {
+                    if (shouldBeCheckedForEnhancement(className)) {
                         // we're back into the play framework code...
                         return; // done checking
                     } else {
@@ -1250,6 +1250,17 @@ public class Controller implements PlayController, ControllerSupport, LocalVaria
             }
 
         }
+    }
+
+
+    /**
+     * Checks if the classname is from the jdk, sun or play package and therefore should not be checked for enhancement
+     * @param String className
+     * @return boolean
+     */
+    static boolean shouldBeCheckedForEnhancement(String className)
+    {
+        return className.startsWith("jdk.") || className.startsWith("sun.") || className.startsWith("play.");
     }
 
     protected static <T> void await(Future<T> future, F.Action<T> callback) {

--- a/framework/test-src/play/mvc/ControllerTest.java
+++ b/framework/test-src/play/mvc/ControllerTest.java
@@ -1,0 +1,14 @@
+package play.mvc;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+import static play.mvc.Controller.shouldBeCheckedForEnhancement;
+
+public class ControllerTest{
+    @Test
+    public void jdkAndPlayClassesShouldNeverBeenCheckedForEnhancement() {
+        assertTrue(shouldBeCheckedForEnhancement("sun.blah"));
+        assertTrue(shouldBeCheckedForEnhancement("play.foo"));
+        assertFalse(shouldBeCheckedForEnhancement("com.bar"));
+    }
+}


### PR DESCRIPTION
This solves the "await/Continuations error" when trying to run tests in if you're using jdk9+