### PR TITLE
fixed 'play idea' now is correctly for WSL Run GitHub Action on win and fixed test for Windows 

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -49,7 +49,7 @@ jobs:
     needs:
       - testing
     runs-on: ubuntu-latest
-    name: BUILD ${{ GITHUB_SHA }}
+    name: BUILD ${{ github.sha }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -21,7 +21,7 @@ jobs:
           - os: windows-latest
             jdk: 11
 
-    name: Check / Tests -> JDK-${{ matrix.jdk }}/${{ runner.os }}
+    name: Check / Tests -> JDK-${{ matrix.jdk }}/${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -10,13 +10,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
+  testing:
+    runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
         jdk: [ 11, 17 ]
-    name: Check / Tests (JDK ${{ matrix.jdk }})
+        os: [ubuntu-latest, windows-latest]
+        exclude:
+          - os: windows-latest
+            jdk: 11
+
+    name: Check / Tests (JDK ${{ matrix.jdk }} - ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -21,7 +21,7 @@ jobs:
           - os: windows-latest
             jdk: 11
 
-    name: Check / Tests (JDK ${{ matrix.jdk }} - ${{ matrix.os }}
+    name: Check / Tests -> JDK-${{ matrix.jdk }}/${{ runner.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -44,3 +44,39 @@ jobs:
       - name: Build with Ant
         working-directory: ./framework
         run: ant test
+
+  build:
+    needs:
+      - testing
+    runs-on: ubuntu-latest
+    name: BUILD ${{ GITHUB_SHA }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
+          fetch-depth: 0
+
+      - name: Set up python 2
+        uses: actions/setup-python@v2
+        with:
+          python-version: '2.x'
+          architecture: 'x64'
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
+        with:
+          java-version: 17
+          distribution: 'adopt'
+
+      - name: Build with Ant
+        working-directory: ./framework
+        run: ant artifact
+
+      - name: ziping
+        uses: actions/upload-artifact@v2
+        with:
+          name: play-${{ github.sha }}
+          if-no-files-found: error
+          path: |
+            ./framework/dist/*

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -73,7 +73,7 @@ jobs:
         working-directory: ./framework
         run: ant artifact
 
-      - name: ziping
+      - name: ziping artifact
         uses: actions/upload-artifact@v2
         with:
           name: play-${{ github.sha }}

--- a/framework/build.xml
+++ b/framework/build.xml
@@ -420,13 +420,21 @@
         <fail if="junit.failure" message="Unit test(s) failed.  See reports!"/>
     </target>
 
-    <target name="package" depends="clean,version,jar,javadoc">
+    <target name="package" depends="artifact">
         <mkdir dir="dist" />
         <zip destfile="dist/play-${version}.zip" comment="Play! ${version}" update="false">
-            <zipfileset prefix="play-${version}" dir=".." includes="**/*" excludes="**/cobertura.ser,**/*.pyc,hs_err*,.*,.*/*,framework/dist/**,id,play,nbproject/**,**/.bzr/**,**/.git/**,*.bzrignore,support/textmate/**,framework/classes/**,framework/tests-results/**,samples-and-tests/**/test-result,samples-and-tests/**/i-am-working-here,samples-and-tests/**/data,samples-and-tests/**/logs,samples-and-tests/**/tmp,samples-and-tests/**/db,samples-and-tests/**/attachments,modules/**" />
-            <zipfileset prefix="play-${version}" dir=".." includes="play" filemode="777" />
-            <zipfileset prefix="play-${version}" dir=".." includes="modules/grizzly/**,modules/crud/**,modules/secure/**,modules/docviewer/**,modules/testrunner/**" excludes="**/*.pyc" />
+            <zipfileset prefix="play-${version}" dir="dist/play-${version}" includes="**/*" excludes="play" />
+            <zipfileset prefix="play-${version}" dir="dist/play-${version}" includes="play" filemode="777" />
         </zip>
+    </target>
+
+    <target name="artifact" depends="clean,version,jar,javadoc">
+        <mkdir dir="dist" />
+        <mkdir dir="dist/play-${version}" />
+        <copy todir="dist/play-${version}">
+            <fileset dir=".." excludes=".github,**/cobertura.ser,**/*.pyc,hs_err*,.*,.*/*,framework/dist/**,id,nbproject/**,**/.bzr/**,**/.git/**,*.bzrignore,support/textmate/**,framework/classes/**,framework/tests-results/**,samples-and-tests/**/test-result,samples-and-tests/**/i-am-working-here,samples-and-tests/**/data,samples-and-tests/**/logs,samples-and-tests/**/tmp,samples-and-tests/**/db,samples-and-tests/**/attachments,modules/**" />
+            <fileset dir=".." includes="modules/grizzly/**,modules/crud/**,modules/secure/**,modules/docviewer/**,modules/testrunner/**" excludes="**/*.pyc" />
+        </copy>
     </target>
 
 </project>

--- a/framework/pym/play/commands/intellij.py
+++ b/framework/pym/play/commands/intellij.py
@@ -24,7 +24,9 @@ def execute(**kargs):
     shutil.copyfile(os.path.join(play_env["basedir"], 'resources/idea/imlTemplate.xml'), imlFile)
     cpXML = ""
 
-    playHome = play_env["basedir"].replace('\\', '/')
+    playHomeAlternative = app.toRelative(playHome).replace('\\', '/')
+    if playHomeAlternative[0:2] == "..":
+        playHome = "$MODULE_DIR$/" + playHomeAlternative
 
     if os.name == 'nt':
         # On Windows, IntelliJ needs uppercase driveletter
@@ -44,7 +46,9 @@ def execute(**kargs):
         for i, module in enumerate(modules):
             libpath = os.path.join(module, 'lib')
             srcpath = os.path.join(module, 'src')
-            lXML += '        <content url="file://%s">\n            <sourceFolder url="file://%s" isTestSource="false" />\n        </content>\n' % (module, os.path.join(module, 'app').replace('\\', '/'))
+            path = app.toRelative(module).replace('\\', '/')
+            modulePath =  "$MODULE_DIR$/" + path if path[0:2]==".."  else module
+            lXML += '        <content url="file://%s">\n            <sourceFolder url="file://%s" isTestSource="false" />\n        </content>\n' % (modulePath, os.path.join(modulePath, 'app').replace('\\', '/'))
             if os.path.exists(srcpath):
                 msXML += '                    <root url="file://$MODULE_DIR$/%s"/>\n' % (app.toRelative(srcpath).replace('\\', '/'))
             if os.path.exists(libpath):
@@ -54,13 +58,13 @@ def execute(**kargs):
     replaceAll(imlFile, r'%MODULE_LINKS%', mlXML)
     replaceAll(imlFile, r'%MODULE_SOURCES%', msXML)
     replaceAll(imlFile, r'%MODULE_LIBRARIES%', jdXML)
-    
+
     iprFile = os.path.join(app.path, application_name + '.ipr')
     # Only copy/create if missing to avoid overwriting customizations
     if not os.path.exists(iprFile):
         shutil.copyfile(os.path.join(play_env["basedir"], 'resources/idea/iprTemplate.xml'), iprFile)
         replaceAll(iprFile, r'%PROJECT_NAME%', application_name)
-    
+
 
     print "~ OK, the application is ready for Intellij Idea"
     print "~ Use File, Open Project... to open \"" + application_name + ".ipr\""

--- a/framework/test-src/play/templates/FastTagsTest.java
+++ b/framework/test-src/play/templates/FastTagsTest.java
@@ -1,23 +1,23 @@
 package play.templates;
 
-import groovy.lang.Closure;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import play.mvc.Http;
-import play.mvc.Router;
-import play.mvc.Scope;
-
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.HashMap;
 import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+
+import groovy.lang.Closure;
+import play.mvc.Http;
+import play.mvc.Router;
+import play.mvc.Scope;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 
 public class FastTagsTest {
 
+    private static final String LINE_SEPARATOR = System.lineSeparator();
     private StringWriter out = new StringWriter();
 
     @Before
@@ -43,9 +43,8 @@ public class FastTagsTest {
         FastTags._form(args, mock(Closure.class), new PrintWriter(out), null, 0);
 
         assertEquals(
-                "<form action=\"/foo/bar\" method=\"get\" accept-charset=\"UTF-8\" enctype=\"application/x-www-form-urlencoded\" >" + System.lineSeparator() +
-                System.lineSeparator() +
-                "</form>", out.toString());
+                "<form action=\"/foo/bar\" method=\"get\" accept-charset=\"UTF-8\" enctype=\"application/x-www-form-urlencoded\" >" + LINE_SEPARATOR
+                        + LINE_SEPARATOR + "</form>", out.toString());
     }
 
     @Test
@@ -62,9 +61,8 @@ public class FastTagsTest {
         FastTags._form(args, mock(Closure.class), new PrintWriter(out), null, 0);
 
         assertEquals(
-                "<form action=\"/foo/bar\" method=\"get\" accept-charset=\"UTF-8\" enctype=\"application/x-www-form-urlencoded\" name=\"my-form\">" + System.lineSeparator() +
-                System.lineSeparator() +
-                "</form>", out.toString());
+                "<form action=\"/foo/bar\" method=\"get\" accept-charset=\"UTF-8\" enctype=\"application/x-www-form-urlencoded\" name=\"my-form\">"
+                        + LINE_SEPARATOR + LINE_SEPARATOR + "</form>", out.toString());
     }
 
     @Test
@@ -80,10 +78,9 @@ public class FastTagsTest {
         FastTags._form(args, mock(Closure.class), new PrintWriter(out), null, 0);
 
         assertEquals(
-                "<form action=\"/foo/bar\" method=\"post\" accept-charset=\"UTF-8\" enctype=\"application/x-www-form-urlencoded\" >" + System.lineSeparator() +
-                "<input type=\"hidden\" name=\"authenticityToken\" value=\"1234\"/>" + System.lineSeparator() +
-                System.lineSeparator() +
-                "</form>", out.toString());
+                "<form action=\"/foo/bar\" method=\"post\" accept-charset=\"UTF-8\" enctype=\"application/x-www-form-urlencoded\" >" + LINE_SEPARATOR
+                        + "<input type=\"hidden\" name=\"authenticityToken\" value=\"1234\"/>" + LINE_SEPARATOR + LINE_SEPARATOR + "</form>",
+                out.toString());
     }
 
     @Test
@@ -99,10 +96,9 @@ public class FastTagsTest {
         FastTags._form(args, mock(Closure.class), new PrintWriter(out), null, 0);
 
         assertEquals(
-                "<form action=\"/foo/bar\" method=\"post\" accept-charset=\"UTF-8\" enctype=\"application/x-www-form-urlencoded\" >" + System.lineSeparator() +
-                "<input type=\"hidden\" name=\"authenticityToken\" value=\"1234\"/>" + System.lineSeparator() +
-                System.lineSeparator() +
-                "</form>", out.toString());
+                "<form action=\"/foo/bar\" method=\"post\" accept-charset=\"UTF-8\" enctype=\"application/x-www-form-urlencoded\" >" + LINE_SEPARATOR
+                        + "<input type=\"hidden\" name=\"authenticityToken\" value=\"1234\"/>" + LINE_SEPARATOR + LINE_SEPARATOR + "</form>",
+                out.toString());
     }
 
     @Test
@@ -119,10 +115,9 @@ public class FastTagsTest {
         FastTags._form(args, mock(Closure.class), new PrintWriter(out), null, 0);
 
         assertEquals(
-                "<form action=\"/foo/bar\" method=\"post\" accept-charset=\"UTF-8\" enctype=\"application/x-www-form-urlencoded\" >" + System.lineSeparator() +
-                "<input type=\"hidden\" name=\"authenticityToken\" value=\"1234\"/>" + System.lineSeparator() +
-                System.lineSeparator() +
-                "</form>", out.toString());
+                "<form action=\"/foo/bar\" method=\"post\" accept-charset=\"UTF-8\" enctype=\"application/x-www-form-urlencoded\" >" + LINE_SEPARATOR
+                        + "<input type=\"hidden\" name=\"authenticityToken\" value=\"1234\"/>" + LINE_SEPARATOR + LINE_SEPARATOR + "</form>",
+                out.toString());
     }
 
     @Test
@@ -139,9 +134,8 @@ public class FastTagsTest {
         FastTags._form(args, mock(Closure.class), new PrintWriter(out), null, 0);
 
         assertEquals(
-                "<form action=\"/foo/bar\" method=\"get\" accept-charset=\"UTF-8\" enctype=\"application/x-www-form-urlencoded\" data-customer=\"12\" >" + System.lineSeparator() +
-                System.lineSeparator() +
-                "</form>", out.toString());
+                "<form action=\"/foo/bar\" method=\"get\" accept-charset=\"UTF-8\" enctype=\"application/x-www-form-urlencoded\" data-customer=\"12\" >"
+                        + LINE_SEPARATOR + LINE_SEPARATOR + "</form>", out.toString());
     }
 
     @Test
@@ -157,9 +151,8 @@ public class FastTagsTest {
         FastTags._form(args, mock(Closure.class), new PrintWriter(out), null, 0);
 
         assertEquals(
-                "<form action=\"/foo/bar\" method=\"get\" accept-charset=\"UTF-8\" enctype=\"application/x-www-form-urlencoded\" >" + System.lineSeparator() +
-                System.lineSeparator() +
-                "</form>", out.toString());
+                "<form action=\"/foo/bar\" method=\"get\" accept-charset=\"UTF-8\" enctype=\"application/x-www-form-urlencoded\" >" + LINE_SEPARATOR
+                        + LINE_SEPARATOR + "</form>", out.toString());
     }
 
     @Test
@@ -176,9 +169,8 @@ public class FastTagsTest {
         FastTags._form(args, mock(Closure.class), new PrintWriter(out), null, 0);
 
         assertEquals(
-                "<form action=\"/foo/bar\" method=\"get\" accept-charset=\"UTF-8\" enctype=\"xyz\" >" + System.lineSeparator() +
-                System.lineSeparator() +
-                "</form>", out.toString());
+                "<form action=\"/foo/bar\" method=\"get\" accept-charset=\"UTF-8\" enctype=\"xyz\" >" + LINE_SEPARATOR + LINE_SEPARATOR + "</form>",
+                out.toString());
     }
 
     @Test
