### PR TITLE
Fix missing HTTPMessage.getHeader()

### DIFF
--- a/framework/pym/play/commands/modulesrepo.py
+++ b/framework/pym/play/commands/modulesrepo.py
@@ -117,7 +117,7 @@ class Downloader(object):
         return self.size
 
     def chunk_read(self, response, destination, chunk_size=8192, report_hook=None):
-        total_size = response.info().getheader('Content-Length').strip()
+        total_size = response.headers['Content-Length'].strip()
         total_size = int(total_size)
         bytes_so_far = 0
         file = open(destination,"wb")


### PR DESCRIPTION
## Info

* Play1 (1.7.1-35-g557a968a)
* Python 3.7.16

## Steps to reproduce:

```
./play install cas 3.0
~ Will install cas-3.1
~ This module is compatible with: 1.1.x, 1.2.x
~ Do you want to install this version (y/n)? y
~ Installing module cas-3.1...
~
~ Fetching https://www.playframework.com/modules/cas-3.1.zip
Traceback (most recent call last):
  File "./pp/play", line 168, in <module>
    status = cmdloader.commands[play_command].execute(command=play_command, app=play_app, args=remaining_args, env=play_env, cmdloader=cmdloader)
  File "/Users/tle/Work/clui/pp/framework/pym/play/commands/modulesrepo.py", line 67, in execute
    install(app, args, env)
  File "/Users/tle/Work/clui/pp/framework/pym/play/commands/modulesrepo.py", line 476, in install
    Downloader().retrieve(fetch, archive)
  File "/Users/tle/Work/clui/pp/framework/pym/play/commands/modulesrepo.py", line 103, in retrieve
    self.chunk_read(result, destination, report_hook=self.chunk_report)
  File "/Users/tle/Work/clui/pp/framework/pym/play/commands/modulesrepo.py", line 120, in chunk_read
    total_size = response.info().headers['Content-Length'].strip()
AttributeError: 'HTTPMessage' object has no attribute 'headers'
```

## Context

The `response.info()` returns `HTTPMessage` object in Python 3 and no longer have the `getHeader()` method.