### PR TITLE
[#1935] Don't create CPU*2 "New I/O worker" threads for unused ports

### DIFF
--- a/framework/src/play/server/Server.java
+++ b/framework/src/play/server/Server.java
@@ -63,11 +63,13 @@ public class Server {
             Logger.error(e, "Could not understand https.address");
             Play.fatalServerErrorOccurred();
         }
-        ServerBootstrap bootstrap = new ServerBootstrap(new NioServerSocketChannelFactory(
-                Executors.newCachedThreadPool(), Executors.newCachedThreadPool())
-        );
+
         try {
             if (httpPort != -1) {
+                ServerBootstrap bootstrap = new ServerBootstrap(new NioServerSocketChannelFactory(
+                        Executors.newCachedThreadPool(), Executors.newCachedThreadPool())
+                );
+
                 bootstrap.setPipelineFactory(new HttpServerPipelineFactory());
 
                 bootstrap.bind(new InetSocketAddress(address, httpPort));
@@ -94,12 +96,12 @@ public class Server {
             Play.fatalServerErrorOccurred();
         }
 
-        bootstrap = new ServerBootstrap(new NioServerSocketChannelFactory(
-                Executors.newCachedThreadPool(), Executors.newCachedThreadPool())
-        );
-
         try {
             if (httpsPort != -1) {
+                ServerBootstrap bootstrap = new ServerBootstrap(new NioServerSocketChannelFactory(
+                        Executors.newCachedThreadPool(), Executors.newCachedThreadPool())
+                );
+
                 bootstrap.setPipelineFactory(new SslHttpServerPipelineFactory());
                 bootstrap.bind(new InetSocketAddress(secureAddress, httpsPort));
                 bootstrap.setOption("child.tcpNoDelay", true);


### PR DESCRIPTION
This change avoids creating `ServerBootstrap` objects which are never bound to a port (for example, not creating the HTTPS server if the application doesn't have a `https.port` configured).  
The change is simple, it only moves the code which instantiates these objects into the following if statement.  Netty creates 2*(number of processor) "New I/O worker" threads when a `NioServerSocketChannelFactory` object is created, so this change avoids creating lots of threads that the application never uses.

For example, on a machine with 16 CPUs, this eliminates the creation of 32 threads that would otherwise exist for the lifetime of the Play server and never execute.  The benefit for eliminating these threads:

- Less thread pollution when viewing a Play! JVM with tools like jstack or visualvm.
- Less memory use.
- For organizations which impose a process limit on GNU/Linux systems, these threads counted against the user's process quota.  These excess threads prevented some developers from running applications on some machines.

## Background Context
The Play! code has been like this since at least 1.2.7, but the excess thread creation didn't exist until 1.3.0 when an update to the netty library changed the location from which Netty creates the threads.

In my organization, we run dozens of Play! applications on a machine with many CPUs and each of these Play! applications only has `http.port` configured (no `https.port`).  End users access these Play! servers through a reverse proxy that provides the HTTPS connection.  For us, the reduction in thread usage is noticeable.