### PR TITLE
GitHub issue #1278: OrderBy support in simplified JPA queries for 1.5.x

### DIFF
--- a/documentation/manual/jpa.textile
+++ b/documentation/manual/jpa.textile
@@ -118,6 +118,8 @@ bc. Post.find("byTitle", "My first post").fetch();
 Post.find("byTitleLike", "%hello%").fetch();
 Post.find("byAuthorIsNull").fetch();
 Post.find("byTitleLikeAndAuthor", "%hello%", connectedUser).fetch();
+Post.find("byTitleOrderByTitle", "%hello%").fetch(); //default for order is asc
+Post.find("byTitleOrderByNbCommentsDesc", "%hello%").fetch();
 
 Simple queries follow the following syntax <code>==[Property][Comparator]And?==</code> where Comparator can be the following:
 

--- a/documentation/manual/jpa.textile
+++ b/documentation/manual/jpa.textile
@@ -135,10 +135,14 @@ Simple queries follow the following syntax <code>==[Property][Comparator]And?[Or
 * @IsNotNull@ - Not a null value (doesn't require an argument)
 * @IsNull@ - Is a null value (doesn't require an argument)
 
-and Orderdirective can be (for a property named @property@) :
+and Orderdirective can be (e.g for a property named @name@) :
 
-* @OrderByProperty@ - default ascending order
-* @OrderByPropertyDesc@ - descending order
+* @OrderByName@ - default ascending order
+* @OrderByNameDesc@ - descending order
+
+you can also use several attributes in Orderdirective :  
+* @OrderByNameAndAge@
+* @OrderByNameAndAgeDesc@
 
 h3. Find using a JPQL query
 

--- a/documentation/manual/jpa.textile
+++ b/documentation/manual/jpa.textile
@@ -118,10 +118,10 @@ bc. Post.find("byTitle", "My first post").fetch();
 Post.find("byTitleLike", "%hello%").fetch();
 Post.find("byAuthorIsNull").fetch();
 Post.find("byTitleLikeAndAuthor", "%hello%", connectedUser).fetch();
-Post.find("byTitleOrderByTitle", "%hello%").fetch(); //default for order is asc
-Post.find("byTitleOrderByNbCommentsDesc", "%hello%").fetch();
+Post.find("byTitleOrderByTitle", "A nice post").fetch();
+Post.find("byTitleOrderByNbCommentsDesc", "A nice post").fetch();
 
-Simple queries follow the following syntax <code>==[Property][Comparator]And?==</code> where Comparator can be the following:
+Simple queries follow the following syntax <code>==[Property][Comparator]And?[Orderdirective]?==</code> where Comparator can be the following:
 
 * @LessThan@ - less than the given value
 * @LessThanEquals@ - less than or equal a give value
@@ -134,6 +134,11 @@ Simple queries follow the following syntax <code>==[Property][Comparator]And?==<
 * @Between@ - Between two values (requires two arguments)
 * @IsNotNull@ - Not a null value (doesn't require an argument)
 * @IsNull@ - Is a null value (doesn't require an argument)
+
+and Orderdirective can be (for a property named @property@) :
+
+* @OrderByProperty@ - default ascending order
+* @OrderByPropertyDesc@ - descending order
 
 h3. Find using a JPQL query
 

--- a/framework/src/play/db/jpa/JPQL.java
+++ b/framework/src/play/db/jpa/JPQL.java
@@ -248,11 +248,7 @@ public class JPQL {
     public String findByToJPQL(String dbName, String findBy) {
         findBy = findBy.substring(2);
         StringBuilder jpql = new StringBuilder();
-        String subRequest;
-        if (findBy.contains("OrderBy"))
-            subRequest = findBy.split("OrderBy")[0];
-        else subRequest = findBy;
-        String[] parts = subRequest.split("And");
+        String[] parts = findBy.split("And");
         int index = 1;
         for (int i = 0; i < parts.length; i++) {
             String part = parts[i];

--- a/framework/src/play/db/jpa/JPQL.java
+++ b/framework/src/play/db/jpa/JPQL.java
@@ -248,7 +248,11 @@ public class JPQL {
     public String findByToJPQL(String dbName, String findBy) {
         findBy = findBy.substring(2);
         StringBuilder jpql = new StringBuilder();
-        String[] parts = findBy.split("And");
+        String subRequest;
+        if (findBy.contains("OrderBy"))
+        	subRequest = findBy.split("OrderBy")[0];
+        else subRequest = findBy;
+        String[] parts = subRequest.split("And");
         int index = 1;
         for (int i = 0; i < parts.length; i++) {
             String part = parts[i];
@@ -305,6 +309,22 @@ public class JPQL {
                 jpql.append(" AND ");
             }
         }
+		// ORDER BY clause
+		if (findBy.contains("OrderBy")) {
+			jpql.append(" ORDER BY ");
+			String orderQuery = findBy.split("OrderBy")[1];
+			parts = orderQuery.split("And");
+			for (int i = 0; i < parts.length; i++) {
+				String part = parts[i];
+				String orderProp;
+				if (part.endsWith("Desc"))
+					orderProp = extractProp(part, "Desc") + " DESC";
+				else orderProp = part.toLowerCase();
+				if (i > 0)
+					jpql.append(", ");
+				jpql.append(orderProp);
+			}
+		}
         return jpql.toString();
     }
 

--- a/framework/test-src/play/db/jpa/JPQLTest.java
+++ b/framework/test-src/play/db/jpa/JPQLTest.java
@@ -1,0 +1,52 @@
+package play.db.jpa;
+
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Properties;
+import java.util.Set;
+
+import static play.db.jpa.JPQL.extractProp;
+
+import static org.junit.Assert.*;
+
+public class JPQLTest {
+
+	static JPQL jpql;
+
+	@BeforeClass
+	public static void setup(){
+		jpql = new JPQL(null);
+	}
+
+    @Test
+    public void testOrder() {
+
+        String query = "ByNameOrderByName";
+        String result = jpql.findByToJPQL(query);
+        assertTrue(result.endsWith(" ORDER BY name"));
+
+        query = "ByNameOrderByNameAndAge";
+        result = jpql.findByToJPQL(query);
+        assertTrue(result.endsWith(" ORDER BY name, age"));
+
+        query = "ByNameOrderByNameDesc";
+        result = jpql.findByToJPQL(query);
+        assertTrue(result.endsWith(" ORDER BY name DESC"));
+
+        query = "ByNameOrderByNameDescAndAge";
+        result = jpql.findByToJPQL(query);
+        assertTrue(result.endsWith(" ORDER BY name DESC, age"));
+
+        query = "ByNameOrderByNameAndAgeDesc";
+        result = jpql.findByToJPQL(query);
+        assertTrue(result.endsWith(" ORDER BY name, age DESC"));
+
+        query = "ByNameOrderByNameDescAndAgeDesc";
+        result = jpql.findByToJPQL(query);
+        assertTrue(result.endsWith(" ORDER BY name DESC, age DESC"));
+
+    }
+	
+}

--- a/framework/test-src/play/db/jpa/JPQLTest.java
+++ b/framework/test-src/play/db/jpa/JPQLTest.java
@@ -17,7 +17,7 @@ public class JPQLTest {
 
 	@BeforeClass
 	public static void setup(){
-		jpql = new JPQL(null);
+		jpql = new JPQL();
 	}
 
     @Test


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you updated the documentation? Not me, but the original author!
* [x] Have you added tests for any changed functionality? Not me, but the original author!

# Helpful things

## Purpose

This pull request:
* fixes an `old_master` -> `master` port of an old, unrelated pull request (#504) where some parts of "OrderBy" change sneaked in
* ports those `[#878] Add OrderBy support in simplified queries` commits which were never ported to new `master`

## Background Context

I voted for creating a preparing commit to make the cherry picking as seamless as possible.
I added `(cherry picked from commit xxxxxx)` the cherry picked commits to make it clear this is an `old_master` -> `master` port

I could add a whitespace fixup commit, as the original commits used TABs for indentation.


## References

All details are in the original issue: #1278