@@ -190,9 +182,8 @@ public class FastTagsTest {
         FastTags._form(args, mock(Closure.class), new PrintWriter(out), null, 0);
 
         assertEquals(
-                "<form action=\"/foo/bar\" method=\"post\" accept-charset=\"UTF-8\" enctype=\"application/x-www-form-urlencoded\" >" + System.lineSeparator() +
-                        "<input type=\"hidden\" name=\"authenticityToken\" value=\"1234\"/>" + System.lineSeparator() +
-                        System.lineSeparator() +
-                        "</form>", out.toString());
+                "<form action=\"/foo/bar\" method=\"post\" accept-charset=\"UTF-8\" enctype=\"application/x-www-form-urlencoded\" >" + LINE_SEPARATOR
+                        + "<input type=\"hidden\" name=\"authenticityToken\" value=\"1234\"/>" + LINE_SEPARATOR + LINE_SEPARATOR + "</form>",
+                out.toString());
     }
 }

--- a/framework/test-src/play/templates/FastTagsTest.java
+++ b/framework/test-src/play/templates/FastTagsTest.java
@@ -19,26 +19,15 @@ import static org.mockito.Mockito.mock;
 public class FastTagsTest {
 
     private StringWriter out = new StringWriter();
-    final String backupSystemLineBreak = System.getProperty("line.separator");
 
     @Before
     public void setUp() throws Exception {
-        //if you render html into out
-        // and expect results with line breaks
-        // take into account that your tests will fail on other platforms
-        // force line.separator be the same on any platform
-        // or use String.format in expected code with the placeholder '%n' for any expected line separation.
-        System.setProperty("line.separator","\n");
+
         Http.Response.current.set(new Http.Response());
         Http.Response.current().encoding = "UTF-8";
 
         Scope.Session.current.set(new Scope.Session());
         Scope.Session.current().put("___AT", "1234");
-    }
-    @After
-    public void tearDown() throws Exception {
-        // restore line.separator
-        System.setProperty("line.separator", backupSystemLineBreak);
     }
 
     @Test
@@ -47,15 +36,15 @@ public class FastTagsTest {
         actionDefinition.url = "/foo/bar";
         actionDefinition.method = "GET";
 
-        Map<String, ?> args = new HashMap<String, Object>() {{
+        Map<String, ?> args = new HashMap<>() {{
             put("arg", actionDefinition);
         }};
 
         FastTags._form(args, mock(Closure.class), new PrintWriter(out), null, 0);
 
         assertEquals(
-                "<form action=\"/foo/bar\" method=\"get\" accept-charset=\"UTF-8\" enctype=\"application/x-www-form-urlencoded\" >\n" +
-                "\n" +
+                "<form action=\"/foo/bar\" method=\"get\" accept-charset=\"UTF-8\" enctype=\"application/x-www-form-urlencoded\" >" + System.lineSeparator() +
+                System.lineSeparator() +
                 "</form>", out.toString());
     }
 
@@ -65,7 +54,7 @@ public class FastTagsTest {
         actionDefinition.url = "/foo/bar";
         actionDefinition.method = "GET";
 
-        Map<String, ?> args = new HashMap<String, Object>() {{
+        Map<String, ?> args = new HashMap<>() {{
             put("arg", actionDefinition);
             put("name", "my-form");
         }};
@@ -73,8 +62,8 @@ public class FastTagsTest {
         FastTags._form(args, mock(Closure.class), new PrintWriter(out), null, 0);
 
         assertEquals(
-                "<form action=\"/foo/bar\" method=\"get\" accept-charset=\"UTF-8\" enctype=\"application/x-www-form-urlencoded\" name=\"my-form\">\n" +
-                "\n" +
+                "<form action=\"/foo/bar\" method=\"get\" accept-charset=\"UTF-8\" enctype=\"application/x-www-form-urlencoded\" name=\"my-form\">" + System.lineSeparator() +
+                System.lineSeparator() +
                 "</form>", out.toString());
     }
 
@@ -84,16 +73,16 @@ public class FastTagsTest {
         actionDefinition.url = "/foo/bar";
         actionDefinition.method = "POST";
 
-        Map<String, ?> args = new HashMap<String, Object>() {{
+        Map<String, ?> args = new HashMap<>() {{
             put("arg", actionDefinition);
         }};
 
         FastTags._form(args, mock(Closure.class), new PrintWriter(out), null, 0);
 
         assertEquals(
-                "<form action=\"/foo/bar\" method=\"post\" accept-charset=\"UTF-8\" enctype=\"application/x-www-form-urlencoded\" >\n" +
-                "<input type=\"hidden\" name=\"authenticityToken\" value=\"1234\"/>\n" +
-                "\n" +
+                "<form action=\"/foo/bar\" method=\"post\" accept-charset=\"UTF-8\" enctype=\"application/x-www-form-urlencoded\" >" + System.lineSeparator() +
+                "<input type=\"hidden\" name=\"authenticityToken\" value=\"1234\"/>" + System.lineSeparator() +
+                System.lineSeparator() +
                 "</form>", out.toString());
     }
 
@@ -103,16 +92,16 @@ public class FastTagsTest {
         actionDefinition.url = "/foo/bar";
         actionDefinition.star = true;
 
-        Map<String, ?> args = new HashMap<String, Object>() {{
+        Map<String, ?> args = new HashMap<>() {{
             put("arg", actionDefinition);
         }};
 
         FastTags._form(args, mock(Closure.class), new PrintWriter(out), null, 0);
 
         assertEquals(
-                "<form action=\"/foo/bar\" method=\"post\" accept-charset=\"UTF-8\" enctype=\"application/x-www-form-urlencoded\" >\n" +
-                "<input type=\"hidden\" name=\"authenticityToken\" value=\"1234\"/>\n" +
-                "\n" +
+                "<form action=\"/foo/bar\" method=\"post\" accept-charset=\"UTF-8\" enctype=\"application/x-www-form-urlencoded\" >" + System.lineSeparator() +
+                "<input type=\"hidden\" name=\"authenticityToken\" value=\"1234\"/>" + System.lineSeparator() +
+                System.lineSeparator() +
                 "</form>", out.toString());
     }
 
@@ -122,7 +111,7 @@ public class FastTagsTest {
         actionDefinition.url = "/foo/bar";
         actionDefinition.method = "GET";
 
-        Map<String, ?> args = new HashMap<String, Object>() {{
+        Map<String, ?> args = new HashMap<>() {{
             put("arg", actionDefinition);
             put("method", "POST");
         }};
@@ -130,9 +119,9 @@ public class FastTagsTest {
         FastTags._form(args, mock(Closure.class), new PrintWriter(out), null, 0);
 
         assertEquals(
-                "<form action=\"/foo/bar\" method=\"post\" accept-charset=\"UTF-8\" enctype=\"application/x-www-form-urlencoded\" >\n" +
-                "<input type=\"hidden\" name=\"authenticityToken\" value=\"1234\"/>\n" +
-                "\n" +
+                "<form action=\"/foo/bar\" method=\"post\" accept-charset=\"UTF-8\" enctype=\"application/x-www-form-urlencoded\" >" + System.lineSeparator() +
+                "<input type=\"hidden\" name=\"authenticityToken\" value=\"1234\"/>" + System.lineSeparator() +
+                System.lineSeparator() +
                 "</form>", out.toString());
     }
 
@@ -142,7 +131,7 @@ public class FastTagsTest {
         actionDefinition.url = "/foo/bar";
         actionDefinition.method = "GET";
 
-        Map<String, ?> args = new HashMap<String, Object>() {{
+        Map<String, ?> args = new HashMap<>() {{
             put("arg", actionDefinition);
             put("data-customer", "12");
         }};
@@ -150,8 +139,8 @@ public class FastTagsTest {
         FastTags._form(args, mock(Closure.class), new PrintWriter(out), null, 0);
 
         assertEquals(
-                "<form action=\"/foo/bar\" method=\"get\" accept-charset=\"UTF-8\" enctype=\"application/x-www-form-urlencoded\" data-customer=\"12\" >\n" +
-                "\n" +
+                "<form action=\"/foo/bar\" method=\"get\" accept-charset=\"UTF-8\" enctype=\"application/x-www-form-urlencoded\" data-customer=\"12\" >" + System.lineSeparator() +
+                System.lineSeparator() +
                 "</form>", out.toString());
     }
 
@@ -161,15 +150,15 @@ public class FastTagsTest {
         actionDefinition.url = "/foo/bar";
         actionDefinition.method = "GET";
 
-        Map<String, ?> args = new HashMap<String, Object>() {{
+        Map<String, ?> args = new HashMap<>() {{
             put("action", actionDefinition);
         }};
 
         FastTags._form(args, mock(Closure.class), new PrintWriter(out), null, 0);
 
         assertEquals(
-                "<form action=\"/foo/bar\" method=\"get\" accept-charset=\"UTF-8\" enctype=\"application/x-www-form-urlencoded\" >\n" +
-                "\n" +
+                "<form action=\"/foo/bar\" method=\"get\" accept-charset=\"UTF-8\" enctype=\"application/x-www-form-urlencoded\" >" + System.lineSeparator() +
+                System.lineSeparator() +
                 "</form>", out.toString());
     }
 
@@ -179,7 +168,7 @@ public class FastTagsTest {
         actionDefinition.url = "/foo/bar";
         actionDefinition.method = "GET";
 
-        Map<String, ?> args = new HashMap<String, Object>() {{
+        Map<String, ?> args = new HashMap<>() {{
             put("arg", actionDefinition);
             put("enctype", "xyz");
         }};
@@ -187,23 +176,23 @@ public class FastTagsTest {
         FastTags._form(args, mock(Closure.class), new PrintWriter(out), null, 0);
 
         assertEquals(
-                "<form action=\"/foo/bar\" method=\"get\" accept-charset=\"UTF-8\" enctype=\"xyz\" >\n" +
-                "\n" +
+                "<form action=\"/foo/bar\" method=\"get\" accept-charset=\"UTF-8\" enctype=\"xyz\" >" + System.lineSeparator() +
+                System.lineSeparator() +
                 "</form>", out.toString());
     }
 
     @Test
     public void _form_argAsUrlInsteadOfActionDefinition() throws Exception {
-        Map<String, ?> args = new HashMap<String, Object>() {{
+        Map<String, ?> args = new HashMap<>() {{
             put("arg", "/foo/bar");
         }};
 
         FastTags._form(args, mock(Closure.class), new PrintWriter(out), null, 0);
 
         assertEquals(
-                "<form action=\"/foo/bar\" method=\"post\" accept-charset=\"UTF-8\" enctype=\"application/x-www-form-urlencoded\" >\n" +
-                        "<input type=\"hidden\" name=\"authenticityToken\" value=\"1234\"/>\n" +
-                        "\n" +
+                "<form action=\"/foo/bar\" method=\"post\" accept-charset=\"UTF-8\" enctype=\"application/x-www-form-urlencoded\" >" + System.lineSeparator() +
+                        "<input type=\"hidden\" name=\"authenticityToken\" value=\"1234\"/>" + System.lineSeparator() +
+                        System.lineSeparator() +
                         "</form>", out.toString());
     }
 }


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [ ] Have you updated the documentation? (no update needed)
* [x] Have you added tests for any changed functionality?(I fixed tests for OS-Windows )

# Helpful things

## Fixes
#1371
#1366
#1292

added ability to run IDEA with WSL
fixed test on Windows play.templates.FastTagsTest

## Purpose

now you can run IDEA from WSL
fixes the test that screams
end of line problem in jdk 11 and 17 under Windows and system variable "line.separator"
`System.setProperty("line.separator","\n");`

## Background Context

I solved the problem by inserting line breaks as they are in the system and now it will not test depend on OS
I added "action "it to the tests performed on OS-Windows and  jdk17 so that this situation would not happen
added run 

