### PR TITLE
Fix Controller.shouldBeCheckedForEnhancement method

### DIFF
--- a/framework/src/play/mvc/Controller.java
+++ b/framework/src/play/mvc/Controller.java
@@ -1234,8 +1234,7 @@ public class Controller implements PlayController, ControllerSupport, LocalVaria
                 }
 
                 if (haveSeenFirstApplicationClass) {
-                    if (shouldBeCheckedForEnhancement(className)) {
-                        // we're back into the play framework code...
+                    if (enhancementCheckComplete(className)) {
                         return; // done checking
                     } else {
                         // is this class enhanced?
@@ -1254,12 +1253,12 @@ public class Controller implements PlayController, ControllerSupport, LocalVaria
 
 
     /**
-     * Checks if the classname is from the jdk, sun or play package and therefore should not be checked for enhancement
+     * Checks if the classname is from the jdk, sun, or play package. These packages indicate that stack inspection is
+     * back into framework code and the enhancement check is complete.
      * @param String className
      * @return boolean
      */
-    static boolean shouldBeCheckedForEnhancement(String className)
-    {
+    static boolean enhancementCheckComplete(String className) {
         return className.startsWith("jdk.") || className.startsWith("sun.") || className.startsWith("play.");
     }
 

--- a/framework/test-src/play/mvc/ControllerTest.java
+++ b/framework/test-src/play/mvc/ControllerTest.java
@@ -2,13 +2,14 @@ package play.mvc;
 
 import org.junit.Test;
 import static org.junit.Assert.*;
-import static play.mvc.Controller.shouldBeCheckedForEnhancement;
+import static play.mvc.Controller.enhancementCheckComplete;
 
 public class ControllerTest{
     @Test
     public void jdkAndPlayClassesShouldNeverBeenCheckedForEnhancement() {
-        assertTrue(shouldBeCheckedForEnhancement("sun.blah"));
-        assertTrue(shouldBeCheckedForEnhancement("play.foo"));
-        assertFalse(shouldBeCheckedForEnhancement("com.bar"));
+        assertTrue(enhancementCheckComplete("sun.blah"));
+        assertTrue(enhancementCheckComplete("jdk.base"));
+        assertTrue(enhancementCheckComplete("play.foo"));
+        assertFalse(enhancementCheckComplete("com.bar"));
     }
 }


### PR DESCRIPTION
Rename the method Controller.shouldBeCheckedForEnhancement to Controller.enhancementCheckComplete to accurately reflect what the code is doing. Addresses issue https://github.com/playframework/play1/issues/1271.
