### PR TITLE
Fix : Check multiple profile

### DIFF
--- a/modules/secure/app/controllers/Secure.java
+++ b/modules/secure/app/controllers/Secure.java
@@ -29,11 +29,16 @@ public class Secure extends Controller {
     }
 
     private static void check(Check check) throws Throwable {
+        boolean hasOne = false;
         for(String profile : check.value()) {
             boolean hasProfile = (Boolean)Security.invoke("check", profile);
-            if(!hasProfile) {
-                Security.invoke("onCheckFailed", profile);
+            if (hasProfile) {
+                hasOne = true;
+                break;
             }
+        }
+        if(!hasOne) {
+            Security.invoke("onCheckFailed", profile);
         }
     }
 


### PR DESCRIPTION
This fix allow multiple profile check with the secure module because the original method only allow user having all specified profiles to access the resource. 
It is now possible to add a list of granted profile to a controller or method :
```java
@With(Secure.class)
@Check({"ADMIN","MANAGER"})
public class MyManageableController extends Controller {
    ...
}
```
AdminUser(role=ADMIN) and ManagerUser(role=MANAGER) will both be granted.