### PR TITLE
[#1331] 🆕 Add new parameter jpda.address support

### DIFF
--- a/documentation/manual/configuration.textile
+++ b/documentation/manual/configuration.textile
@@ -832,6 +832,13 @@ Defines which port is used by JPDA when application is in debug mode. For exampl
 
 Default: @8000@
 
+h3(#jpda.address). jpda.address
+
+Defines which address is used by JPDA when application is in debug mode. For example:
+jpda.address=0.0.0.0
+jpda.address=* # Special value only for JDK >= 9, will bind to 0.0.0.0.
+
+Default: none, in that case the listening address will be 127.0.0.1 only for JDK >= 9
 
 h2(#keystore). keystore
 


### PR DESCRIPTION
 * ♻ Adapt startup scripts to take into account new parameter
 * 📝 Update documentation for the new parameter jpda.address

## Fixes

Fixes #1331

## Purpose

Add new configuration parameter jpda.address to allow to specify the listening address, useful for JDK >=9 to allow listening to other interface than localhost. For JDK < 9, this allows to restrict the service to localhost.
