### PR TITLE
[#1312] stylesheet.tag missing trailing slash in documentation

### DIFF
--- a/documentation/manual/tags.textile
+++ b/documentation/manual/tags.textile
@@ -570,10 +570,11 @@ h2. <a name="stylesheet">stylesheet</a>
 
 Inserts a @link@ tag in the template. By convention, the tag refers to a CSS file in @/public/stylesheets@
 
-* @src@ (required) - file name, without the leading path @/public/stylesheets@
-* @id@ (optional) - an @id@ attribute value for the generated @link@ tag
-* @media@ (optional) - a @media@ attribute value: screen, print, aural, projection…
+* @src@ (required) - file name without the leading path
+* @id@ (optional) - @id@ attribute value for the generated @link@ tag
+* @media@ (optional) - @media@ attribute value: screen, print, aural, projection…
 * @title@ (optional) - @title@ attribute value (or description)
+* @path@ (optional) - leading path (default: "/public/stylesheets/")
 
 The @src@ parameter can be replaced by the default @arg@ argument.
 

--- a/documentation/manual_ja/tags.textile
+++ b/documentation/manual_ja/tags.textile
@@ -535,10 +535,11 @@ h2. <a name="stylesheet">stylesheet</a>
 
 テンプレートに @link@ タグを挿入します。利便性のため、このタグは @/public/stylesheets@ 内の CSS ファイルを参照します。
 
-* @src@ (必須) - @/public/stylesheets@ パスを含まないファイル名
+* @src@ (必須) - @/public/stylesheets/@ パスを含まないファイル名
 * @id@ (オプション) - 生成された @link@ タグの @id@ 属性の値
 * @media@ (オプション) - @media@ 属性の値: screen, print, aural, projection…
 * @title@ (オプション) - @title@ 属性の値 (または説明)
+* @path@ (オプション)
 
 @src@ パラメータはデフォルトの @arg@ 引数に置き換えることもできます。
 

--- a/framework/templates/tags/stylesheet.tag
+++ b/framework/templates/tags/stylesheet.tag
@@ -1,11 +1,11 @@
 *{
  *  create a link element for a CSS file
- *    src   (required) filename without the leading path (default:"/public/stylesheets")
- *    id    (optional) an id attribute for the generated link tag
- *    media (optional) media : screen, print, aural, projection ...
- *    title (optional) title attribute (or description)
- *    path  (optional) : sets the path defaults to "/public/stylesheets"
- *    ${stylesheet src:'default.css' media:'screen,print' /}
+ *    src   (required) filename without the leading path
+ *    id    (optional) id attribute for the generated link tag
+ *    media (optional) media attribute value: screen, print, aural, projection...
+ *    title (optional) title attribute value (or description)
+ *    path  (optional) leading path (default: "/public/stylesheets/")
+ *    ${stylesheet src:'default.css', media:'screen,print' /}
 }*
 %{
     (_arg ) && (_src = _arg);


### PR DESCRIPTION
The documentation of stylesheet.tag refers to default leading path

`/public/stylesheets`

instead of

`/public/stylesheets/`

The documentation also lacks the path attribute (which should be set to a path with a trailing slash).