### PR TITLE
[#1383] 🆕 Ability to disable database evolutions on a datasource basis

### DIFF
--- a/documentation/manual/configuration.textile
+++ b/documentation/manual/configuration.textile
@@ -358,11 +358,17 @@ Valid values are @NONE@, @READ_UNCOMMITTED@, @READ_COMMITTED@, @REPEATABLE_READ@
 
 Default: database dependent, usually @READ_COMMITTED@
 
+h3(#db.evolutions.enabled). db.[DB_name].evolutions.enabled
+
+Allows to disable database evolutions on a specific database.
+
+Default: true.
+
 h3(#db.pass). db.pass
 
 Database connection password, used with "db.url":#db.url.
 
-Default: no value, or an empty string when "db":#db is set to @mem@ or @fs@. 
+Default: no value, or an empty string when "db":#db is set to @mem@ or @fs@.
 
 h3(#db.pool.acquireIncrement). db.pool.acquireIncrement
 

--- a/documentation/manual/evolutions.textile
+++ b/documentation/manual/evolutions.textile
@@ -45,6 +45,7 @@ DROP TABLE User;
 As you see you have to delimitate the both *Ups* and *Downs* section by using comments in your SQL script.
 
 Evolutions are automatically activated if a database is configured in @application.conf@ and evolution scripts are present. You can disable them by setting "evolutions.enabled":configuration#evolutions.enabled to @false@. For example when tests set up their own database you can disable evolutions for the test environment.
+In multiple databases context, there is the ability to disable the evolutions on a specific database by setting the "db.[DB_name].evolutions.enabled":configuration#db.evolutions.enabled parameter to @false@.
 
 When **evolutions** are activated, Play will check your database schema state before each request in DEV mode, or before starting the application in PROD mode. In DEV mode, if your database schema is not up to date, an error page will suggest that you synchronise your database schema by running the appropriate SQL script.
 

--- a/framework/src/play/db/Evolutions.java
+++ b/framework/src/play/db/Evolutions.java
@@ -392,6 +392,10 @@ public class Evolutions extends PlayPlugin {
         return "false".equals(Play.configuration.getProperty("evolutions.enabled", "true"));
     }
 
+    private static boolean isDatabaseEvolutionDisabled(String dbName) {
+        return "false".equals(Play.configuration.getProperty("db." + dbName + ".evolutions.enabled", "true"));
+    }
+
     private static boolean isModuleEvolutionDisabled() {
         return "false".equals(Play.configuration.getProperty("modules.evolutions.enabled", "true"));
     }
@@ -501,7 +505,9 @@ public class Evolutions extends PlayPlugin {
         // Look over all the DB
         Set<String> dBNames = Configuration.getDbNames();
         for (String dbName : dBNames) {
-            checkEvolutionsState(dbName);
+            if (!isDatabaseEvolutionDisabled(dbName)) {
+                checkEvolutionsState(dbName);
+            }
         }
     }
 

--- a/framework/test-src/play/db/ConfigurationTest.java
+++ b/framework/test-src/play/db/ConfigurationTest.java
@@ -302,6 +302,7 @@ public class ConfigurationTest {
         Play.configuration.put("db.test.pool.maxSize", "20");
         Play.configuration.put("db.test.pool.minSize", "1");
         Play.configuration.put("db.test.pool.maxIdleTimeExcessConnections", "60");
+        Play.configuration.put("db.test.evolutions.enabled", "false");
         //javax.persistence
         Play.configuration.put("javax.persistence.test.lock.scope", "EXTENDED");
         Play.configuration.put("javax.persistence.test.lock.timeout", "1000");
@@ -327,6 +328,7 @@ public class ConfigurationTest {
         assertEquals("20", properties.get("db.pool.maxSize"));
         assertEquals("1", properties.get("db.pool.minSize"));
         assertEquals("60", properties.get("db.pool.maxIdleTimeExcessConnections"));
+        assertEquals("false", properties.get("db.evolutions.enabled"));
         //javax.persistence
         assertEquals("EXTENDED", properties.get("javax.persistence.lock.scope"));
         assertEquals("1000", properties.get("javax.persistence.lock.timeout"));


### PR DESCRIPTION

## Fixes

Fixes #1383 

## Purpose

Add support for a new configuration parameter to allow disabling database evolutions per database.

## References

#1383 
