### PR TITLE
#1437: play auto-test can return an exit code of zero when the te…

### DIFF
--- a/framework/pym/play/commands/autotest.py
+++ b/framework/pym/play/commands/autotest.py
@@ -148,12 +148,20 @@ def autotest(app, args):
         opener.open('%s://localhost:%s/@kill' % (protocol, http_port))
     except Exception as e:
         pass
- 
+
+    testCompleted = False
     if os.path.exists(os.path.join(app.path, 'test-result/result.passed')):
+        testCompleted = True
         print("~ All tests passed")
         print("~")
         testspassed = True
     if os.path.exists(os.path.join(app.path, 'test-result/result.failed')):
+        testCompleted = True
         print("~ Some tests have failed. See file://%s for results" % test_result)
         print("~")
         sys.exit(1)
+
+    if not testCompleted:
+        print("~ Tests did not successfully complete.")
+        print("~")
+        sys.exit(-1)


### PR DESCRIPTION
…sts do not run

# Pull Request Checklist

* [x ] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x ] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [ x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [ n/a] Have you updated the documentation?
* [ n/a] Have you added tests for any changed functionality?

# Helpful things

## Fixes
git hub issue playframework/play1#1437
play auto-test can return an exit code of zero when the tests do not run due to the application failing to start. This can occur as a result of an unhandled exception when initializing a module or a compiler error within the application.

## Purpose

Exists with return value of -1 when tests have not run.

## Background Context

Jenkins was not reporting errors with play projects, was reporting everything working, even though tests were failing to run.

## References

https://github.com/playframework/play1/issues/1437
