### PR TITLE
chore(securitymanager): remove deprecated Security manager (#1527)

### DIFF
--- a/framework/src/play/utils/PThreadFactory.java
+++ b/framework/src/play/utils/PThreadFactory.java
@@ -10,8 +10,7 @@ public class PThreadFactory implements ThreadFactory {
     final String namePrefix;
 
     public PThreadFactory(String poolName) {
-        SecurityManager s = System.getSecurityManager();
-        group = (s != null) ? s.getThreadGroup() : Thread.currentThread().getThreadGroup();
+        group = Thread.currentThread().getThreadGroup();
         namePrefix = poolName + "-thread-";
     }
 

--- a/framework/src/play/vfs/VirtualFile.java
+++ b/framework/src/play/vfs/VirtualFile.java
@@ -10,7 +10,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.channels.Channel;
-import java.security.AccessControlException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -103,11 +102,7 @@ public class VirtualFile {
     }
 
     public boolean exists() {
-        try {
-            return realFile != null && realFile.exists();
-        } catch (AccessControlException e) {
-            return false;
-        }
+        return realFile != null && realFile.exists();
     }
 
     public InputStream inputstream() {


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixes  #1527

## Purpose

Fix warning
```
 AccessControlException in java.security has been deprecated and marked for removal
    [javac]         } catch (AccessControlException e) {
    [javac]                  ^
    [javac] /home/runner/work/play1/play1/framework/src/play/utils/PThreadFactory.java:13: warning: [removal] SecurityManager in java.lang has been deprecated and marked for removal
```


