### PR TITLE
Add BigInteger binding

### DIFF
--- a/framework/src/play/data/binding/Binder.java
+++ b/framework/src/play/data/binding/Binder.java
@@ -14,6 +14,7 @@ import java.io.File;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.*;
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.text.ParseException;
 import java.time.LocalDateTime;
 import java.util.*;
@@ -788,6 +789,11 @@ public abstract class Binder {
         // BigDecimal binding
         if (clazz.equals(BigDecimal.class)) {
             return nullOrEmpty ? null : new BigDecimal(value);
+        }
+
+        // BigInteger binding
+        if (clazz.equals(BigInteger.class)) {
+            return nullOrEmpty ? null : new BigInteger(value);
         }
 
         // boolean or Boolean binding

--- a/framework/test-src/play/data/binding/BinderTest.java
+++ b/framework/test-src/play/data/binding/BinderTest.java
@@ -9,6 +9,7 @@ import play.data.validation.ValidationPlugin;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.*;
 
 import static java.math.BigDecimal.TEN;
@@ -330,6 +331,18 @@ public class BinderTest {
         public Object bind(String name, Annotation[] annotations, String value, Class actualClass, Type genericType) throws Exception {
             return new BigDecimal(value).add(TEN);
         }
+    }
+
+    @Test
+    public void verify_binding_of_BigInteger() {
+        Map<String, Object> r = new HashMap<>();
+
+        BigInteger myBigInt = new BigInteger("12");
+        Integer myBigIntAsInteger = 12;
+        Unbinder.unBind(r, myBigIntAsInteger, "myBigInt", noAnnotations);
+        Map<String, String[]> r2 = fromUnbindMap2BindMap(r);
+        RootParamNode root = ParamNode.convert(r2);
+        assertThat(Binder.bind(root, "myBigInt", BigInteger.class, null, null)).isEqualTo(myBigInt);
     }
 }
 


### PR DESCRIPTION
There seems to be most basic types in the Binder but
BigInteger was missing, even though BigDecimal was present.
Without the BigInteger binding fixtures for models using this type
will not load.

Fixes #1268
