### PR TITLE
Better compatibility with Hibernate Envers

### DIFF
--- a/framework/src/play/db/jpa/HibernateInterceptor.java
+++ b/framework/src/play/db/jpa/HibernateInterceptor.java
@@ -13,7 +13,7 @@ public class HibernateInterceptor extends EmptyInterceptor {
   public HibernateInterceptor() {
 
   }
-  
+
   @Override
   public int[] findDirty(Object o, Serializable id, Object[] arg2, Object[] arg3, String[] arg4, Type[] arg5) {
     if (o instanceof JPABase && !((JPABase) o).willBeSaved) {
@@ -27,7 +27,7 @@ public class HibernateInterceptor extends EmptyInterceptor {
         if (collection instanceof PersistentCollection) {
             Object o = ((PersistentCollection) collection).getOwner();
             if (o instanceof JPABase) {
-                if (entities.get() != null) {
+                if (entities.get() instanceof JPABase) {
                     return ((JPABase) o).willBeSaved || ((JPABase) entities.get()).willBeSaved;
                 } else {
                     return ((JPABase) o).willBeSaved;
@@ -44,7 +44,7 @@ public class HibernateInterceptor extends EmptyInterceptor {
         if (collection instanceof PersistentCollection) {
             Object o = ((PersistentCollection) collection).getOwner();
             if (o instanceof JPABase) {
-                if (entities.get() != null) {
+                if (entities.get() instanceof JPABase) {
                     return ((JPABase) o).willBeSaved || ((JPABase) entities.get()).willBeSaved;
                 } else {
                     return ((JPABase) o).willBeSaved;
@@ -62,7 +62,7 @@ public class HibernateInterceptor extends EmptyInterceptor {
         if (collection instanceof PersistentCollection) {
             Object o = ((PersistentCollection) collection).getOwner();
             if (o instanceof JPABase) {
-                if (entities.get() != null) {
+                if (entities.get() instanceof JPABase) {
                     return ((JPABase) o).willBeSaved || ((JPABase) entities.get()).willBeSaved;
                 } else {
                     return ((JPABase) o).willBeSaved;


### PR DESCRIPTION
## Purpose

When [Hibernate Envers](https://hibernate.org/orm/envers/) is triggered via an `@Audited` annotation, it attempts to insert a record in a related `AUD` table.

However, Play! assumes all related entities extend `JPABase`, which the `AUD` tables don't. This leads to a `ClassCastException` because `HashMap` is cast to `JPABase`.

By adding a check for `JPABase` here, we can avoid this problem. This effectively also checks for 'not null' which the previous implementation did.