### PR TITLE
[#1414] 🐛 Change Logger implementation to SLF4JLogger for Memcached c…

### DIFF
--- a/framework/src/play/cache/MemcachedImpl.java
+++ b/framework/src/play/cache/MemcachedImpl.java
@@ -90,7 +90,7 @@ public class MemcachedImpl implements CacheImpl {
     }
 
     public void initClient() throws IOException {
-        System.setProperty("net.spy.log.LoggerImpl", "net.spy.memcached.compat.log.Log4JLogger");
+        System.setProperty("net.spy.log.LoggerImpl", "net.spy.memcached.compat.log.SLF4JLogger");
         
         List<InetSocketAddress> addrs;
         if (Play.configuration.containsKey("memcached.host")) {


### PR DESCRIPTION
…lient library as it is not compatible with log4j 2.x

## Fixes

Fixes #1414

## Purpose

Change the Logger implementation used by the Memcached client library to slf4j as it is not compatible with log4j 2.x
