### PR TITLE
GH-1328: Added SameSite support for session cookie.

### DIFF
--- a/framework/src/play/data/validation/ValidationPlugin.java
+++ b/framework/src/play/data/validation/ValidationPlugin.java
@@ -159,7 +159,7 @@ public class ValidationPlugin extends PlayPlugin {
         if (Validation.errors().isEmpty()) {
             // Only send "delete cookie" header when the cookie was present in the request
             if(Http.Request.current().cookies.containsKey(Scope.COOKIE_PREFIX + "_ERRORS") || !Scope.SESSION_SEND_ONLY_IF_CHANGED) {
-                Http.Response.current().setCookie(Scope.COOKIE_PREFIX + "_ERRORS", "", null, "/", 0, Scope.COOKIE_SECURE, Scope.SESSION_HTTPONLY);
+                Http.Response.current().setCookie(Scope.COOKIE_PREFIX + "_ERRORS", "", null, "/", 0, Scope.COOKIE_SECURE, Scope.SESSION_HTTPONLY, Scope.SESSION_SAMESITE);
             }
             return;
         }
@@ -179,7 +179,7 @@ public class ValidationPlugin extends PlayPlugin {
                 }
             }
             String errorsData = URLEncoder.encode(errors.toString(), "utf-8");
-            Http.Response.current().setCookie(Scope.COOKIE_PREFIX + "_ERRORS", errorsData, null, "/", null, Scope.COOKIE_SECURE, Scope.SESSION_HTTPONLY);
+            Http.Response.current().setCookie(Scope.COOKIE_PREFIX + "_ERRORS", errorsData, null, "/", null, Scope.COOKIE_SECURE, Scope.SESSION_HTTPONLY, Scope.SESSION_SAMESITE);
         } catch (Exception e) {
             throw new UnexpectedException("Errors serializationProblem", e);
         }

--- a/framework/src/play/i18n/Lang.java
+++ b/framework/src/play/i18n/Lang.java
@@ -82,7 +82,7 @@ public class Lang {
             Response response = Response.current();
             if (response != null) {
                 // We have a current response in scope - set the language-cookie to store the selected language for the next requests
-                response.setCookie(Play.configuration.getProperty("application.lang.cookie", "PLAY_LANG"), locale, null, "/", null, Scope.COOKIE_SECURE);
+                response.setCookie(Play.configuration.getProperty("application.lang.cookie", "PLAY_LANG"), locale, null, "/", null, Scope.COOKIE_SECURE, Scope.SESSION_SAMESITE);
             }
         }
 
@@ -155,7 +155,7 @@ public class Lang {
                     return;
                 }
                 // could not use locale from cookie - clear the locale-cookie
-                Response.current().setCookie(cn, "", null, "/", null, Scope.COOKIE_SECURE);
+                Response.current().setCookie(cn, "", null, "/", null, Scope.COOKIE_SECURE, Scope.SESSION_SAMESITE);
 
             }
 

