### PR TITLE
make default jdk 11

### DIFF
--- a/documentation/manual/configuration.textile
+++ b/documentation/manual/configuration.textile
@@ -745,9 +745,9 @@ h3(#java.source). java.source
 
 Java source level, which overrides the @java.version@ system property. For example:
 
-bc. java.source=17
+bc. java.source=11
 
-Values:  @1.7@ (No longer supported since 1.5.0), @1.8@ (No longer supported since 1.6.x), @9@ (No longer supported since 1.6.x), @10@ (No longer supported since 1.6.x), @11@, @12@, @13@, @14@, @15@, @17@.
+Values:  @1.7@ (No longer supported since 1.5.0), @1.8@ (No longer supported since 1.7.0), @9@ (No longer supported since 1.7.0), @10@ (No longer supported since 1.7.0), @11@, @12@, @13@, @14@, @15@, @17@.
 
 Default: @11@
 

--- a/documentation/manual/configuration.textile
+++ b/documentation/manual/configuration.textile
@@ -745,11 +745,11 @@ h3(#java.source). java.source
 
 Java source level, which overrides the @java.version@ system property. For example:
 
-bc. java.source=1.8
+bc. java.source=17
 
-Values:  @1.7@ (No longer supported since 1.5.0), @1.8@, @9@, @10@, @11@, @12@, @13@, @14@, @15@, @17@.
+Values:  @1.7@ (No longer supported since 1.5.0), @1.8@ (No longer supported since 1.6.x), @9@ (No longer supported since 1.6.x), @10@ (No longer supported since 1.6.x), @11@, @12@, @13@, @14@, @15@, @17@.
 
-Default: @1.8@
+Default: @11@
 
 
 h2(#jpa). JPA

--- a/documentation/manual/install.textile
+++ b/documentation/manual/install.textile
@@ -3,7 +3,7 @@ h1. Installation guide
 
 h2. <a name="prerequisites">Prerequisites</a>
 
-To run the Play framework, you need "Java 8 or later":http://java.sun.com. If you wish to build Play from source, you will need the "Git source control client":http://git-scm.com/ to fetch the source code and "Ant":http://ant.apache.org/ to build it.
+To run the Play framework, you need "Java 11 or later":http://java.sun.com. If you wish to build Play from source, you will need the "Git source control client":http://git-scm.com/ to fetch the source code and "Ant":http://ant.apache.org/ to build it.
 
 Be sure to have Java in the current path (enter @java -version@ to check). Play will use the default Java or the one available at the @$JAVA_HOME@ path if defined.
 

--- a/framework/build.xml
+++ b/framework/build.xml
@@ -64,7 +64,7 @@
 
     <target name="compile" description="compile without cleaning">
         <mkdir dir="classes"/>
-        <javac encoding="utf-8" srcdir="src" destdir="classes" debug="true" source="1.8" target="1.8">
+        <javac encoding="utf-8" srcdir="src" destdir="classes" debug="true" source="11" target="11">
             <classpath refid="project.classpath" />
         </javac>
         <copy todir="classes">

--- a/framework/src/play/classloading/ApplicationCompiler.java
+++ b/framework/src/play/classloading/ApplicationCompiler.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.StringTokenizer;
+import java.util.stream.Stream;
 
 import org.eclipse.jdt.core.compiler.IProblem;
 import org.eclipse.jdt.internal.compiler.ClassFile;
@@ -40,9 +41,6 @@ public class ApplicationCompiler {
     static final Map<String, String> compatibleJavaVersions = new HashMap<>();
 
     static {
-        compatibleJavaVersions.put("1.8", CompilerOptions.VERSION_1_8);
-        compatibleJavaVersions.put("9", CompilerOptions.VERSION_9);
-        compatibleJavaVersions.put("10", CompilerOptions.VERSION_10);
         compatibleJavaVersions.put("11", CompilerOptions.VERSION_11);
         compatibleJavaVersions.put("12", CompilerOptions.VERSION_12);
         compatibleJavaVersions.put("13", CompilerOptions.VERSION_13);
@@ -70,8 +68,8 @@ public class ApplicationCompiler {
         this.settings.put(CompilerOptions.OPTION_LocalVariableAttribute, CompilerOptions.GENERATE);
 
         final String runningJavaVersion = System.getProperty("java.version");
-		if (runningJavaVersion.startsWith("1.5") || runningJavaVersion.startsWith("1.6") || runningJavaVersion.startsWith("1.7")) {
-            throw new CompilationException("JDK version prior to 1.8 are not supported to run the application");
+		if (Stream.of("1.5", "1.6", "1.7", "1.8", "9", "10").anyMatch(runningJavaVersion::startsWith)) {
+            throw new CompilationException("JDK version prior to 11 are not supported to run the application");
         }
         final String configSourceVersion = Play.configuration.getProperty("java.source", JAVA_SOURCE_DEFAULT_VERSION);
         final String jdtVersion = compatibleJavaVersions.get(configSourceVersion);

--- a/framework/src/play/classloading/ApplicationCompiler.java
+++ b/framework/src/play/classloading/ApplicationCompiler.java
@@ -36,7 +36,7 @@ public class ApplicationCompiler {
     Map<String, Boolean> packagesCache = new HashMap<>();
     ApplicationClasses applicationClasses;
     Map<String, String> settings;
-    private static final String JAVA_SOURCE_DEFAULT_VERSION = "1.8";
+    private static final String JAVA_SOURCE_DEFAULT_VERSION = "11";
     static final Map<String, String> compatibleJavaVersions = new HashMap<>();
 
     static {

--- a/resources/application-skel/conf/application.conf
+++ b/resources/application-skel/conf/application.conf
@@ -62,7 +62,7 @@ date.format=yyyy-MM-dd
 # Define which port is used by JPDA when application is in debug mode (default is set to 8000)
 # jpda.port=8000
 #
-# Java source level => 1.8, 9, 10, 11, 12, 13, 14, 15, 17
+# Java source level => 11, 12, 13, 14, 15, 17
 # java.source=11
 
 # Log level

--- a/resources/application-skel/conf/application.conf
+++ b/resources/application-skel/conf/application.conf
@@ -63,7 +63,7 @@ date.format=yyyy-MM-dd
 # jpda.port=8000
 #
 # Java source level => 1.8, 9, 10, 11, 12, 13, 14, 15, 17
-# java.source=1.8
+# java.source=11
 
 # Log level
 # ~~~~~

--- a/resources/idea/imlTemplate.xml
+++ b/resources/idea/imlTemplate.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module relativePaths="true" type="JAVA_MODULE" version="4">
     <component name="NewModuleRootManager" inherit-compiler-output="true">
-        <orderEntry type="jdk" jdkName="1.8" jdkType="JavaSDK" />
+        <orderEntry type="jdk" jdkName="11" jdkType="JavaSDK" />
         <orderEntry type="sourceFolder" forTests="false" />
         <exclude-output />
         <content url="file://$MODULE_DIR$">

--- a/resources/idea/iprTemplate.xml
+++ b/resources/idea/iprTemplate.xml
@@ -5,7 +5,7 @@
       <module fileurl="file://$PROJECT_DIR$/%PROJECT_NAME%.iml" filepath="$PROJECT_DIR$/%PROJECT_NAME%.iml" />
     </modules>
   </component>
-  <component name="ProjectRootManager" languageLevel="JDK_1_8" assert-keyword="true" jdk-15="true" project-jdk-name="1.6" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" languageLevel="JDK_11" assert-keyword="true" jdk-15="true" project-jdk-name="11" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/tmp/classes" />
   </component>
 </project>

--- a/resources/module-skel/build.xml
+++ b/resources/module-skel/build.xml
@@ -41,7 +41,7 @@
 
     <target name="compile" depends="check">
         <mkdir dir="tmp/classes" />
-        <javac srcdir="src" destdir="tmp/classes" target="1.5" debug="true">
+        <javac srcdir="src" destdir="tmp/classes" source="11" target="11" debug="true">
             <classpath refid="project.classpath" />
         </javac>
     </target>


### PR DESCRIPTION
Since https://github.com/playframework/play1/commit/6dabc5308399226cc7cb11d64fc12ebbd5529e8c play! is compiled and tested on jdk 11 and 17 in CI. So in my opinion it's good cause to migrate to jdk 11 in the next release.