### PR TITLE
Fix "play build-module" by replacing yaml.load with yaml.safe_load

### DIFF
--- a/framework/pym/play/commands/modulesrepo.py
+++ b/framework/pym/play/commands/modulesrepo.py
@@ -328,7 +328,7 @@ def build(app, args, env):
     if os.path.exists(deps_file):
         f = open(deps_file)
         try:
-            deps = yaml.load(f.read())
+            deps = yaml.safe_load(f.read())
             if 'self' in deps:
                splitted = deps["self"].split(" -> ")
                if len(splitted) == 2:
@@ -354,7 +354,7 @@ def build(app, args, env):
 
     if os.path.exists(deps_file):
         f = open(deps_file)
-        deps = yaml.load(f.read())
+        deps = yaml.safe_load(f.read())
         if 'self' in deps:
            splitted = deps["self"].split(" -> ")
            f.close()


### PR DESCRIPTION
This fixes an error when "play build-module" is run on Python 3.7.11

  load() missing 1 required positional argument: 'Loader'

This follows the recommendation shown on
  https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation

A loader argument is now required.  This commit assumes that dependencies.yml uses standard YAML tags, and so uses safe_loader. This is the most secure loader.

# Helpful things

## Fixes

Fixes #1456

## Purpose

This pull request fixes a bug where "play build-module" throws an error with Python 3.7.11

```
Traceback (most recent call last):
  File "/devel/dcostanz/github/play1_david_costanzo/play", line 168, in <module>
    status = cmdloader.commands[play_command].execute(command=play_command, app=play_app, args=remaining_args, env=play_env, cmdloader=cmdloader)
  File "/scharp/devel/dcostanz/github/play1_david_costanzo/framework/pym/play/commands/modulesrepo.py", line 73, in execute
    build(app, args, env)
  File "/scharp/devel/dcostanz/github/play1_david_costanzo/framework/pym/play/commands/modulesrepo.py", line 331, in build
    deps = yaml.load(f.read())
```

With Python 3.10.12, it's merely a warning

```
~ calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
```
