### PR TITLE
[#1849] restore checks in TransactionalJPATest that were accidentally deleted in PR 1246

### DIFF
--- a/samples-and-tests/just-test-cases/app/controllers/Binary.java
+++ b/samples-and-tests/just-test-cases/app/controllers/Binary.java
@@ -1,16 +1,16 @@
 package controllers;
 
-import play.*;
+import models.UserWithAvatar;
 import play.data.Upload;
-import play.mvc.*;
+import play.mvc.Controller;
+import play.mvc.Http;
 import play.test.Fixtures;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.util.*;
-
-import models.*;
-import play.vfs.VirtualFile;
-import java.io.*;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
 
 public class Binary extends Controller {
     
@@ -114,12 +114,12 @@ public class Binary extends Controller {
 
         @Override
         public int read() throws IOException {
-            throw new IOException();
+            throw new IOException("io ups");
         }
 
         @Override
         public int read(byte[] b, int off, int len) throws IOException {
-            throw new IOException();
+            throw new IOException("io failed");
         }
 
         @Override
@@ -128,7 +128,7 @@ public class Binary extends Controller {
         }
 
         @Override
-        public void close() throws IOException {
+        public void close() {
             errorInputStreamClosed = true;
         }
     }

--- a/samples-and-tests/just-test-cases/test/BinaryTest.java
+++ b/samples-and-tests/just-test-cases/test/BinaryTest.java
@@ -1,20 +1,17 @@
-import java.io.File;
-import java.util.HashMap;
-import java.util.Map;
-
+import controllers.Binary;
 import org.junit.Before;
 import org.junit.Test;
-
-import play.Logger;
 import play.Play;
-import play.data.MemoryUpload;
-import play.data.Upload;
-import play.mvc.Http;
+import play.exceptions.UnexpectedException;
 import play.mvc.Http.Response;
-import play.mvc.results.Redirect;
 import play.test.Fixtures;
 import play.test.FunctionalTest;
-import controllers.Binary;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
 
 public class BinaryTest extends FunctionalTest {
 
@@ -235,10 +232,17 @@ public class BinaryTest extends FunctionalTest {
         assertTrue(Binary.emptyInputStreamClosed);
     }
 
-    @Test(expected = Exception.class)
+    @Test
     public void testGetErrorBinary() {
         try {
             GET("/binary/getErrorBinary");
+            fail("expected wrapped IOException");
+        }
+        catch (RuntimeException expected) {
+            assertTrue(expected.getCause() instanceof ExecutionException);
+            assertTrue(expected.getCause().getCause() instanceof UnexpectedException);
+            assertTrue(expected.getCause().getCause().getCause() instanceof IOException);
+            assertEquals("io failed", expected.getCause().getCause().getCause().getMessage());
         }
         finally {
             assertTrue(Binary.errorInputStreamClosed);

--- a/samples-and-tests/just-test-cases/test/FunctionalTestTest.java
+++ b/samples-and-tests/just-test-cases/test/FunctionalTestTest.java
@@ -1,17 +1,19 @@
-import org.junit.*;
-
-import play.test.*;
-import play.libs.WS;
-import play.mvc.Http.*;
-import play.mvc.results.*;
-import models.*;
+import models.User;
+import org.junit.Test;
+import play.mvc.Http.Cookie;
+import play.mvc.Http.Request;
+import play.mvc.Http.Response;
+import play.mvc.results.NotFound;
+import play.test.Fixtures;
+import play.test.FunctionalTest;
+import play.test.UnitTest;
 
 import java.util.HashMap;
 
 public class FunctionalTestTest extends FunctionalTest {
     
     @org.junit.Before
-    public void setUp() throws Exception {
+    public void setUp() {
         Fixtures.deleteDatabase();
         Fixtures.loadModels("users.yml");
     }
@@ -115,17 +117,17 @@ public class FunctionalTestTest extends FunctionalTest {
     
     @Test
     public void canGetRenderArgs() {
-	Response response = GET("/users/edit");
+        Response response = GET("/users/edit");
         assertIsOk(response);
         assertNotNull(renderArgs("u"));
         User u = (User) renderArgs("u");
         assertEquals("Guillaume", u.name);
     }
     
-    @Test(expected = RenderStatic.class)
+    @Test
     public void testGettingStaticFile() {
-	Response response = GET("/public/session.test?req=1");
-	assertIsOk(response);
+        Response response = GET("/public/session.test?req=1");
+        assertIsStaticFile(response, "public/session.test");
     }
     
       /**

--- a/samples-and-tests/just-test-cases/test/TransactionalJPATest.java
+++ b/samples-and-tests/just-test-cases/test/TransactionalJPATest.java
@@ -6,9 +6,17 @@ import javax.persistence.TransactionRequiredException;
 
 public class TransactionalJPATest extends FunctionalTest {
     
-    @Test(expected = TransactionRequiredException.class)
+    @Test
     public void testImport() {
-        Response response = GET("/Transactional/readOnlyTest");
+        try {
+            GET("/Transactional/readOnlyTest");
+            throw new AssertionError("expected TransactionRequiredException");
+        }
+        catch (TransactionRequiredException expected) {
+        }
+        Response response = GET("/Transactional/echoHowManyPosts");
+        assertIsOk(response);
+        assertEquals("There are 0 posts", getContent(response));
     }
     
     @Test


### PR DESCRIPTION
P.S. it implements my comments for PR https://github.com/playframework/play1/pull/1246
* [#1849]  improve design of BinaryTest
        P.S. it implements my comments for PR https://github.com/playframework/play1/pull/1246
* [#1849]  add method assertIsStaticFile() and special case allowing to test RenderStatic in functional tests
        P.S. it implements my comments for PR https://github.com/playframework/play1/pull/1246

cf #1849, #1246, #1248 