### PR TITLE
HikariCP: config property for init connection sql added

### DIFF
--- a/documentation/manual/configuration.textile
+++ b/documentation/manual/configuration.textile
@@ -527,6 +527,12 @@ c3p0 is very asynchronous. Slow JDBC operations are generally performed by helpe
 Default: @3@
 
 
+h3(#db.pool.connectionInitSql). db.pool.connectionInitSql
+
+Sets the SQL string that will be executed on all new connections when they are created, before they are added to the pool (HikariCP only).
+
+Default: none
+
 h2(#evolutions). Database evolutions
 
 

--- a/framework/src/play/db/hikaricp/HikariDataSourceFactory.java
+++ b/framework/src/play/db/hikaricp/HikariDataSourceFactory.java
@@ -36,6 +36,10 @@ public class HikariDataSourceFactory implements DataSourceFactory {
     ds.setLoginTimeout(parseInt(dbConfig.getProperty("db.pool.loginTimeout", "0"))); // in seconds
     ds.setMaxLifetime(parseLong(dbConfig.getProperty("db.pool.maxConnectionAge", "0"))); // in ms
 
+    if (dbConfig.getProperty("db.pool.connectionInitSql") != null) {
+      ds.setConnectionInitSql(dbConfig.getProperty("db.pool.connectionInitSql"));
+    }
+    
     // not used in HikariCP:
     // db.pool.initialSize
     // db.pool.idleConnectionTestPeriod


### PR DESCRIPTION
Hikari supports setConnectionInitSql() to register custom SQL to initialize a new connection. This is handy to configure the character set for the connection (e.g. "SET NAMES utf8mb4" in MySQL to make emojis etc. work ;)
I added a play config option to setup this property.