### PR TITLE
fix(command): remove deprecated use of -noverify jvm parameter (1526)

### DIFF
--- a/framework/pym/play/application.py
+++ b/framework/pym/play/application.py
@@ -291,15 +291,13 @@ class PlayApplication(object):
             java_args.append('-server')
 
         if 'jvm_version' in self.play_env:
-            javaVersion = self.play_env['jvm_version']
+            java_version = self.play_env['jvm_version']
         else:
-            javaVersion = getJavaVersion() 
-        print("~ using java version \"%s\"" % javaVersion)
-        
-        if javaVersion.startswith("1.5") or javaVersion.startswith("1.6") or javaVersion.startswith("1.7") or javaVersion.startswith("1.8") or javaVersion.startswith("9") or javaVersion.startswith("10") :
-            print("~ ERROR: java version prior to 11 are no longer supported: current version \"%s\" : please update" % javaVersion)
-            
-        java_args.append('-noverify')
+            java_version = get_java_version()
+        print("~ using java version \"%s\"" % java_version)
+
+        if is_java_version_supported(java_version):
+            print("~ ERROR: java version prior to %s are no longer supported: current version \"%s\" : please update" % (get_minimal_supported_java_version(), java_version))
 
         java_policy = self.readConf('java.policy')
         if java_policy != '':

--- a/framework/pym/play/commands/eclipse.py
+++ b/framework/pym/play/commands/eclipse.py
@@ -30,13 +30,11 @@ def execute(**kargs):
     application_name = app.readConf('application.name')
     vm_arguments = app.readConf('jvm.memory')
     
-    javaVersion = getJavaVersion()
+    javaVersion = get_java_version()
     
     print("~ using java version \"%s\"" % javaVersion)
-    if javaVersion.startswith("1.5") or javaVersion.startswith("1.6") or javaVersion.startswith("1.7"):
-        print("~ ERROR: java version prior to 1.8 are no longer supported: current version \"%s\" : please update" % javaVersion)
-            
-    vm_arguments = vm_arguments +' -noverify'
+    if is_java_version_supported(javaVersion):
+        print("~ ERROR: java version prior to %s are no longer supported: current version \"%s\" : please update" % (get_minimal_supported_java_version(), javaVersion))
 
     if application_name:
         application_name = application_name.replace("/", " ")

--- a/framework/pym/play/commands/javadoc.py
+++ b/framework/pym/play/commands/javadoc.py
@@ -74,7 +74,7 @@ def defineJavadocOptions(app, outdir, args):
         args.remove('--links')
         # Add link to JavaDoc of JAVA
         
-        javaVersion = getJavaVersion()
+        javaVersion = get_java_version()
         print("~ using java version \"%s\"" % javaVersion)
         if javaVersion.startswith("1.5"):
             print("~    Java(TM) Platform, Platform Standard Edition 5.0")        

--- a/framework/pym/play/utils.py
+++ b/framework/pym/play/utils.py
@@ -188,7 +188,7 @@ def package_as_war(app, env, war_path, war_zip_path, war_exclusion_list = None):
         zip.close()
 
 # Recursively delete all files/folders in root whose name equals to filename
-# We could pass a "ignore" parameter to copytree, but that's not supported in Python 2.5
+# We could pass an "ignore" parameter to copytree, but that's not supported in Python 2.5
 
 def deleteFrom(root, filenames):
     for f in os.listdir(root):
@@ -250,15 +250,30 @@ def java_path():
     else:
         return os.path.normpath("%s/bin/java" % os.environ['JAVA_HOME'])
 
-def getJavaVersion():
+def get_java_version():
     sp = subprocess.Popen([java_path(), "-version"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    javaVersion = sp.communicate()
-    javaVersion = str(javaVersion)
+    java_version = sp.communicate()
+    java_version = str(java_version)
     
-    result = re.search('version "([a-zA-Z0-9\.\-_]{1,})"', javaVersion)
+    result = re.search('version "([a-zA-Z0-9\.\-_]{1,})"', java_version)
     
     if result:
         return result.group(1)
     else:
-        print("Unable to retrieve java version from " + javaVersion)
+        print("Unable to retrieve java version from " + java_version)
         return ""
+
+def get_minimal_supported_java_version():
+    return 11
+
+def is_java_version_supported(java_version):
+    try:
+        if java_version.startswith("1."):
+            num = int(java_version.split('.')[-1])
+        elif java_version.count('.') >= 1:
+            num = int(java_version.split('.')[0])
+        else:
+            num = int(java_version)
+        return not (num < get_minimal_supported_java_version())
+    except ValueError:
+        return True

--- a/samples-and-tests/i-am-a-developer/test_jvm_version_flag.py
+++ b/samples-and-tests/i-am-a-developer/test_jvm_version_flag.py
@@ -23,7 +23,7 @@ class JvmVersionFlag(unittest.TestCase):
             'jpda.port': 8000
         }
 
-    @mock.patch('play.application.getJavaVersion', return_value='')
+    @mock.patch('play.application.get_java_version', return_value='')
     def testWithFlag(self, mock):
         play_env = self.common.copy()
         # pass the jvm_version flag in
@@ -32,17 +32,17 @@ class JvmVersionFlag(unittest.TestCase):
         play_app = PlayApplication('fake', play_env, True)
         play_app.java_cmd([])
 
-        step('Assert getJavaVersion was not called')
+        step('Assert get_java_version was not called')
         mock.assert_(not mock.called)
 
-    @mock.patch('play.application.getJavaVersion', return_value='')
+    @mock.patch('play.application.get_java_version', return_value='')
     def testWithoutFlag(self, mock):
         play_env = self.common.copy()
 
         play_app = PlayApplication('fake', play_env, True)
         play_app.java_cmd([])
 
-        step('Assert getJavaVersion was called once')
+        step('Assert get_java_version was called once')
         mock.assert_(mock.called)
 
 


### PR DESCRIPTION

# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://www.playframework.com/contributing)?
* [x] Have you referenced any issues you're fixing using [commit message keywords](https://help.github.com/articles/closing-issues-using-keywords/)?
* [x] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?

# Helpful things

## Fixes

Fixes #1526

## Purpose
- check version compatibility (11)

Fix Warning when  running play test
```
Server VM warning: Options -Xverify:none and -noverify were deprecated in JDK 13 and will likely be removed in a future release.
```