### PR TITLE
Adds exit codes to play deps command

### DIFF
--- a/framework/src/play/deps/DependenciesManager.java
+++ b/framework/src/play/deps/DependenciesManager.java
@@ -67,10 +67,12 @@ public class DependenciesManager {
             System.out.println("~");
             System.out.println("~ Some dependencies are still missing.");
             System.out.println("~");
+            System.exit(1);
         } else {
             System.out.println("~");
             System.out.println("~ Done!");
             System.out.println("~");
+            System.exit(0);
         }
     }
 


### PR DESCRIPTION
## Purpose

This commit adds a non-zero exit code to the "play deps" command, allowing scripts to check if the dependencies were properly fetch or not.

## Background Context

We needed to be able to check how the dependencies fetching went for our integration process
