### PR TITLE
Do not overwrite system property net.spy.log.LoggerImpl -> 1.7.1

### DIFF
--- a/framework/src/play/cache/MemcachedImpl.java
+++ b/framework/src/play/cache/MemcachedImpl.java
@@ -92,7 +92,7 @@ public class MemcachedImpl implements CacheImpl {
     public void initClient() throws IOException {
         String loggerImpl = System.getProperty("net.spy.log.LoggerImpl");
         if (loggerImpl == null) {
-            System.setProperty("net.spy.log.LoggerImpl", "net.spy.memcached.compat.log.Log4JLogger");
+            System.setProperty("net.spy.log.LoggerImpl", "net.spy.memcached.compat.log.SLF4JLogger");
         }        
         
         List<InetSocketAddress> addrs;

--- a/framework/src/play/cache/MemcachedImpl.java
+++ b/framework/src/play/cache/MemcachedImpl.java
@@ -90,7 +90,10 @@ public class MemcachedImpl implements CacheImpl {
     }
 
     public void initClient() throws IOException {
-        System.setProperty("net.spy.log.LoggerImpl", "net.spy.memcached.compat.log.Log4JLogger");
+        String loggerImpl = System.getProperty("net.spy.log.LoggerImpl");
+        if (loggerImpl == null) {
+            System.setProperty("net.spy.log.LoggerImpl", "net.spy.memcached.compat.log.Log4JLogger");
+        }        
         
         List<InetSocketAddress> addrs;
         if (Play.configuration.containsKey("memcached.host")) {


### PR DESCRIPTION
`MemcachedImpl` forces the usage of `net.spy.memcached.compat.log.Log4JLogger` while it shouldn't.

Fixes https://github.com/playframework/play1/issues/1414. 