### PR TITLE
#1466 The clock function was removed from time module in Python 3.8

### DIFF
--- a/framework/pym/play/commands/modulesrepo.py
+++ b/framework/pym/play/commands/modulesrepo.py
@@ -93,7 +93,7 @@ class Downloader(object):
 
     def retrieve(self, url, destination, callback=None):
         self.size = 0
-        time.clock()   
+        time.perf_counter()
         try:
           headers={'User-Agent':DEFAULT_USER_AGENT,
                   'Accept': 'application/json'
@@ -154,7 +154,7 @@ class Downloader(object):
             done = 100
         bar = self.bar(bytes_so_far, filesize, done)
         if not self.cycles % 3 and bits != filesize:
-            now = time.clock()
+            now = time.perf_counter()
             elapsed = now-self.before
             if elapsed:
                 speed = self.kibi(blocksize * 3 // elapsed)


### PR DESCRIPTION
One solution to this issue: [Python AttributeError: module 'time' has no attribute 'clock'](https://github.com/playframework/play1/issues/1466)

`play install` command works after the changes made

```
#19 [stage-1  9/10] RUN play install deadbolt <<< 'y'
#19 1.347 ~        _            _ 
#19 1.347 ~  _ __ | | __ _ _  _| |
#19 1.347 ~ | '_ \| |/ _' | || |_|
#19 1.347 ~ |  __/|_|\____|\__ (_)
#19 1.347 ~ |_|            |__/   
#19 1.347 ~
#19 1.347 ~ play! 1.7.x-8070e1e3, https://www.playframework.com
#19 1.347 ~
#19 1.347 ~ Will install deadbolt-1.5.4
#19 1.347 ~ This module is compatible with: *
#19 1.347 ~ Do you want to install this version (y/n)? ~ Installing module deadbolt-1.5.4...
#19 2.184 ~
#19 2.184 ~ Fetching https://www.playframework.com/modules/deadbolt-1.5.4.zip
~ [-----------------532-of-532-KiB-(100%)-----------------] 7953.0 KiB/s   
#19 2.184 ~ Unzipping...
#19 2.184 ~
#19 2.184 ~ Module deadbolt-1.5.4 is installed!
#19 2.184 ~ You can now use it by adding it to the dependencies.yml file:
#19 2.184 ~
#19 2.184 ~ require:
#19 2.184 ~     play -> deadbolt 1.5.4
#19 2.184 ~
#19 DONE 2.3s
```