--- a/framework/src/play/mvc/CookieSessionStore.java
+++ b/framework/src/play/mvc/CookieSessionStore.java
@@ -75,7 +75,7 @@ public class CookieSessionStore implements SessionStore {
         if (session.isEmpty()) {
             // The session is empty: delete the cookie
             if (Http.Request.current().cookies.containsKey(COOKIE_PREFIX + "_SESSION") || !SESSION_SEND_ONLY_IF_CHANGED) {
-                Http.Response.current().setCookie(COOKIE_PREFIX + "_SESSION", "", null, "/", 0, COOKIE_SECURE, SESSION_HTTPONLY);
+                Http.Response.current().setCookie(COOKIE_PREFIX + "_SESSION", "", null, "/", 0, COOKIE_SECURE, SESSION_HTTPONLY, SESSION_SAMESITE);
             }
             return;
         }
@@ -84,10 +84,10 @@ public class CookieSessionStore implements SessionStore {
             String sign = Crypto.sign(sessionData, Play.secretKey.getBytes());
             if (COOKIE_EXPIRE == null) {
                 Http.Response.current().setCookie(COOKIE_PREFIX + "_SESSION", sign + "-" + sessionData, null, "/", null, COOKIE_SECURE,
-                        SESSION_HTTPONLY);
+                        SESSION_HTTPONLY, SESSION_SAMESITE);
             } else {
                 Http.Response.current().setCookie(COOKIE_PREFIX + "_SESSION", sign + "-" + sessionData, null, "/",
-                        Time.parseDuration(COOKIE_EXPIRE), COOKIE_SECURE, SESSION_HTTPONLY);
+                        Time.parseDuration(COOKIE_EXPIRE), COOKIE_SECURE, SESSION_HTTPONLY, SESSION_SAMESITE);
             }
         } catch (Exception e) {
             throw new UnexpectedException("Session serializationProblem", e);

--- a/framework/src/play/mvc/Http.java
+++ b/framework/src/play/mvc/Http.java
@@ -163,6 +163,10 @@ public class Http {
          * See http://www.owasp.org/index.php/HttpOnly
          */
         public boolean httpOnly = false;
+        /**
+         * See https://owasp.org/www-community/SameSite
+         */
+        public String sameSite;
     }
 
     /**
@@ -707,8 +711,8 @@ public class Http {
          * @param value
          *            Cookie value
          */
-        public void setCookie(String name, String value) {
-            setCookie(name, value, null, "/", null, false);
+        public void setCookie(String name, String value, String sameSite) {
+            setCookie(name, value, null, "/", null, false, sameSite);
         }
 
         /**
@@ -730,7 +734,7 @@ public class Http {
          *            cookie path
          */
         public void removeCookie(String name, String path) {
-            setCookie(name, "", null, path, 0, false);
+            setCookie(name, "", null, path, 0, false, null);
         }
 
         /**
@@ -743,15 +747,15 @@ public class Http {
          * @param duration
          *            the cookie duration (Ex: 3d)
          */
-        public void setCookie(String name, String value, String duration) {
-            setCookie(name, value, null, "/", Time.parseDuration(duration), false);
+        public void setCookie(String name, String value, String duration, String sameSite) {
+            setCookie(name, value, null, "/", Time.parseDuration(duration), false, sameSite);
         }
 
-        public void setCookie(String name, String value, String domain, String path, Integer maxAge, boolean secure) {
-            setCookie(name, value, domain, path, maxAge, secure, false);
+        public void setCookie(String name, String value, String domain, String path, Integer maxAge, boolean secure, String sameSite) {
+            setCookie(name, value, domain, path, maxAge, secure, false, sameSite);
         }
 
-        public void setCookie(String name, String value, String domain, String path, Integer maxAge, boolean secure, boolean httpOnly) {
+        public void setCookie(String name, String value, String domain, String path, Integer maxAge, boolean secure, boolean httpOnly, String sameSite) {
             path = Play.ctxPath + path;
             if (cookies.containsKey(name) && cookies.get(name).path.equals(path)
                     && ((cookies.get(name).domain == null && domain == null) || (cookies.get(name).domain.equals(domain)))) {
@@ -765,6 +769,7 @@ public class Http {
                 cookie.path = path;
                 cookie.secure = secure;
                 cookie.httpOnly = httpOnly;
+                cookie.sameSite = sameSite;
                 if (domain != null) {
                     cookie.domain = domain;
                 } else {

--- a/framework/src/play/mvc/Scope.java
+++ b/framework/src/play/mvc/Scope.java
@@ -32,6 +32,7 @@ public class Scope {
             .equals("true");
     public static boolean SESSION_SEND_ONLY_IF_CHANGED = Play.configuration
             .getProperty("application.session.sendOnlyIfChanged", "false").toLowerCase().equals("true");
+    public static final String SESSION_SAMESITE = Play.configuration.getProperty("application.session.sameSite");
 
     public static SessionStore sessionStore = createSessionStore();
 
@@ -78,13 +79,13 @@ public class Scope {
             }
             if (out.isEmpty()) {
                 if (Http.Request.current().cookies.containsKey(COOKIE_PREFIX + "_FLASH") || !SESSION_SEND_ONLY_IF_CHANGED) {
-                    Http.Response.current().setCookie(COOKIE_PREFIX + "_FLASH", "", null, "/", 0, COOKIE_SECURE, SESSION_HTTPONLY);
+                    Http.Response.current().setCookie(COOKIE_PREFIX + "_FLASH", "", null, "/", 0, COOKIE_SECURE, SESSION_HTTPONLY, SESSION_SAMESITE);
                 }
                 return;
             }
             try {
                 String flashData = CookieDataCodec.encode(out);
-                Http.Response.current().setCookie(COOKIE_PREFIX + "_FLASH", flashData, null, "/", null, COOKIE_SECURE, SESSION_HTTPONLY);
+                Http.Response.current().setCookie(COOKIE_PREFIX + "_FLASH", flashData, null, "/", null, COOKIE_SECURE, SESSION_HTTPONLY, SESSION_SAMESITE);
             } catch (Exception e) {
                 throw new UnexpectedException("Flash serializationProblem", e);
             }

--- a/framework/src/play/server/PlayHandler.java
+++ b/framework/src/play/server/PlayHandler.java
@@ -45,7 +45,6 @@ import java.nio.charset.Charset;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
-import java.text.ParseException;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -375,7 +374,11 @@ public class PlayHandler extends SimpleChannelUpstreamHandler {
                 c.setMaxAge(cookie.maxAge);
             }
             c.setHttpOnly(cookie.httpOnly);
-            nettyResponse.headers().add(SET_COOKIE, ServerCookieEncoder.STRICT.encode(c));
+            String encodedCookie = ServerCookieEncoder.STRICT.encode(c);
+            if(cookie.sameSite != null) {
+                encodedCookie += "; SameSite=" + cookie.sameSite;
+            }
+            nettyResponse.headers().add(SET_COOKIE, encodedCookie);
         }
 
         if (!response.headers.containsKey(CACHE_CONTROL) && !response.headers.containsKey(EXPIRES)
@@ -792,8 +795,11 @@ public class PlayHandler extends SimpleChannelUpstreamHandler {
                         c.setMaxAge(cookie.maxAge);
                     }
                     c.setHttpOnly(cookie.httpOnly);
-
-                    nettyResponse.headers().add(SET_COOKIE, ServerCookieEncoder.STRICT.encode(c));
+                    String encodedCookie = ServerCookieEncoder.STRICT.encode(c);
+                    if(cookie.sameSite != null) {
+                        encodedCookie += "; SameSite=" + cookie.sameSite;
+                    }
+                    nettyResponse.headers().add(SET_COOKIE, encodedCookie);
                 }
 
             } catch (Exception exx) {

--- a/framework/test-src/play/mvc/HttpResponseTest.java
+++ b/framework/test-src/play/mvc/HttpResponseTest.java
@@ -9,12 +9,30 @@ public class HttpResponseTest {
     public void verifyDefaultCookieDomain() {
         Http.Cookie.defaultDomain = null;
         Http.Response response = new Http.Response();
-        response.setCookie("testCookie", "testValue");
+        response.setCookie("testCookie", "testValue", null);
         assertThat(response.cookies.get("testCookie").domain).isNull();
 
         Http.Cookie.defaultDomain = ".abc.com";
         response = new Http.Response();
-        response.setCookie("testCookie", "testValue");
+        response.setCookie("testCookie", "testValue", null);
         assertThat(response.cookies.get("testCookie").domain).isEqualTo(".abc.com");
+    }
+
+    @Test
+    public void verifySameSiteCookie() {
+        Http.Cookie.defaultDomain = null;
+        Http.Response response = new Http.Response();
+        response.setCookie("testCookie", "testValue", null);
+        assertThat(response.cookies.get("testCookie").sameSite).isNull();
+
+        Http.Cookie.defaultDomain = ".abc.com";
+        response = new Http.Response();
+        response.setCookie("testCookie", "testValue", "lax");
+        assertThat(response.cookies.get("testCookie").sameSite).isEqualTo("lax");
+
+        Http.Cookie.defaultDomain = ".abc.com";
+        response = new Http.Response();
+        response.setCookie("testCookie", "testValue", "strict");
+        assertThat(response.cookies.get("testCookie").sameSite).isEqualTo("strict");
     }
 }

--- a/resources/application-skel/conf/application.conf
+++ b/resources/application-skel/conf/application.conf
@@ -48,6 +48,7 @@ date.format=yyyy-MM-dd
 # application.session.cookie=PLAY
 # application.session.maxAge=1h
 # application.session.secure=false
+# application.session.sameSite=lax
 
 # Session/Cookie sharing between subdomain
 # ~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
# Pull Request Checklist

* [ ] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [ ] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [ ] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixes #1328 

## Purpose

**What does this PR do?**
This PR add support for SameSite attribute on the session cookie (https://owasp.org/www-community/SameSite) 

## Background Context

**Why did you take this approach?**
At first, I created PlayCookie.java which extended Cookie.java, and DefaultPlayCookie.java extending DefaultCookie and implementing PlayCookie because Netty does not support SameSite attribute. 
I realized that for this to work, I had to implement PlayServerCookieEncoder to override encode methods in ServerCookieEncoder and for the encoder to work I had to copy CookieUtil from Netty in to the Play source code as it was package private. It worked, but it was a lot of code copy and duplication.

I refactored the code and ended up with this solution. Instead of implement a new version of ServerCookieEncoder, I call the original encoder (in Playhandler) from Netty and add SameSite at the end of the encoded string if the SameSite attribute is defined.

The SameSite attribute can be defined in "application.conf" with "application.session.sameSite"
Can ble not defined, blank, "None", "lax", "strict". 
Not sure if casing is browser independent. "Lax" and "lax" resulted in "Lax" in Chrome, but "none" was only registered with capital N ("None").

## References

**Are there any relevant issues / PRs / mailing lists discussions?**
Not that IO 
