### PR TITLE
[#1849] Give tests more fine grained control over what exceptions they expect

### DIFF
--- a/samples-and-tests/just-test-cases/app/controllers/StatusCodes.java
+++ b/samples-and-tests/just-test-cases/app/controllers/StatusCodes.java
@@ -1,0 +1,36 @@
+package controllers;
+
+import play.jobs.Job;
+import play.mvc.Controller;
+import play.mvc.Http.Response;
+
+public class StatusCodes extends Controller {
+
+  public static void justOkay() {
+    renderText("Okay");
+  }
+
+  public static void rendersNotFound() {
+    notFound();
+  }
+
+  public static void rendersUnauthorized() {
+    unauthorized();
+  }
+
+  public static void usesContinuation() {
+    final String text = await(new Job<String>() {
+      @Override
+      public String doJobWithResult() throws Exception {
+        return "Job completed successfully";
+      }
+    }.now());
+    Response.current().status = Integer.valueOf(201);
+    renderText(text);
+  }
+
+  public static void throwsException() throws Exception {
+    throw new UnsupportedOperationException("Whoops");
+  }
+
+}

--- a/samples-and-tests/just-test-cases/app/controllers/Transactional.java
+++ b/samples-and-tests/just-test-cases/app/controllers/Transactional.java
@@ -19,9 +19,8 @@ public class Transactional extends Controller {
         tag2.name = "TransactionalTest";
         post.tags.add(tag1);
         post.tags.add(tag2);
-        post.save();
-        // since this is read only the count will not go up with successive 
-        // calls as the Post we just stored will be rolled back
+        post.save(); // since this is read only the request will fail with javax.persistence.TransactionRequiredException
+
         renderText("Wrote 1 post: total is now " + Post.count());
     }
 

--- a/samples-and-tests/just-test-cases/app/controllers/WithContinuations.java
+++ b/samples-and-tests/just-test-cases/app/controllers/WithContinuations.java
@@ -163,14 +163,14 @@ public class WithContinuations extends Controller {
     
     public static void streamedResult() {
         response.contentType = "text/html";
-        response.writeChunk("<h1>This page should load progressively in about 3 second</h1>");
+        response.writeChunk("<h1>This page should load progressively in about a few seconds</h1>");
         long s = System.currentTimeMillis();
         for(int i=0; i<100; i++) {
             await(10);
             response.writeChunk("<h2>Hello " + i + "</h2>");
         }
         long t = System.currentTimeMillis() - s;
-        response.writeChunk("Time: " + t + ", isOk->" + (t > 1000 && t < 10000));
+        response.writeChunk("Time: " + t + ", isOk->" + (t > 1000 && t < 25000));
     }
     
     public static void loopWithCallback() {
@@ -206,7 +206,7 @@ public class WithContinuations extends Controller {
                     await(10, this);
                 } else {
                     long t = System.currentTimeMillis() - s.get();
-                    response.writeChunk("Time: " + t + ", isOk->" + (t > 1000 && t < 10000));
+                    response.writeChunk("Time: " + t + ", isOk->" + (t > 1000 && t < 25000));
                 }                
             }
         };

--- a/samples-and-tests/just-test-cases/conf/routes
+++ b/samples-and-tests/just-test-cases/conf/routes
@@ -83,5 +83,11 @@ GET     /databinding/changeLanguage/{lang}/?                DataBinding.changeLa
 
 GET		/useAwaitViaOtherClass				WithContinuations.ControllerWithoutContinuations.useAwaitViaOtherClass
 
+GET   /status/ok/             StatusCodes.justOkay
+GET   /status/not-found/      StatusCodes.rendersNotFound
+GET   /status/unauthorized/   StatusCodes.rendersUnauthorized
+POST  /status/job/            StatusCodes.usesContinuation
+GET   /status/failure/        StatusCodes.throwsException
+
 # module
 *         /               module:secure

--- a/samples-and-tests/just-test-cases/test/BinaryTest.java
+++ b/samples-and-tests/just-test-cases/test/BinaryTest.java
@@ -28,7 +28,7 @@ public class BinaryTest extends FunctionalTest {
         Response deletedResponse = GET(deleteURL);
         assertStatus(200, deletedResponse);
     }
-    
+
     @Test
     public void testUploadSomething() {
         URL imageURL = reverse(); {
@@ -235,11 +235,13 @@ public class BinaryTest extends FunctionalTest {
         assertTrue(Binary.emptyInputStreamClosed);
     }
 
-    @Test
+    @Test(expected = Exception.class)
     public void testGetErrorBinary() {
-        Response response = GET("/binary/getErrorBinary");
-        // This does not work. See Lighthouse ticket #1637.
-        // assertStatus(500, response);
-        assertTrue(Binary.errorInputStreamClosed);
+        try {
+            GET("/binary/getErrorBinary");
+        }
+        finally {
+            assertTrue(Binary.errorInputStreamClosed);
+        }
     }
 }

--- a/samples-and-tests/just-test-cases/test/TransactionalJPATest.java
+++ b/samples-and-tests/just-test-cases/test/TransactionalJPATest.java
@@ -2,16 +2,13 @@ import org.junit.Test;
 
 import play.mvc.Http.Response;
 import play.test.FunctionalTest;
+import javax.persistence.TransactionRequiredException;
 
 public class TransactionalJPATest extends FunctionalTest {
     
-    @Test
+    @Test(expected = TransactionRequiredException.class)
     public void testImport() {
         Response response = GET("/Transactional/readOnlyTest");
-        assertIsOk(response);
-        response = GET("/Transactional/echoHowManyPosts");
-        assertIsOk(response);
-        assertEquals("There are 0 posts", getContent(response));
     }
     
     @Test


### PR DESCRIPTION
* [#1849] Fixed that exceptions from controllers are being ignored
* [#1849] Adapted BinaryTest to reflect corrected expectations
* [#1849] Added test cases that show the unexpected behavior
* [#1849] Made an unrelated test a little bit more robust against timing issues
* Fixed issue with Transactional Tests
* Fixed issue with Static test

cf #1849, #1246 